### PR TITLE
Bump copyright year to 2024

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/docker-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/docker-conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/go-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/go-conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/plugin/go/Go.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/Go.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/plugin/go/GoExtension.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/plugin/go/GoPlugin.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/snykcode-extension.gradle.kts
+++ b/buildSrc/src/main/kotlin/snykcode-extension.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/build.gradle.kts
+++ b/hedera-mirror-common/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/aggregator/LogsBloomAggregator.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/aggregator/LogsBloomAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/EntityIdConverter.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/EntityIdConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/EntityIdDeserializer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/EntityIdDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/EntityIdSerializer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/EntityIdSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/ListToStringSerializer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/ListToStringSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/ObjectToStringSerializer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/ObjectToStringSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/RangeToStringSerializer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/RangeToStringSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverter.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/DigestAlgorithm.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/DigestAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/History.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/History.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamItem.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamType.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/UpsertColumn.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/UpsertColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/Upsertable.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/Upsertable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/AddressBook.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/AddressBook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/AddressBookEntry.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/AddressBookEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/AddressBookServiceEndpoint.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/AddressBookServiceEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/NetworkStake.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/NetworkStake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/NodeStake.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/addressbook/NodeStake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalance.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/TokenBalance.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/TokenBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/Contract.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/Contract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractAction.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractLog.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractResult.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractState.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractStateChange.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractStateChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractTransaction.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractTransactionHash.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/contract/ContractTransactionHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractCryptoAllowance.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractCryptoAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractEntity.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractEntityStake.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractEntityStake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractNftAllowance.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractNftAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractTokenAllowance.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/AbstractTokenAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/CryptoAllowance.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/CryptoAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/CryptoAllowanceHistory.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/CryptoAllowanceHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/Entity.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/Entity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityHistory.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityOperation.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityStake.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityStake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityStakeHistory.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityStakeHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityTransaction.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityType.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/FungibleAllowance.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/FungibleAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/NftAllowance.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/NftAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/NftAllowanceHistory.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/NftAllowanceHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/TokenAllowance.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/TokenAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/TokenAllowanceHistory.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/TokenAllowanceHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventItem.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/event/EventItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/file/FileData.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/file/FileData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/job/ReconciliationJob.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/job/ReconciliationJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/job/ReconciliationStatus.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/job/ReconciliationStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/schedule/Schedule.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/schedule/Schedule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractCustomFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractCustomFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractNft.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractNft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractToken.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractTokenAccount.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractTokenAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/CustomFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/CustomFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/CustomFeeHistory.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/CustomFeeHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/DissociateTokenTransfer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/DissociateTokenTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/FallbackFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/FallbackFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/FixedFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/FixedFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/FractionalFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/FractionalFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/Nft.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/Nft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/NftHistory.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/NftHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/NftTransfer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/NftTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/RoyaltyFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/RoyaltyFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/Token.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/Token.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenAccount.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenAccountHistory.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenAccountHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenFreezeStatusEnum.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenFreezeStatusEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenHistory.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenKycStatusEnum.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenKycStatusEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenPauseStatusEnum.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenPauseStatusEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenSupplyTypeEnum.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenSupplyTypeEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenTransfer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenTypeEnum.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/TokenTypeEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/topic/StreamMessage.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/topic/StreamMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/topic/TopicMessage.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/topic/TopicMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/topic/TopicMessageLookup.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/topic/TopicMessageLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/AssessedCustomFee.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/AssessedCustomFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/CryptoTransfer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/CryptoTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/ErrataType.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/ErrataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/EthereumTransaction.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/EthereumTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/ItemizedTransfer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/ItemizedTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/LiveHash.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/LiveHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/NetworkFreeze.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/NetworkFreeze.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Prng.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Prng.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/SidecarFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/SidecarFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/StakingRewardTransfer.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/StakingRewardTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Transaction.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/TransactionHash.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/TransactionHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/TransactionSignature.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/TransactionSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/TransactionType.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/TransactionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/exception/InvalidEntityException.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/exception/InvalidEntityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/exception/MirrorNodeException.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/exception/MirrorNodeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/exception/NonParsableKeyException.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/exception/NonParsableKeyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/exception/ProtobufException.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/exception/ProtobufException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/util/DomainUtils.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/util/DomainUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/CommonIntegrationTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/CommonIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/CommonTestConfiguration.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/CommonTestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/EntityIdConverterTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/EntityIdConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/EntityIdDeserializerTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/EntityIdDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/EntityIdSerializerTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/EntityIdSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/ListToStringSerializerTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/ListToStringSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/ObjectToStringSerializerTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/ObjectToStringSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/RangeToStringSerializerTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/RangeToStringSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverterTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/converter/WeiBarTinyBarConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DigestAlgorithmTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DigestAlgorithmTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainWrapper.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/StreamTypeTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/StreamTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/entity/EntityIdTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/entity/EntityIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/entity/EntityTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/entity/EntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/token/TokenAccountTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/token/TokenAccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/token/TokenSupplyTypeEnumTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/token/TokenSupplyTypeEnumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/token/TokenTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/token/TokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/token/TokenTypeEnumTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/token/TokenTypeEnumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/topic/TopicMessageTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/topic/TopicMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/LogsBloomAggregatorTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/LogsBloomAggregatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/RecordFileTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/RecordFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/TransactionHashTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/TransactionHashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/TransactionTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/transaction/TransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/util/CommonUtils.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/util/CommonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/util/DomainUtilsTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/util/DomainUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/build.gradle.kts
+++ b/hedera-mirror-graphql/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/GraphqlApplication.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/GraphqlApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/cache/CacheProperties.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/cache/CacheProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/cache/CachedPreparsedDocumentProvider.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/cache/CachedPreparsedDocumentProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/CustomExceptionResolver.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/CustomExceptionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/GraphQlConfiguration.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/GraphQlConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/LoggingFilter.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/LoggingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/MetricsConfiguration.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/MetricsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/controller/AccountController.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/controller/AccountController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/mapper/AccountMapper.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/mapper/AccountMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/mapper/CommonMapper.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/mapper/CommonMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/mapper/EntityMapper.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/mapper/EntityMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/repository/EntityRepository.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/repository/EntityRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/scalar/GraphQlDuration.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/scalar/GraphQlDuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/scalar/GraphQlTimestamp.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/scalar/GraphQlTimestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/service/EntityService.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/service/EntityService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/service/EntityServiceImpl.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/service/EntityServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/util/GraphQlUtils.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/util/GraphQlUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/GraphqlIntegrationTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/GraphqlIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/config/LoggingFilterTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/config/LoggingFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/controller/AccountControllerTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/controller/AccountControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/mapper/AccountMapperTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/mapper/AccountMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/mapper/CommonMapperTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/mapper/CommonMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/repository/EntityRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/scalar/GraphQlDurationTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/scalar/GraphQlDurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/scalar/GraphQlTimestampTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/scalar/GraphQlTimestampTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/service/EntityServiceTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/service/EntityServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/util/GraphQlUtilsTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/util/GraphQlUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/build.gradle.kts
+++ b/hedera-mirror-grpc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/DbProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/DbProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/GrpcApplication.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/GrpcApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/GrpcProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/GrpcProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/CacheConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/CacheConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcHealthIndicator.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/GrpcHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/MetricsConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/MetricsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/NettyProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/RedisConfiguration.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/config/RedisConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/NetworkController.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/NetworkController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/AddressBookFilter.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/AddressBookFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/TopicMessageFilter.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/domain/TopicMessageFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/exception/EntityNotFoundException.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/exception/EntityNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/CompositeTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/CompositeTopicListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/ListenerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/NotifyingTopicListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/PollingTopicListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/RedisTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/RedisTopicListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedTopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/SharedTopicListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/TopicListener.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/listener/TopicListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/AddressBookEntryRepository.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/AddressBookEntryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/AddressBookRepository.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/AddressBookRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/EntityRepository.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/EntityRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/NodeStakeRepository.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/NodeStakeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepository.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryCustom.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryCustom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryCustomImpl.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryCustomImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/retriever/PollingTopicMessageRetriever.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/retriever/PollingTopicMessageRetriever.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/retriever/RetrieverProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/retriever/RetrieverProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/retriever/TopicMessageRetriever.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/retriever/TopicMessageRetriever.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/AddressBookProperties.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/AddressBookProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/NetworkService.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/NetworkService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/NetworkServiceImpl.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/NetworkServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/TopicMessageService.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/TopicMessageService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/TopicMessageServiceImpl.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/service/TopicMessageServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/util/ProtoUtil.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/util/ProtoUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/GrpcIntegrationTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/GrpcIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/ConsensusControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/NetworkControllerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/controller/NetworkControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/domain/ReactiveDomainBuilder.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/domain/ReactiveDomainBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractSharedTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractSharedTopicListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/AbstractTopicListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/NotifyingTopicListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/PollingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/PollingTopicListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/RedisTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/RedisTopicListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListenerTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/listener/SharedPollingTopicListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/repository/AddressBookEntryRepositoryTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/repository/AddressBookEntryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/repository/AddressBookRepositoryTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/repository/AddressBookRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/repository/NodeStakeRepositoryTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/repository/NodeStakeRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/repository/TopicMessageRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/retriever/PollingTopicMessageRetrieverTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/retriever/PollingTopicMessageRetrieverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/NetworkServiceTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/NetworkServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/TopicMessageServiceTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/service/TopicMessageServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/util/ProtoUtilTest.java
+++ b/hedera-mirror-grpc/src/test/java/com/hedera/mirror/grpc/util/ProtoUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/build.gradle.kts
+++ b/hedera-mirror-importer/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/ImporterApplication.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/ImporterApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/ImporterProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/ImporterProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/ConsensusNode.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/ConsensusNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/ConsensusNodeService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/ConsensusNodeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/ConsensusNodeWrapper.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/ConsensusNodeWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CacheProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CloudStorageConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/CloudStorageConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/DateRangeCalculator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/DateRangeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HealthCheckConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HealthCheckConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HibernateConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/HibernateConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/ImporterConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/ImporterConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/JdbcTemplateConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/JdbcTemplateConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MessagingConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MessagingConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptor.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MigrationHealthIndicator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/MigrationHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/Owner.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/Owner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/PubSubAutoConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/PubSubAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/RedisConfiguration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/RedisConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/StreamFileHealthIndicator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/config/StreamFileHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/ByteArrayToHexSerializer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/ByteArrayToHexSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdConverter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/converter/EntityIdConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/DBProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/DBProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/PartitionMaintenance.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/PartitionMaintenance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/TimePartition.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/TimePartition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/TimePartitionService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/db/TimePartitionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFilename.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionFilterFields.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/TransactionFilterFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/CommonDownloaderProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/ConsensusValidator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/ConsensusValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/ConsensusValidatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/DownloaderProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/NodeSignatureVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/StreamFileNotifier.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/StreamFileNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/StreamSourceProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/StreamSourceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/balance/BalanceDownloaderProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventDownloaderProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/event/EventFileDownloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/CompositeStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/CompositeStreamFileProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/StreamFileProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/TransientProviderException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/TransientProviderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordDownloaderProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/FieldInaccessibleException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/FieldInaccessibleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/FileOperationException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/FileOperationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/HashMismatchException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/HashMismatchException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ImporterException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ImporterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidConfigurationException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidDatasetException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidDatasetException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidEthereumBytesException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidEthereumBytesException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidEventFileException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidEventFileException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidStreamFileException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/InvalidStreamFileException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/MissingCredentialsException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/MissingCredentialsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ParserException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/ParserException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/SignatureFileParsingException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/SignatureFileParsingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/SignatureVerificationException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/SignatureVerificationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/StreamFileReaderException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/exception/StreamFileReaderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/leader/Leader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/leader/Leader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/leader/LeaderAspect.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/leader/LeaderAspect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/leader/LeaderService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/leader/LeaderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AbstractJavaMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AbstractJavaMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AsyncJavaMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/AsyncJavaMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillBlockMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillBlockMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BlockNumberMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BlockNumberMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ContractResultMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ContractResultMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ConvertEthereumTransactionValueMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ConvertEthereumTransactionValueMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ErrataMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ErrataMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixCryptoAllowanceAmountMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixCryptoAllowanceAmountMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixStakedBeforeEnabledMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/FixStakedBeforeEnabledMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/HistoricalAccountInfoMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/HistoricalAccountInfoMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MigrationProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MigrationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/RecalculatePendingRewardMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/RecalculatePendingRewardMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/RepeatableMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/RepeatableMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SidecarContractMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SidecarContractMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticNftAllowanceOwnerMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticNftAllowanceOwnerMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TimeSensitiveBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TimeSensitiveBalanceMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractParserProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/CommonParserProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/ParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/ParserProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamFileListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamFileListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamFileParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamItemListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/BalanceParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/BalanceParserProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/BalanceStreamFileListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/BalanceStreamFileListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/CompositeBalanceStreamFileListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/CompositeBalanceStreamFileListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/BatchInserter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/BatchInserter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/BatchPersister.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/BatchPersister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/BatchUpserter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/BatchUpserter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/CompositeBatchPersister.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/CompositeBatchPersister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/TransactionHashBatchInserter.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/TransactionHashBatchInserter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/TransactionHashTxManager.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/batch/TransactionHashTxManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/AbstractSyntheticContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/AbstractSyntheticContractLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveAllowanceContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveAllowanceContractLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveAllowanceIndexedContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveAllowanceIndexedContractLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveForAllAllowanceContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/ApproveForAllAllowanceContractLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/TransferContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/TransferContractLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/TransferIndexedContractLog.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractlog/TransferIndexedContractLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/AbstractSyntheticContractResult.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/AbstractSyntheticContractResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/ApproveAllowanceContractResult.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/ApproveAllowanceContractResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/SyntheticContractResult.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/SyntheticContractResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/SyntheticContractResultService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/SyntheticContractResultService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/SyntheticContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/SyntheticContractResultServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/TransferContractResult.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/contractresult/TransferContractResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/domain/PubSubMessage.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/domain/PubSubMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/event/EventFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/event/EventFileParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/event/EventParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/event/EventParserProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParsedEvent.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParsedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordItemListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordParserProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordParserProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordStreamFileListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordStreamFileListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeEntityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeRecordStreamFileListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeRecordStreamFileListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/ConditionOnEntityRecordParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/ConditionOnEntityRecordParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/DomainClassComparator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/DomainClassComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityBatchCleanupEvent.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityBatchCleanupEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityBatchSaveEvent.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityBatchSaveEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityListenerProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityListenerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/ParserContext.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/ParserContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyingEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyingEntityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/topic/TopicMessageLookupEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/topic/TopicMessageLookupEntityListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/ethereum/CompositeEthereumTransactionParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/ethereum/CompositeEthereumTransactionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/ethereum/Eip1559EthereumTransactionParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/ethereum/Eip1559EthereumTransactionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/ethereum/Eip2930EthereumTransactionParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/ethereum/Eip2930EthereumTransactionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/ethereum/EthereumTransactionParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/ethereum/EthereumTransactionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/ethereum/LegacyEthereumTransactionParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/ethereum/LegacyEthereumTransactionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/ConditionalOnPubSubRecordParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/ConditionalOnPubSubRecordParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordStreamFileListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordStreamFileListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/sidecar/SidecarProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/sidecar/SidecarProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractEntityCrudTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractEntityCrudTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusDeleteTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusDeleteTopicTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusSubmitMessageTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusSubmitMessageTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCallTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCallTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoAddLiveHashTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoAddLiveHashTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteAllowanceTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteAllowanceTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteLiveHashTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteLiveHashTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoTransferTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoTransferTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileAppendTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileAppendTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileCreateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileDataHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileDataHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileDeleteTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileUpdateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FreezeTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/FreezeTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeStakeUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeStakeUpdateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeStakeUpdatedEvent.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeStakeUpdatedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleCreateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleDeleteTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleSignTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleSignTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemDeleteTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemUndeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemUndeleteTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenAssociateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenAssociateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenBurnTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenBurnTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenCreateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenCreateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenDeleteTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenDissociateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenDissociateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenFeeScheduleUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenFeeScheduleUpdateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenFreezeTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenFreezeTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenGrantKycTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenGrantKycTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenMintTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenMintTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenPauseTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenPauseTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenRevokeKycTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenRevokeKycTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUnfreezeTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUnfreezeTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUnpauseTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUnpauseTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenWipeTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenWipeTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandlerFactory.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/UncheckedSubmitTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/UncheckedSubmitTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/UnknownDataTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/UnknownDataTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/UtilPrngTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/UtilPrngTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/serializer/ProtoJsonSerializer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/serializer/ProtoJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/serializer/PubSubEntityIdSerializer.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/serializer/PubSubEntityIdSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/AbstractStreamObject.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/AbstractStreamObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/HashObject.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/HashObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/StreamFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/StreamFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/ValidatedDataInputStream.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/ValidatedDataInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/BalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/BalanceFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/BalanceFileReaderImplV1.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/BalanceFileReaderImplV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/BalanceFileReaderImplV2.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/BalanceFileReaderImplV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV1.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV2.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/AbstractPreV5RecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/AbstractPreV5RecordFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/CompositeRecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/CompositeRecordFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/ProtoRecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/ProtoRecordFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV1.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV2.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV5.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/sidecar/SidecarFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/sidecar/SidecarFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/sidecar/SidecarFileReaderImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/sidecar/SidecarFileReaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/CompositeSignatureFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/CompositeSignatureFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/ProtoSignatureFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/ProtoSignatureFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV5.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reconciliation/BalanceReconciliationService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reconciliation/BalanceReconciliationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reconciliation/ReconciliationException.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reconciliation/ReconciliationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reconciliation/ReconciliationProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reconciliation/ReconciliationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceFileRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceFileRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AccountBalanceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AddressBookEntryRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AddressBookEntryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AddressBookRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AddressBookRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AddressBookServiceEndpointRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AddressBookServiceEndpointRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AssessedCustomFeeRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/AssessedCustomFeeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/BalanceSnapshotRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/BalanceSnapshotRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractActionRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractActionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractLogRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractLogRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractResultRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractResultRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractStateChangeRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractStateChangeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractStateRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractStateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractTransactionHashRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractTransactionHashRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractTransactionRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ContractTransactionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/CryptoAllowanceHistoryRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/CryptoAllowanceHistoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/CryptoAllowanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/CryptoAllowanceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/CryptoTransferRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/CryptoTransferRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/CustomFeeHistoryRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/CustomFeeHistoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/CustomFeeRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/CustomFeeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityHistoryRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityHistoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeHistoryRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeHistoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityTransactionRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityTransactionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EthereumTransactionRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EthereumTransactionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EventFileRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EventFileRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/FileDataRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/FileDataRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/LiveHashRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/LiveHashRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NetworkFreezeRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NetworkFreezeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NetworkStakeRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NetworkStakeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftAllowanceHistoryRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftAllowanceHistoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftAllowanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftAllowanceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftHistoryRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftHistoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NftRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NodeStakeRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/NodeStakeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/PrngRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/PrngRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ReconciliationJobRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ReconciliationJobRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/RecordFileRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/RecordFileRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/RetentionRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/RetentionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ScheduleRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/ScheduleRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/SidecarFileRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/SidecarFileRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/StakingRewardTransferRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/StakingRewardTransferRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/StreamFileRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/StreamFileRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenAccountHistoryRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenAccountHistoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenAccountRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenAccountRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenAllowanceHistoryRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenAllowanceHistoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenAllowanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenAllowanceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenBalanceRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenBalanceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenHistoryRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenHistoryRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenTransferRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TokenTransferRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TopicMessageLookupRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TopicMessageLookupRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TopicMessageRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TopicMessageRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TransactionHashRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TransactionHashRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TransactionRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TransactionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TransactionSignatureRepository.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/TransactionSignatureRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/ColumnMetadata.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/ColumnMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/DissociateTokenTransferUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/DissociateTokenTransferUpsertQueryGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityMetadata.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistry.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGenerator.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGeneratorFactory.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/retention/RetentionJob.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/retention/RetentionJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/retention/RetentionProperties.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/retention/RetentionProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/ShutdownHelper.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/ShutdownHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/DisableRepeatableSqlMigration.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/DisableRepeatableSqlMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/EnabledIfV1.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/EnabledIfV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/EnabledIfV2.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/EnabledIfV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/FileCopier.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/FileCopier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/ImporterIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/ImporterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/ImporterPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/ImporterPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/PubSubIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/PubSubIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/RetryRecorder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/RetryRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestRecordFiles.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestRecordFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/AbstractStreamFileHealthIndicatorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/AbstractStreamFileHealthIndicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/BalanceStreamFileHealthIndicatorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/BalanceStreamFileHealthIndicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/DateRangeCalculatorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/DateRangeCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MetricsConfigurationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MetricsConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MetricsExecutionInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MigrationHealthIndicatorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MigrationHealthIndicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/RecordStreamFileHealthIndicatorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/RecordStreamFileHealthIndicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/ByteArrayToHexSerializerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/ByteArrayToHexSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/InstantConverter.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/InstantConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/JsonbToListConverter.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/JsonbToListConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/KeyConverter.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/KeyConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/TopicIdArgumentConverter.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/TopicIdArgumentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/db/PartitionMaintenanceV1Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/db/PartitionMaintenanceV1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/db/PartitionMaintenanceV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/db/PartitionMaintenanceV2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/db/TimePartitionServiceTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/db/TimePartitionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ConsensusNodeStub.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ConsensusNodeStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/EntityIdServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/EntityIdServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFileDataTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFileDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFileSignatureTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFileSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFilenameTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/StreamFilenameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/token/AbstractTokenTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/token/AbstractTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractLinkedStreamDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractLinkedStreamDownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/CommonDownloaderPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/CommonDownloaderPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/DownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/DownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/balance/AccountBalancesDownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/event/EventFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/event/EventFileDownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AutoS3StreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AutoS3StreamFileProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/CompositeStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/CompositeStreamFileProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/NodeIdS3StreamProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/NodeIdS3StreamProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/AbstractRecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/AbstractRecordFileDownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/ProtoRecordFileDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/ProtoRecordFileDownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileV2DownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileV2DownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileV2V5DownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileV2V5DownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileV5DownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileV5DownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileV5V6DownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/record/RecordFileV5V6DownloaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AbstractAsyncJavaMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AbstractAsyncJavaMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AbstractJavaMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AbstractJavaMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AbstractStakingMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AbstractStakingMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AccountEvmAddressMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddAddressBookServiceEndpointsMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddAddressBookServiceEndpointsMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddBalanceTimestampMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddBalanceTimestampMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddNftHistoryMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddNftHistoryMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddNftHistoryRangesMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddNftHistoryRangesMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddRootContractIdMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AddRootContractIdMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AsyncJavaMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AsyncJavaMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillBlockMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillBlockMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillFailedEthereumTransactionContractResultMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillFailedEthereumTransactionContractResultMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BlockNumberMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BlockNumberMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CleanupEntityMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ContractLogsConvertTopicsToBytesMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ContractLogsConvertTopicsToBytesMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ContractResultMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ContractResultMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ContractStateMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ContractStateMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ConvertEthereumTransactionValueMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ConvertEthereumTransactionValueMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CustomFeesMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/CustomFeesMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/DisablePartitionMaintenanceConfiguration.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/DisablePartitionMaintenanceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/DummyMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/DummyMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/EntityTimestampMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/EntityTimestampMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/EntityTimestampMigrationV1_46_0Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/EntityTimestampMigrationV1_46_0Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ErrataMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ErrataMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FillMissingContractInitsourceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FillMissingContractInitsourceMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/Fix102AddressBookMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/Fix102AddressBookMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixAllowanceAmountsMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixAllowanceAmountsMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixCryptoAllowanceAmountMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixCryptoAllowanceAmountMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixStakePeriodStartMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixStakePeriodStartMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixStakedBeforeEnabledMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixStakedBeforeEnabledMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixTokenAllowanceAmountMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixTokenAllowanceAmountMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/HistoricalAccountInfoMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/HistoricalAccountInfoMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/InitializeEntityBalanceMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MergeDuplicateBlocksMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingAddressBooksMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingEvmAddressMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/MissingEvmAddressMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/NestNftTransferMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/NestNftTransferMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RecalculatePendingRewardMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RecalculatePendingRewardMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveEntityTypeMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveEntityTypeMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveInvalidEntityMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RemoveInvalidEntityMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RepeatableMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/RepeatableMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SidecarContractMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SidecarContractMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SupportDeletedTokenDissociateMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticNftAllowanceOwnerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticNftAllowanceOwnerMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticTokenAllowanceOwnerMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TimePartitionBalanceTablesMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TimePartitionBalanceTablesMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountBalanceMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TokenAccountMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TopicMessagePayerAccountIdMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TopicMessagePayerAccountIdMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/TransferTransactionPayerMigrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/CommonParserPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/CommonParserPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserPerformanceTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserPerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/BatchInserterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/BatchInserterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/BatchUpserterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/BatchUpserterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/CompositeBatchPersisterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/CompositeBatchPersisterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/TransactionHashBatchInserterTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/TransactionHashBatchInserterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/TransactionHashTxManagerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/batch/TransactionHashTxManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/contractlog/SyntheticContractLogServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/contractresult/SyntheticContractResultServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/contractresult/SyntheticContractResultServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/PubSubMessageTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/PubSubMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordFileBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordFileBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/event/EventFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/event/EventFileParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/PerformanceIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/PerformanceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/RestoreClientIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/performance/RestoreClientIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ParserPerformanceProperties.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ParserPerformanceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserPerformanceTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserPerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/BatchEntityListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/DomainClassComparatorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/DomainClassComparatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerCryptoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerEntityTransactionTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerEntityTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerFileTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerFreezeTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerFreezeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerNodeTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerScheduleTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerScheduleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTopicTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerTopicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerUtilTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/PersistPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/TransactionSignatureTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/TransactionSignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyingEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/notify/NotifyingEntityListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/performance/EntityRecordItemListenerPerformanceCryptoTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/performance/EntityRecordItemListenerPerformanceCryptoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/redis/RedisEntityListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/topic/AbstractTopicMessageLookupIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/topic/AbstractTopicMessageLookupIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/topic/TopicMessageLookupEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/topic/TopicMessageLookupEntityListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ethereum/AbstractEthereumTransactionParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ethereum/CompositeEthereumTransactionParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ethereum/CompositeEthereumTransactionParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ethereum/Eip1559EthereumTransactionParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ethereum/Eip1559EthereumTransactionParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ethereum/Eip2930EthereumTransactionParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ethereum/Eip2930EthereumTransactionParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ethereum/LegacyEthereumTransactionParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/ethereum/LegacyEthereumTransactionParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalancePropertiesTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalancePropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceServiceIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceServiceTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/historicalbalance/HistoricalBalanceServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordItemListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/pubsub/PubSubRecordParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractDeleteOrUndeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractDeleteOrUndeleteTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/AbstractTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusCreateTopicTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusDeleteTopicTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusDeleteTopicTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusSubmitMessageTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusSubmitMessageTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ConsensusUpdateTopicTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCallTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCallTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractCreateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractDeleteTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ContractUpdateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoAddLiveHashTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoAddLiveHashTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoApproveAllowanceTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoCreateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteAllowanceTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteAllowanceTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteLiveHashTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteLiveHashTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoDeleteTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoTransferTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoTransferTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileAppendTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileAppendTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileCreateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileDeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileDeleteTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FileUpdateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FreezeTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/FreezeTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeStakeUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeStakeUpdateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleCreateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleDeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleDeleteTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleSignTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/ScheduleSignTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemDeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemDeleteTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemUndeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/SystemUndeleteTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenAssociateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenAssociateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenBurnTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenBurnTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenCreateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenCreateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenDeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenDeleteTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenDissociateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenDissociateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenFeeScheduleUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenFeeScheduleUpdateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenFreezeTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenFreezeTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenGrantKycTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenGrantKycTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenMintTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenMintTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenPauseTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenPauseTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenRevokeKycTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenRevokeKycTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUnfreezeTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUnfreezeTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUnpauseTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUnpauseTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenWipeTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenWipeTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandlerFactoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TransactionHandlerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/UncheckedSubmitTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/UncheckedSubmitTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/UnknownDataTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/UnknownDataTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/UtilPrngTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/UtilPrngTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/HashObjectTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/HashObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/ValidatedDataInputStreamTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/ValidatedDataInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/BalanceFileReaderImplV1Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/BalanceFileReaderImplV1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/BalanceFileReaderImplV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/BalanceFileReaderImplV2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CompositeBalanceFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV1Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/line/AccountBalanceLineParserV2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/event/EventFileReaderV3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/AbstractRecordFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/AbstractRecordFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/CompositeRecordFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/CompositeRecordFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/ProtoRecordFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/ProtoRecordFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV1Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV5Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV5Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/sidecar/SidecarFileReaderImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/sidecar/SidecarFileReaderImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/AbstractSignatureFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/AbstractSignatureFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/CompositeSignatureFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/CompositeSignatureFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/ProtoSignatureFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/ProtoSignatureFileReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/signature/SignatureFileReaderV2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reconciliation/BalanceReconciliationServiceTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reconciliation/BalanceReconciliationServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AbstractRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AbstractRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceFileRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceFileRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AccountBalanceRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookEntryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookEntryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookServiceEndpointRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AddressBookServiceEndpointRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AssessedCustomFeeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/AssessedCustomFeeRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractActionRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractActionRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractLogRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractLogRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractResultRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractResultRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractStateChangeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractStateChangeRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractStateRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractStateRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractTransactionHashRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractTransactionHashRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractTransactionRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ContractTransactionRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/CryptoAllowanceHistoryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/CryptoAllowanceHistoryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/CryptoAllowanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/CryptoAllowanceRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/CryptoTransferRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/CryptoTransferRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/CustomFeeHistoryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/CustomFeeHistoryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/CustomFeeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/CustomFeeRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityHistoryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityHistoryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeHistoryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeHistoryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityTransactionRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityTransactionRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EthereumTransactionRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EthereumTransactionRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EventFileRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EventFileRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/FileDataRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/FileDataRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/LiveHashRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/LiveHashRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NetworkFreezeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NetworkFreezeRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NetworkStakeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NetworkStakeRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NftAllowanceHistoryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NftAllowanceHistoryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NftAllowanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NftAllowanceRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NftHistoryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NftHistoryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NftRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NftRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NodeStakeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/NodeStakeRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/PrngRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/PrngRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ReconciliationJobRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ReconciliationJobRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/RecordFileRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/RecordFileRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/ScheduleRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/SidecarFileRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/SidecarFileRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/StakingRewardTransferRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/StakingRewardTransferRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenAccountHistoryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenAccountHistoryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenAccountRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenAccountRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenAllowanceHistoryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenAllowanceHistoryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenAllowanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenAllowanceRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenBalanceRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenBalanceRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenHistoryRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenHistoryRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenTransferRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TokenTransferRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TopicMessageLookupRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TopicMessageLookupRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TopicMessageRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TopicMessageRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TransactionHashRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TransactionHashRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TransactionRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TransactionRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TransactionSignatureRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/TransactionSignatureRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/EntityMetadataRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/GenericUpsertQueryGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGeneratorTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/TokenAccountUpsertQueryGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGeneratorFactoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/upsert/UpsertQueryGeneratorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/retention/RetentionJobTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/retention/RetentionJobTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/util/UtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/AbstractScenario.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/AbstractScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/HederaNetwork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MirrorNodeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MirrorNodeProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MonitorApplication.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MonitorApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MonitorProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/MonitorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeValidationProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/NodeValidationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/OperatorProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/OperatorProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioProtocol.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioStatus.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/ScenarioStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/LoggingFilter.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/LoggingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MetricsConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MetricsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/config/MonitorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/DurationToStringSerializer.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/DurationToStringSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/StringToDurationDeserializer.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/StringToDurationDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/StringToInstantDeserializer.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/converter/StringToInstantDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/exception/ExpressionConversionException.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/exception/ExpressionConversionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverter.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/expression/ExpressionConverterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ClusterHealthIndicator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ClusterHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/properties/ScenarioPropertiesAggregator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/properties/ScenarioPropertiesAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/properties/ScenarioPropertiesAggregatorImpl.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/properties/ScenarioPropertiesAggregatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/NodeSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/NodeSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishException.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenarioProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/PublishScenarioProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/TransactionPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/CompositeTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/CompositeTransactionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ScenarioException.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/ScenarioException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/TransactionGenerator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/generator/TransactionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/AdminKeyable.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/AdminKeyable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/TransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/TransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/TransactionType.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/TransactionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/account/AccountCreateTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/account/AccountCreateTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/account/AccountDeleteTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/account/AccountDeleteTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/account/AccountUpdateTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/account/AccountUpdateTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/account/CryptoTransferTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/account/CryptoTransferTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusCreateTopicTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusCreateTopicTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusDeleteTopicTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusDeleteTopicTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusSubmitMessageTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusSubmitMessageTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusUpdateTopicTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusUpdateTopicTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/network/FreezeTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/network/FreezeTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleCreateTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleCreateTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleDeleteTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleDeleteTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleSignTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleSignTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenAssociateTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenAssociateTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenBurnTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenBurnTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenCreateTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenCreateTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenDeleteTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenDeleteTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenDissociateTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenDissociateTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenFreezeTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenFreezeTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenGrantKycTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenGrantKycTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenMintTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenMintTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenPauseTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenPauseTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenRevokeKycTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenRevokeKycTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUnfreezeTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUnfreezeTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUnpauseTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUnpauseTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUpdateTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUpdateTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenWipeTransactionSupplier.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/publish/transaction/token/TokenWipeTransactionSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/AbstractSubscriberProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/MirrorSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/MirrorSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Scenario.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/Scenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeResponse.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/SubscribeResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberController.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClient.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDK.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDK.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscription.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestApiClient.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriber.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriberProperties.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriberProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscription.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/config/LoggingFilterTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/config/LoggingFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/DurationToStringSerializerTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/DurationToStringSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/StringToDurationDeserializerTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/StringToDurationDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/StringToInstantDeserializerTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/converter/StringToInstantDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/expression/ExpressionConverterImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/health/ClusterHealthIndicatorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/health/ClusterHealthIndicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicatorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/NodeSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/NodeSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishMetricsTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishPropertiesTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/PublishPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/TransactionPublisherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/CompositeTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/CompositeTransactionGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/generator/ConfigurableTransactionGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/AbstractTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/AbstractTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/account/AccountCreateTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/account/AccountCreateTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/account/AccountDeleteTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/account/AccountDeleteTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/account/AccountUpdateTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/account/AccountUpdateTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/account/CryptoTransferTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/account/CryptoTransferTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusCreateTopicTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusCreateTopicTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusDeleteTopicTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusDeleteTopicTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusSubmitMessageTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusSubmitMessageTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusUpdateTopicTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/consensus/ConsensusUpdateTopicTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleCreateTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleCreateTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleDeleteTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleDeleteTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleSignTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/schedule/ScheduleSignTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/FreezeTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/FreezeTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenAssociateTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenAssociateTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenBurnTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenBurnTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenCreateTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenCreateTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenDeleteTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenDeleteTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenDissociateTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenDissociateTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenFreezeTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenFreezeTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenGrantKycTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenGrantKycTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenMintTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenMintTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenPauseTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenPauseTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenRevokeKycTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenRevokeKycTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUnfreezeTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUnfreezeTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUnpauseTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUnpauseTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUpdateTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenUpdateTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenWipeTransactionSupplierTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/publish/transaction/token/TokenWipeTransactionSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/CompositeSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/SubscribeMetricsTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/SubscribeMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/SubscribePropertiesTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/SubscribePropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/TestScenario.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/TestScenario.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberControllerTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/controller/SubscriberControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDKTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcClientSDKTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/grpc/GrpcSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/rest/RestApiClientTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/rest/RestApiClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriberTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/subscribe/rest/RestSubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/util/UtilityTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/util/UtilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-protobuf/build.gradle.kts
+++ b/hedera-mirror-protobuf/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-protobuf/src/main/proto/com/hedera/mirror/api/proto/consensus_service.proto
+++ b/hedera-mirror-protobuf/src/main/proto/com/hedera/mirror/api/proto/consensus_service.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-protobuf/src/main/proto/com/hedera/mirror/api/proto/network_service.proto
+++ b/hedera-mirror-protobuf/src/main/proto/com/hedera/mirror/api/proto/network_service.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/RestJavaApplication.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/RestJavaApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/repository/NftAllowanceRepository.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/repository/NftAllowanceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/RestJavaIntegrationTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/RestJavaIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/repository/NftAllowanceRepositoryTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/repository/NftAllowanceRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/accountAlias.test.js
+++ b/hedera-mirror-rest/__tests__/accountAlias.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp-lte.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp-lte.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp-notfound.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp-notfound.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/accounts.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/balances.deduplication.test.js
+++ b/hedera-mirror-rest/__tests__/balances.deduplication.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/balances.test.js
+++ b/hedera-mirror-rest/__tests__/balances.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/base32.test.js
+++ b/hedera-mirror-rest/__tests__/base32.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/config.test.js
+++ b/hedera-mirror-rest/__tests__/config.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/controllers/accountController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/accountController.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/controllers/blockController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/blockController.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/controllers/contractController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/contractController.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/controllers/cryptoAllowanceController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/cryptoAllowanceController.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/controllers/networkController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/networkController.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/controllers/tokenAllowanceController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/tokenAllowanceController.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/controllers/tokenController.test.js
+++ b/hedera-mirror-rest/__tests__/controllers/tokenController.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/data/db/stateproof/addRecordFileWithBytes.js
+++ b/hedera-mirror-rest/__tests__/data/db/stateproof/addRecordFileWithBytes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/ed25519.test.js
+++ b/hedera-mirror-rest/__tests__/ed25519.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/entityId.test.js
+++ b/hedera-mirror-rest/__tests__/entityId.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/globalSetup.js
+++ b/hedera-mirror-rest/__tests__/globalSetup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/globalTeardown.js
+++ b/hedera-mirror-rest/__tests__/globalTeardown.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/integration/generator.js
+++ b/hedera-mirror-rest/__tests__/integration/generator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/integration/transactionHashV1Matrix.js
+++ b/hedera-mirror-rest/__tests__/integration/transactionHashV1Matrix.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/integrationS3Ops.js
+++ b/hedera-mirror-rest/__tests__/integrationS3Ops.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/integrationUtils.js
+++ b/hedera-mirror-rest/__tests__/integrationUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/jestSetup.js
+++ b/hedera-mirror-rest/__tests__/jestSetup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/middleware/responseHandler.test.js
+++ b/hedera-mirror-rest/__tests__/middleware/responseHandler.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/mockPool.js
+++ b/hedera-mirror-rest/__tests__/mockPool.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
+++ b/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/model/feeSchedule.test.js
+++ b/hedera-mirror-rest/__tests__/model/feeSchedule.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/model/signatureType.test.js
+++ b/hedera-mirror-rest/__tests__/model/signatureType.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/model/tokenFreezeStatus.test.js
+++ b/hedera-mirror-rest/__tests__/model/tokenFreezeStatus.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/model/tokenKycStatus.test.js
+++ b/hedera-mirror-rest/__tests__/model/tokenKycStatus.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/model/transactionResult.test.js
+++ b/hedera-mirror-rest/__tests__/model/transactionResult.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/model/transactionType.test.js
+++ b/hedera-mirror-rest/__tests__/model/transactionType.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/requestHandler.test.js
+++ b/hedera-mirror-rest/__tests__/requestHandler.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/s3client.test.js
+++ b/hedera-mirror-rest/__tests__/s3client.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/schedules.test.js
+++ b/hedera-mirror-rest/__tests__/schedules.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/baseService.test.js
+++ b/hedera-mirror-rest/__tests__/service/baseService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/contractService.test.js
+++ b/hedera-mirror-rest/__tests__/service/contractService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/cryptoAllowanceService.test.js
+++ b/hedera-mirror-rest/__tests__/service/cryptoAllowanceService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/entityService.test.js
+++ b/hedera-mirror-rest/__tests__/service/entityService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/fileDataService.test.js
+++ b/hedera-mirror-rest/__tests__/service/fileDataService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/networkNodeService.test.js
+++ b/hedera-mirror-rest/__tests__/service/networkNodeService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/nftService.test.js
+++ b/hedera-mirror-rest/__tests__/service/nftService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/recordFileService.test.js
+++ b/hedera-mirror-rest/__tests__/service/recordFileService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/stakingRewardTransferService.test.js
+++ b/hedera-mirror-rest/__tests__/service/stakingRewardTransferService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/tokenAllowanceService.test.js
+++ b/hedera-mirror-rest/__tests__/service/tokenAllowanceService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/tokenService.test.js
+++ b/hedera-mirror-rest/__tests__/service/tokenService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/service/transactionService.test.js
+++ b/hedera-mirror-rest/__tests__/service/transactionService.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stateproof.test.js
+++ b/hedera-mirror-rest/__tests__/stateproof.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/compositeRecordFile.test.js
+++ b/hedera-mirror-rest/__tests__/stream/compositeRecordFile.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/hashObject.test.js
+++ b/hedera-mirror-rest/__tests__/stream/hashObject.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/recordFilePreV5.test.js
+++ b/hedera-mirror-rest/__tests__/stream/recordFilePreV5.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/recordFileV5.test.js
+++ b/hedera-mirror-rest/__tests__/stream/recordFileV5.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/recordFileV6.test.js
+++ b/hedera-mirror-rest/__tests__/stream/recordFileV6.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/recordStreamObject.test.js
+++ b/hedera-mirror-rest/__tests__/stream/recordStreamObject.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/runningHash.test.js
+++ b/hedera-mirror-rest/__tests__/stream/runningHash.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/signatureFile.test.js
+++ b/hedera-mirror-rest/__tests__/stream/signatureFile.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/signatureObject.test.js
+++ b/hedera-mirror-rest/__tests__/stream/signatureObject.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/streamObject.test.js
+++ b/hedera-mirror-rest/__tests__/stream/streamObject.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/testUtils.js
+++ b/hedera-mirror-rest/__tests__/stream/testUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/stream/utils.test.js
+++ b/hedera-mirror-rest/__tests__/stream/utils.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/testutils.js
+++ b/hedera-mirror-rest/__tests__/testutils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/transactionId.test.js
+++ b/hedera-mirror-rest/__tests__/transactionId.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/transactions.test.js
+++ b/hedera-mirror-rest/__tests__/transactions.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/utilsFilters.test.js
+++ b/hedera-mirror-rest/__tests__/utilsFilters.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/assessedCustomFeeViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/assessedCustomFeeViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/blockViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/blockViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/contractActionViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/contractActionViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/contractLogViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/contractLogViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/contractResultViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/contractResultViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/contractStateViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/contractStateViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/contractViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/contractViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/customFeeViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/customFeeViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/feeScheduleViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/feeScheduleViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/networkNodeViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/networkNodeViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/networkStakeViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/networkStakeViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/__tests__/viewmodel/topicMessageViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/topicMessageViewModel.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/accountAlias.js
+++ b/hedera-mirror-rest/accountAlias.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/accounts.js
+++ b/hedera-mirror-rest/accounts.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/base32.js
+++ b/hedera-mirror-rest/base32.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/build.gradle.kts
+++ b/hedera-mirror-rest/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/check-state-proof/addressBook.js
+++ b/hedera-mirror-rest/check-state-proof/addressBook.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/check-state-proof/index.js
+++ b/hedera-mirror-rest/check-state-proof/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/check-state-proof/jest.config.js
+++ b/hedera-mirror-rest/check-state-proof/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/check-state-proof/startUpScreen.js
+++ b/hedera-mirror-rest/check-state-proof/startUpScreen.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/check-state-proof/stateProofHandler.js
+++ b/hedera-mirror-rest/check-state-proof/stateProofHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/check-state-proof/tests/stateProof.test.js
+++ b/hedera-mirror-rest/check-state-proof/tests/stateProof.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/check-state-proof/transactionValidator.js
+++ b/hedera-mirror-rest/check-state-proof/transactionValidator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/check-state-proof/utils.js
+++ b/hedera-mirror-rest/check-state-proof/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/config.js
+++ b/hedera-mirror-rest/config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/constants.js
+++ b/hedera-mirror-rest/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/controllers/accountController.js
+++ b/hedera-mirror-rest/controllers/accountController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/controllers/baseController.js
+++ b/hedera-mirror-rest/controllers/baseController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/controllers/blockController.js
+++ b/hedera-mirror-rest/controllers/blockController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/controllers/bound.js
+++ b/hedera-mirror-rest/controllers/bound.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/controllers/cryptoAllowanceController.js
+++ b/hedera-mirror-rest/controllers/cryptoAllowanceController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/controllers/index.js
+++ b/hedera-mirror-rest/controllers/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/controllers/networkController.js
+++ b/hedera-mirror-rest/controllers/networkController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/controllers/tokenAllowanceController.js
+++ b/hedera-mirror-rest/controllers/tokenAllowanceController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/controllers/tokenController.js
+++ b/hedera-mirror-rest/controllers/tokenController.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/ed25519.js
+++ b/hedera-mirror-rest/ed25519.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/errors/dbError.js
+++ b/hedera-mirror-rest/errors/dbError.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/errors/fileDecodeError.js
+++ b/hedera-mirror-rest/errors/fileDecodeError.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/errors/fileDownloadError.js
+++ b/hedera-mirror-rest/errors/fileDownloadError.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/errors/index.js
+++ b/hedera-mirror-rest/errors/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/errors/invalidArgumentError.js
+++ b/hedera-mirror-rest/errors/invalidArgumentError.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/errors/invalidClauseError.js
+++ b/hedera-mirror-rest/errors/invalidClauseError.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/errors/invalidConfigError.js
+++ b/hedera-mirror-rest/errors/invalidConfigError.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/errors/notFoundError.js
+++ b/hedera-mirror-rest/errors/notFoundError.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/health.js
+++ b/hedera-mirror-rest/health.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/logger.js
+++ b/hedera-mirror-rest/logger.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/middleware/httpErrorHandler.js
+++ b/hedera-mirror-rest/middleware/httpErrorHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/middleware/index.js
+++ b/hedera-mirror-rest/middleware/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/middleware/metricsHandler.js
+++ b/hedera-mirror-rest/middleware/metricsHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/middleware/openapiHandler.js
+++ b/hedera-mirror-rest/middleware/openapiHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/middleware/requestHandler.js
+++ b/hedera-mirror-rest/middleware/requestHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/middleware/responseHandler.js
+++ b/hedera-mirror-rest/middleware/responseHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/accountBalanceFile.js
+++ b/hedera-mirror-rest/model/accountBalanceFile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/addressBook.js
+++ b/hedera-mirror-rest/model/addressBook.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/addressBookEntry.js
+++ b/hedera-mirror-rest/model/addressBookEntry.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/addressBookServiceEndpoint.js
+++ b/hedera-mirror-rest/model/addressBookServiceEndpoint.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/assessedCustomFee.js
+++ b/hedera-mirror-rest/model/assessedCustomFee.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/contract.js
+++ b/hedera-mirror-rest/model/contract.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/contractAction.js
+++ b/hedera-mirror-rest/model/contractAction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/contractLog.js
+++ b/hedera-mirror-rest/model/contractLog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/contractResult.js
+++ b/hedera-mirror-rest/model/contractResult.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/contractState.js
+++ b/hedera-mirror-rest/model/contractState.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/contractStateChange.js
+++ b/hedera-mirror-rest/model/contractStateChange.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/contractTransaction.js
+++ b/hedera-mirror-rest/model/contractTransaction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/contractTransactionHash.js
+++ b/hedera-mirror-rest/model/contractTransactionHash.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/cryptoAllowance.js
+++ b/hedera-mirror-rest/model/cryptoAllowance.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/cryptoTransfer.js
+++ b/hedera-mirror-rest/model/cryptoTransfer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/customFee.js
+++ b/hedera-mirror-rest/model/customFee.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/entity.js
+++ b/hedera-mirror-rest/model/entity.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/ethereumTransaction.js
+++ b/hedera-mirror-rest/model/ethereumTransaction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/exchangeRate.js
+++ b/hedera-mirror-rest/model/exchangeRate.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/fee.js
+++ b/hedera-mirror-rest/model/fee.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/feeSchedule.js
+++ b/hedera-mirror-rest/model/feeSchedule.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/fileData.js
+++ b/hedera-mirror-rest/model/fileData.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/fixedFee.js
+++ b/hedera-mirror-rest/model/fixedFee.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/fractionalFee.js
+++ b/hedera-mirror-rest/model/fractionalFee.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/index.js
+++ b/hedera-mirror-rest/model/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/networkNode.js
+++ b/hedera-mirror-rest/model/networkNode.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/networkStake.js
+++ b/hedera-mirror-rest/model/networkStake.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/nft.js
+++ b/hedera-mirror-rest/model/nft.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/nftHistory.js
+++ b/hedera-mirror-rest/model/nftHistory.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/nftTransfer.js
+++ b/hedera-mirror-rest/model/nftTransfer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/nodeStake.js
+++ b/hedera-mirror-rest/model/nodeStake.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/recordFile.js
+++ b/hedera-mirror-rest/model/recordFile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/royaltyFee.js
+++ b/hedera-mirror-rest/model/royaltyFee.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/signatureType.js
+++ b/hedera-mirror-rest/model/signatureType.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/stakingRewardTransfer.js
+++ b/hedera-mirror-rest/model/stakingRewardTransfer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/token.js
+++ b/hedera-mirror-rest/model/token.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/tokenAccount.js
+++ b/hedera-mirror-rest/model/tokenAccount.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/tokenAllowance.js
+++ b/hedera-mirror-rest/model/tokenAllowance.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/tokenBalance.js
+++ b/hedera-mirror-rest/model/tokenBalance.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/tokenFreezeStatus.js
+++ b/hedera-mirror-rest/model/tokenFreezeStatus.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/tokenKycStatus.js
+++ b/hedera-mirror-rest/model/tokenKycStatus.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/tokenTransfer.js
+++ b/hedera-mirror-rest/model/tokenTransfer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/tokenType.js
+++ b/hedera-mirror-rest/model/tokenType.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/topicMessage.js
+++ b/hedera-mirror-rest/model/topicMessage.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/topicMessageLookup.js
+++ b/hedera-mirror-rest/model/topicMessageLookup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/transaction.js
+++ b/hedera-mirror-rest/model/transaction.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/transactionHash.js
+++ b/hedera-mirror-rest/model/transactionHash.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/transactionId.js
+++ b/hedera-mirror-rest/model/transactionId.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/transactionResult.js
+++ b/hedera-mirror-rest/model/transactionResult.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/model/transactionType.js
+++ b/hedera-mirror-rest/model/transactionType.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/account_tests.js
+++ b/hedera-mirror-rest/monitoring/account_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/balance_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/block_tests.js
+++ b/hedera-mirror-rest/monitoring/block_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/common.js
+++ b/hedera-mirror-rest/monitoring/common.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/config.js
+++ b/hedera-mirror-rest/monitoring/config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/logger.js
+++ b/hedera-mirror-rest/monitoring/logger.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/monitor.js
+++ b/hedera-mirror-rest/monitoring/monitor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/monitor_tests.js
+++ b/hedera-mirror-rest/monitoring/monitor_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/network_tests.js
+++ b/hedera-mirror-rest/monitoring/network_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/server.js
+++ b/hedera-mirror-rest/monitoring/server.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/stateproof_tests.js
+++ b/hedera-mirror-rest/monitoring/stateproof_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/token_tests.js
+++ b/hedera-mirror-rest/monitoring/token_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/topicmessage_tests.js
+++ b/hedera-mirror-rest/monitoring/topicmessage_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/transaction_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/monitoring/utils.js
+++ b/hedera-mirror-rest/monitoring/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/routes/accountRoute.js
+++ b/hedera-mirror-rest/routes/accountRoute.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/routes/blockRoute.js
+++ b/hedera-mirror-rest/routes/blockRoute.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/routes/contractRoute.js
+++ b/hedera-mirror-rest/routes/contractRoute.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/routes/index.js
+++ b/hedera-mirror-rest/routes/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/routes/networkRoute.js
+++ b/hedera-mirror-rest/routes/networkRoute.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/s3client.js
+++ b/hedera-mirror-rest/s3client.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/schedules.js
+++ b/hedera-mirror-rest/schedules.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/baseService.js
+++ b/hedera-mirror-rest/service/baseService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/contractService.js
+++ b/hedera-mirror-rest/service/contractService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/cryptoAllowanceService.js
+++ b/hedera-mirror-rest/service/cryptoAllowanceService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/entityService.js
+++ b/hedera-mirror-rest/service/entityService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/fileDataService.js
+++ b/hedera-mirror-rest/service/fileDataService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/index.js
+++ b/hedera-mirror-rest/service/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/nftService.js
+++ b/hedera-mirror-rest/service/nftService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/recordFileService.js
+++ b/hedera-mirror-rest/service/recordFileService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/stakingRewardTransferService.js
+++ b/hedera-mirror-rest/service/stakingRewardTransferService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/tokenAllowanceService.js
+++ b/hedera-mirror-rest/service/tokenAllowanceService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/tokenService.js
+++ b/hedera-mirror-rest/service/tokenService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/service/transactionService.js
+++ b/hedera-mirror-rest/service/transactionService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/sql/index.js
+++ b/hedera-mirror-rest/sql/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/sql/orderSpec.js
+++ b/hedera-mirror-rest/sql/orderSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stateproof.js
+++ b/hedera-mirror-rest/stateproof.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/compactRecordFile.js
+++ b/hedera-mirror-rest/stream/compactRecordFile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/compositeRecordFile.js
+++ b/hedera-mirror-rest/stream/compositeRecordFile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/constants.js
+++ b/hedera-mirror-rest/stream/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/hashObject.js
+++ b/hedera-mirror-rest/stream/hashObject.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/index.js
+++ b/hedera-mirror-rest/stream/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/recordFile.js
+++ b/hedera-mirror-rest/stream/recordFile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/recordFilePreV5.js
+++ b/hedera-mirror-rest/stream/recordFilePreV5.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/recordFileV5.js
+++ b/hedera-mirror-rest/stream/recordFileV5.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/recordFileV6.js
+++ b/hedera-mirror-rest/stream/recordFileV6.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/recordStreamObject.js
+++ b/hedera-mirror-rest/stream/recordStreamObject.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/runningHash.js
+++ b/hedera-mirror-rest/stream/runningHash.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/signatureFile.js
+++ b/hedera-mirror-rest/stream/signatureFile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/signatureObject.js
+++ b/hedera-mirror-rest/stream/signatureObject.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/streamObject.js
+++ b/hedera-mirror-rest/stream/streamObject.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/stream/utils.js
+++ b/hedera-mirror-rest/stream/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/transactionId.js
+++ b/hedera-mirror-rest/transactionId.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/addressBookServiceEndpointViewModel.js
+++ b/hedera-mirror-rest/viewmodel/addressBookServiceEndpointViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/assessedCustomFeeViewModel.js
+++ b/hedera-mirror-rest/viewmodel/assessedCustomFeeViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/baseAllowanceViewModel.js
+++ b/hedera-mirror-rest/viewmodel/baseAllowanceViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/blockViewModel.js
+++ b/hedera-mirror-rest/viewmodel/blockViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/contractActionViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractActionViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/contractBytecodeViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractBytecodeViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/contractLogViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractLogViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/contractResultDetailsViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractResultDetailsViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/contractResultLogViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractResultLogViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/contractResultStateChangeViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractResultStateChangeViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/contractResultViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractResultViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/contractStateViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractStateViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/contractViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/cryptoAllowanceViewModel.js
+++ b/hedera-mirror-rest/viewmodel/cryptoAllowanceViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/customFeeViewModel.js
+++ b/hedera-mirror-rest/viewmodel/customFeeViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/exchangeRateSetViewModel.js
+++ b/hedera-mirror-rest/viewmodel/exchangeRateSetViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/exchangeRateViewModel.js
+++ b/hedera-mirror-rest/viewmodel/exchangeRateViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/feeScheduleViewModel.js
+++ b/hedera-mirror-rest/viewmodel/feeScheduleViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/index.js
+++ b/hedera-mirror-rest/viewmodel/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/networkNodeViewModel.js
+++ b/hedera-mirror-rest/viewmodel/networkNodeViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/networkStakeViewModel.js
+++ b/hedera-mirror-rest/viewmodel/networkStakeViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/networkSupplyViewModel.js
+++ b/hedera-mirror-rest/viewmodel/networkSupplyViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/nftTransactionHistoryViewModel.js
+++ b/hedera-mirror-rest/viewmodel/nftTransactionHistoryViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/nftTransferViewModel.js
+++ b/hedera-mirror-rest/viewmodel/nftTransferViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/nftViewModel.js
+++ b/hedera-mirror-rest/viewmodel/nftViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/stakingRewardTransferViewModel.js
+++ b/hedera-mirror-rest/viewmodel/stakingRewardTransferViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/tokenAllowanceViewModel.js
+++ b/hedera-mirror-rest/viewmodel/tokenAllowanceViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/tokenRelationshipViewModel.js
+++ b/hedera-mirror-rest/viewmodel/tokenRelationshipViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/topicMessageViewModel.js
+++ b/hedera-mirror-rest/viewmodel/topicMessageViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rest/viewmodel/transactionIdViewModel.js
+++ b/hedera-mirror-rest/viewmodel/transactionIdViewModel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/config/config.go
+++ b/hedera-mirror-rosetta/app/config/config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/config/config_test.go
+++ b/hedera-mirror-rosetta/app/config/config_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/config/types.go
+++ b/hedera-mirror-rosetta/app/config/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/config/types_test.go
+++ b/hedera-mirror-rosetta/app/config/types_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/db/client.go
+++ b/hedera-mirror-rosetta/app/db/client.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/db/db.go
+++ b/hedera-mirror-rosetta/app/db/db.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/db/db_test.go
+++ b/hedera-mirror-rosetta/app/db/db_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/account_id.go
+++ b/hedera-mirror-rosetta/app/domain/types/account_id.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/account_id_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/account_id_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/address_book_entry.go
+++ b/hedera-mirror-rosetta/app/domain/types/address_book_entry.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/address_book_entry_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/address_book_entry_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/amount.go
+++ b/hedera-mirror-rosetta/app/domain/types/amount.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/amount_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/amount_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/block.go
+++ b/hedera-mirror-rosetta/app/domain/types/block.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/block_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/block_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/constants.go
+++ b/hedera-mirror-rosetta/app/domain/types/constants.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/constants_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/constants_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/operation.go
+++ b/hedera-mirror-rosetta/app/domain/types/operation.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/operation_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/operation_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/public_key.go
+++ b/hedera-mirror-rosetta/app/domain/types/public_key.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/public_key_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/public_key_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/transaction.go
+++ b/hedera-mirror-rosetta/app/domain/types/transaction.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/domain/types/transaction_test.go
+++ b/hedera-mirror-rosetta/app/domain/types/transaction_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/errors/errors.go
+++ b/hedera-mirror-rosetta/app/errors/errors.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/errors/errors_test.go
+++ b/hedera-mirror-rosetta/app/errors/errors_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/interfaces/account_repository.go
+++ b/hedera-mirror-rosetta/app/interfaces/account_repository.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/interfaces/address_book_entry_repository.go
+++ b/hedera-mirror-rosetta/app/interfaces/address_book_entry_repository.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/interfaces/block_repository.go
+++ b/hedera-mirror-rosetta/app/interfaces/block_repository.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/interfaces/db_client.go
+++ b/hedera-mirror-rosetta/app/interfaces/db_client.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/interfaces/transaction.go
+++ b/hedera-mirror-rosetta/app/interfaces/transaction.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/interfaces/transaction_repository.go
+++ b/hedera-mirror-rosetta/app/interfaces/transaction_repository.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/middleware/health.go
+++ b/hedera-mirror-rosetta/app/middleware/health.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/middleware/health_test.go
+++ b/hedera-mirror-rosetta/app/middleware/health_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/middleware/metrics.go
+++ b/hedera-mirror-rosetta/app/middleware/metrics.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/middleware/metrics_test.go
+++ b/hedera-mirror-rosetta/app/middleware/metrics_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/middleware/trace.go
+++ b/hedera-mirror-rosetta/app/middleware/trace.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/middleware/trace_test.go
+++ b/hedera-mirror-rosetta/app/middleware/trace_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/account.go
+++ b/hedera-mirror-rosetta/app/persistence/account.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/account_test.go
+++ b/hedera-mirror-rosetta/app/persistence/account_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/address_book_entry.go
+++ b/hedera-mirror-rosetta/app/persistence/address_book_entry.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/address_book_entry_test.go
+++ b/hedera-mirror-rosetta/app/persistence/address_book_entry_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/block.go
+++ b/hedera-mirror-rosetta/app/persistence/block.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/block_test.go
+++ b/hedera-mirror-rosetta/app/persistence/block_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/common.go
+++ b/hedera-mirror-rosetta/app/persistence/common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/constants.go
+++ b/hedera-mirror-rosetta/app/persistence/constants.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/account_balance.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/account_balance.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/account_balance_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/account_balance_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/address_book.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/address_book.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/address_book_entry.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/address_book_entry.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/address_book_entry_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/address_book_entry_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/address_book_service_endpoint.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/address_book_service_endpoint.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/address_book_service_endpoint_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/address_book_service_endpoint_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/address_book_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/address_book_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/crypto_transfer.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/crypto_transfer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/crypto_transfer_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/crypto_transfer_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/entity.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/entity.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/entity_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/entity_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/entityid.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/entityid.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/entityid_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/entityid_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/record_file.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/record_file.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/record_file_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/record_file_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/staking_reward_transfer.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/staking_reward_transfer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/staking_reward_transfer_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/staking_reward_transfer_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/transaction.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/transaction.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/domain/transaction_test.go
+++ b/hedera-mirror-rosetta/app/persistence/domain/transaction_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/testmain_test.go
+++ b/hedera-mirror-rosetta/app/persistence/testmain_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/transaction.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/persistence/transaction_test.go
+++ b/hedera-mirror-rosetta/app/persistence/transaction_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/account_service.go
+++ b/hedera-mirror-rosetta/app/services/account_service.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/account_service_test.go
+++ b/hedera-mirror-rosetta/app/services/account_service_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/base_service.go
+++ b/hedera-mirror-rosetta/app/services/base_service.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/base_service_test.go
+++ b/hedera-mirror-rosetta/app/services/base_service_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/block_service.go
+++ b/hedera-mirror-rosetta/app/services/block_service.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/block_service_test.go
+++ b/hedera-mirror-rosetta/app/services/block_service_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction/common.go
+++ b/hedera-mirror-rosetta/app/services/construction/common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction/common_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/common_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/composite_transaction_constructor_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_create_transaction_constructor_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor_test.go
+++ b/hedera-mirror-rosetta/app/services/construction/crypto_transfer_transaction_constructor_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction/types.go
+++ b/hedera-mirror-rosetta/app/services/construction/types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction_service.go
+++ b/hedera-mirror-rosetta/app/services/construction_service.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/construction_service_test.go
+++ b/hedera-mirror-rosetta/app/services/construction_service_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/mempool_service.go
+++ b/hedera-mirror-rosetta/app/services/mempool_service.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/mempool_service_test.go
+++ b/hedera-mirror-rosetta/app/services/mempool_service_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/network_service.go
+++ b/hedera-mirror-rosetta/app/services/network_service.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/services/network_service_test.go
+++ b/hedera-mirror-rosetta/app/services/network_service_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/tools/hex.go
+++ b/hedera-mirror-rosetta/app/tools/hex.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/tools/hex_test.go
+++ b/hedera-mirror-rosetta/app/tools/hex_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/tools/maphelper.go
+++ b/hedera-mirror-rosetta/app/tools/maphelper.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/tools/maphelper_test.go
+++ b/hedera-mirror-rosetta/app/tools/maphelper_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/tools/parse.go
+++ b/hedera-mirror-rosetta/app/tools/parse.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/app/tools/parse_test.go
+++ b/hedera-mirror-rosetta/app/tools/parse_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/build.gradle.kts
+++ b/hedera-mirror-rosetta/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/main.go
+++ b/hedera-mirror-rosetta/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/bdd-client/client/client.go
+++ b/hedera-mirror-rosetta/test/bdd-client/client/client.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/bdd-client/client/config.go
+++ b/hedera-mirror-rosetta/test/bdd-client/client/config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/bdd-client/config.go
+++ b/hedera-mirror-rosetta/test/bdd-client/config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/bdd-client/main_test.go
+++ b/hedera-mirror-rosetta/test/bdd-client/main_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/bdd-client/scenario/asserter.go
+++ b/hedera-mirror-rosetta/test/bdd-client/scenario/asserter.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/bdd-client/scenario/base.go
+++ b/hedera-mirror-rosetta/test/bdd-client/scenario/base.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/bdd-client/scenario/common.go
+++ b/hedera-mirror-rosetta/test/bdd-client/scenario/common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/bdd-client/scenario/crypto.go
+++ b/hedera-mirror-rosetta/test/bdd-client/scenario/crypto.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/db/db.go
+++ b/hedera-mirror-rosetta/test/db/db.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/domain/account_balance_snapshot_builder.go
+++ b/hedera-mirror-rosetta/test/domain/account_balance_snapshot_builder.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/domain/crypto_transfer_builder.go
+++ b/hedera-mirror-rosetta/test/domain/crypto_transfer_builder.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/domain/entity_builder.go
+++ b/hedera-mirror-rosetta/test/domain/entity_builder.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/domain/staking_reward_transfer_builder.go
+++ b/hedera-mirror-rosetta/test/domain/staking_reward_transfer_builder.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/domain/transaction_builder.go
+++ b/hedera-mirror-rosetta/test/domain/transaction_builder.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/domain/utils.go
+++ b/hedera-mirror-rosetta/test/domain/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/mocks/account_repository.go
+++ b/hedera-mirror-rosetta/test/mocks/account_repository.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/mocks/address_book_entry_repository.go
+++ b/hedera-mirror-rosetta/test/mocks/address_book_entry_repository.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/mocks/block_repository.go
+++ b/hedera-mirror-rosetta/test/mocks/block_repository.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/mocks/transaction_constructor.go
+++ b/hedera-mirror-rosetta/test/mocks/transaction_constructor.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/mocks/transaction_constructor_with_type.go
+++ b/hedera-mirror-rosetta/test/mocks/transaction_constructor_with_type.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-rosetta/test/mocks/transaction_repository.go
+++ b/hedera-mirror-rosetta/test/mocks/transaction_repository.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/main/java/com/hedera/mirror/test/LoggingReporter.java
+++ b/hedera-mirror-test/src/main/java/com/hedera/mirror/test/LoggingReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/main/java/com/hedera/mirror/test/TestApplication.java
+++ b/hedera-mirror-test/src/main/java/com/hedera/mirror/test/TestApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/AcceptanceTest.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/AcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AbstractNetworkClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/AccountClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/Cleanable.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/Cleanable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ContractClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/FileClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/NetworkException.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/NetworkException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SDKClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/ScheduleClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/StartupProbe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SubscriptionResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/SubscriptionResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TopicClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/AcceptanceTestProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/ClientConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/FeatureProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/FeatureProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/MapperConfiguration.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/MapperConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/RestPollingProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/SdkProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/SdkProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/Web3Properties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/Web3Properties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/WebClientProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/config/WebClientProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/converter/CustomFeesConverter.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/converter/CustomFeesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/CompiledSolidityArtifact.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/CompiledSolidityArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/ContractCallRequest.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/ContractCallRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/ExpandedAccountId.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/ExpandedAccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorAccountBalance.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorAccountBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorAssessedCustomFee.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorAssessedCustomFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorContractResult.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorContractResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorCryptoAllowance.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorCryptoAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorCryptoBalance.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorCryptoBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorCustomFees.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorCustomFees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorFixedFee.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorFixedFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorFraction.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorFraction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorFractionalFee.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorFractionalFee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorFreezeStatus.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorFreezeStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorKey.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorKycStatus.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorKycStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorLinks.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNetworkNode.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNetworkNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNetworkNodes.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNetworkNodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNetworkStake.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNetworkStake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNftTransaction.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNftTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNftTransfer.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorNftTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorScheduleSignature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorScheduleSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTimestampRange.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTimestampRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTokenAccount.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTokenAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTokenAccountBalance.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTokenAccountBalance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTokenAllowance.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTokenAllowance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTokenTransfer.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTokenTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTransaction.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTransfer.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/MirrorTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/NodeProperties.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/NodeProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/TimestampRange.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/props/TimestampRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/ContractCallResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/ContractCallResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/ExchangeRateResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/ExchangeRateResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorAccountResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorAccountResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorBalancesResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorBalancesResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorContractResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorContractResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorContractResultResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorContractResultResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorContractResultsResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorContractResultsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorCryptoAllowanceResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorCryptoAllowanceResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorNftResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorNftResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorNftTransactionsResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorNftTransactionsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorScheduleResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorScheduleResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorTokenAllowanceResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorTokenAllowanceResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorTokenRelationshipResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorTokenRelationshipResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorTokenResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorTokenResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorTransactionsResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/MirrorTransactionsResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/NetworkTransactionResponse.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/response/NetworkTransactionResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AccountFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ContractFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ERCContractFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/FileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/FileFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/NetworkFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/NetworkFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/RetryAsserts.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/RetryAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TopicFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/FeatureInputHandler.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/FeatureInputHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/TestUtil.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/util/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/Web3Application.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/Web3Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/PrecompileContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/PrecompileContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/LoggingFilter.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/LoggingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/MetricsConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/MetricsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ValidationErrorParser.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ValidationErrorParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/convert/BlockTypeDeserializer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/convert/BlockTypeDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/convert/BlockTypeSerializer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/convert/BlockTypeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/convert/BytesDecoder.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/convert/BytesDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/AccountAccessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/OperationRegistryCallback.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/OperationRegistryCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/PrecompiledContractProvider.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/PrecompiledContractProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/PrecompilesHolder.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/PrecompilesHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorV30.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorV30.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/MirrorOperationTracer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/MirrorOperationTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/operations/HederaBlockHashOperation.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/operations/HederaBlockHashOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/EvmException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/EvmException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/MissingResultException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/MissingResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/ParsingException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/ParsingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/ResponseCodeUtil.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/ResponseCodeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/WrongTypeException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/WrongTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoader.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/StaticBlockMetaSource.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/StaticBlockMetaSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/TraceProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/TraceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/CachingStateFrame.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/CachingStateFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/DatabaseBackedStateFrame.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/DatabaseBackedStateFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/ROCachingStateFrame.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/ROCachingStateFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/RWCachingStateFrame.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/RWCachingStateFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/StackedStateFrames.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/StackedStateFrames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/Store.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/Store.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/StoreImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/StoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/UpdatableReferenceCache.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/UpdatableReferenceCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/CustomFeeDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/CustomFeeDatabaseAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/DatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/DatabaseAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/EntityDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/EntityDatabaseAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/TokenAccountDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/TokenAccountDatabaseAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/TokenAllowanceDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/TokenAllowanceDatabaseAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/UniqueTokenDatabaseAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/UniqueTokenDatabaseAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/model/TokenRelationshipKey.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/accessor/model/TokenRelationshipKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/AbstractEvmStackedLedgerUpdater.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/AbstractEvmStackedLedgerUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/AbstractLedgerWorldUpdater.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/AbstractLedgerWorldUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/EntityAddressSequencer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/EntityAddressSequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdater.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmWorldState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmWorldState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/impl/UpdatableReferenceCacheLineState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/impl/UpdatableReferenceCacheLineState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/utils/EvmTokenUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/utils/EvmTokenUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/BlockNumberOutOfRangeException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/BlockNumberOutOfRangeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/EntityNotFoundException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/EntityNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/InvalidInputException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/InvalidInputException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/InvalidParametersException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/InvalidParametersException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/RateLimitException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/RateLimitException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/Web3Exception.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/Web3Exception.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractStateRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/ContractStateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/CryptoAllowanceRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/CryptoAllowanceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/CustomFeeRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/CustomFeeRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/EntityRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/EntityRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/FileDataRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/FileDataRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/NftAllowanceRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/NftAllowanceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/RecordFileRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/RecordFileRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAccountRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAccountRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAllowanceRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAllowanceRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/projections/TokenAccountAssociationsCount.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/projections/TokenAccountAssociationsCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/properties/CacheProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/properties/CacheProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/model/CallServiceParameters.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/model/CallServiceParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/validation/Hex.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/validation/Hex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/validation/HexValidator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/validation/HexValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/BlockType.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/BlockType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallResponse.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/GenericErrorResponse.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/GenericErrorResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/TransferCheck.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/TransferCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/contracts/execution/LivePricesSource.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/contracts/execution/LivePricesSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtil.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV22.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaPrngSeedOperation.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaPrngSeedOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/exceptions/MissingEntityException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/exceptions/MissingEntityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/BasicHbarCentExchange.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/BasicHbarCentExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/FeeCalculator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/FeeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/HbarCentExchange.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/HbarCentExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/annotations/GenericPriceMultiplier.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/annotations/GenericPriceMultiplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calc/OverflowCheckingCalc.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calc/OverflowCheckingCalc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/BasicFcfsUsagePrices.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/BasicFcfsUsagePrices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/QueryResourceUsageEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/QueryResourceUsageEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/UsagePricesProvider.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/UsagePricesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/crypto/queries/GetTxnRecordResourceUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/crypto/queries/GetTxnRecordResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/AbstractTokenResourceUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/AbstractTokenResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenAssociateResourceUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenAssociateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenDeleteResourceUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenDeleteResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenDissociateResourceUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenDissociateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenUpdateResourceUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenUpdateResourceUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/utils/AccessorBasedUsages.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/utils/AccessorBasedUsages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/utils/PricedUsageCalculator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/utils/PricedUsageCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/pricing/AssetsLoader.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/pricing/AssetsLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/pricing/RequiredPriceTypes.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/pricing/RequiredPriceTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/pricing/ResourceProvider.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/pricing/ResourceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/pricing/UsableResource.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/pricing/UsableResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/state/UsageAccumulator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/state/UsageAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenAssociateUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenAssociateUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenDeleteUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenDeleteUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenDissociateUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenDissociateUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenOpsUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenOpsUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenOpsUsageUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenOpsUsageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenTxnUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenTxnUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenUpdateUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/TokenUpdateUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/entities/TokenEntitySizes.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/entities/TokenEntitySizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenBurnMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenBurnMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenBurnWipeMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenBurnWipeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenCreateMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenCreateMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenFreezeMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenFreezeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenMintMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenMintMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenOpMetaBase.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenOpMetaBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenPauseMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenPauseMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenUnfreezeMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenUnfreezeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenUnpauseMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenUnpauseMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenWipeMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/usage/token/meta/TokenWipeMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/BaseTransactionMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/BaseTransactionMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/EstimatorFactory.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/EstimatorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/EstimatorUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/EstimatorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/SigUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/SigUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/SingletonEstimatorUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/SingletonEstimatorUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/SingletonUsageProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/SingletonUsageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/TxnUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/TxnUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/TxnUsageEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/TxnUsageEstimator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/UsageEstimate.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/UsageEstimate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/UsageProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/UsageProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/AllowanceId.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/AllowanceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoApproveAllowanceMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoApproveAllowanceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoContextUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoContextUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoCreateMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoCreateMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoDeleteAllowanceMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoDeleteAllowanceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoEntitySizes.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoEntitySizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoOpsUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoOpsUsage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoTransferMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoTransferMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoUpdateMeta.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/CryptoUpdateMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/ExtantCryptoContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/fees/usage/crypto/ExtantCryptoContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/ByteStringUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/ByteStringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/contracts/ParsingConstants.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/contracts/ParsingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/fees/CryptoFeeBuilder.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/fees/CryptoFeeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/fees/FeeBuilder.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/fees/FeeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/fees/FeeObject.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/fees/FeeObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/fees/SigValueObj.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/hapi/utils/fees/SigValueObj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JContractIDKey.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JContractIDKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JDelegatableContractIDKey.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JDelegatableContractIDKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JECDSASecp256k1Key.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JECDSASecp256k1Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JEd25519Key.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JEd25519Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKeyList.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/jproto/JKeyList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/ledger/BalanceChange.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/ledger/BalanceChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/ledger/TransferLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/ledger/TransferLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/sigs/utils/ImmutableKeyUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/sigs/utils/ImmutableKeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/state/submerkle/RichInstant.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/state/submerkle/RichInstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/AbiConstants.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/AbiConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/CryptoTransferWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/CryptoTransferWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/ExchangeRatePrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/ExchangeRatePrecompiledContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/FungibleTokenTransfer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/FungibleTokenTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HbarTransfer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HbarTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/NftExchange.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/NftExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/Precompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/Precompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/PrecompileMapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/PrecompileMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/PrngSystemPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/PrngSystemPrecompiledContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/TokenCreateWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/TokenCreateWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/TokenTransferWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/TokenTransferWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/TokenUpdateLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/TokenUpdateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/TokenUpdateWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/TokenUpdateWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/TransferWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/TransferWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/AllowanceResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/AllowanceResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ApproveDecodedNftInfo.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ApproveDecodedNftInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ApproveForAllParams.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ApproveForAllParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ApproveParams.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ApproveParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ApproveResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ApproveResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ApproveWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ApproveWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/Association.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/Association.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/BodyParams.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/BodyParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/BurnResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/BurnResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/BurnWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/BurnWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/CreateParams.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/CreateParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/DecodingFacade.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/DecodingFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/DeleteWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/DeleteWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/Dissociation.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/Dissociation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ERCTransferParams.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ERCTransferParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/EmptyRunResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/EmptyRunResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/EncodingFacade.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/EncodingFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/FunctionParam.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/FunctionParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/GetApprovedResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/GetApprovedResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/HrcParams.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/HrcParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/IsApprovedForAllResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/IsApprovedForAllResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/KeyValueWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/KeyValueWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/MintResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/MintResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/MintWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/MintWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/PauseWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/PauseWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/RunResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/RunResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/SetApprovalForAllWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/SetApprovalForAllWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenCreateResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenCreateResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenExpiryWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenExpiryWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenKeyWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenKeyWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenTransferResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenTransferResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenUpdateExpiryInfoWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenUpdateExpiryInfoWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenUpdateKeysWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TokenUpdateKeysWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TransferParams.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/TransferParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/UnpauseWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/UnpauseWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/WipeResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/WipeResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/WipeWrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/WipeWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/Wrapper.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/Wrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractAssociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractAssociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractDissociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractDissociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractFreezeUnfreezePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractFreezeUnfreezePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractGrantRevokeKycPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractGrantRevokeKycPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractReadOnlyPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractReadOnlyPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractTokenUpdatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractTokenUpdatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractWipePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractWipePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractWritePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AbstractWritePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ApprovePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ApprovePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AssociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/AssociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/BurnPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/BurnPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/DeleteTokenPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/DeleteTokenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/DissociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/DissociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/FreezeTokenPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/FreezeTokenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/GrantKycPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/GrantKycPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ImpliedTransfers.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/ImpliedTransfers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MintPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MintPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MultiAssociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MultiAssociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MultiDissociatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/MultiDissociatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/PausePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/PausePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/RevokeKycPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/RevokeKycPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SystemContractAbis.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SystemContractAbis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SystemContractTypes.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/SystemContractTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenCreatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenCreatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenUpdateKeysPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenUpdateKeysPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenUpdatePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TokenUpdatePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TransferPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TransferPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/UnfreezeTokenPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/UnfreezeTokenPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/UnpausePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/UnpausePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/UpdateTokenExpiryInfoPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/UpdateTokenExpiryInfoPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/WipeFungiblePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/WipeFungiblePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/WipeNonFungiblePrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/WipeNonFungiblePrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/FcTokenAllowanceId.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/FcTokenAllowanceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Id.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Id.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/NftId.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/NftId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Token.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/TokenModificationResult.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/TokenModificationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/TokenRelationship.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/TokenRelationship.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/UniqueToken.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/UniqueToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/AssociateLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/AssociateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/BurnLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/BurnLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/CreateLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/CreateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/DeleteLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/DeleteLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/DissociateLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/DissociateLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/FreezeLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/FreezeLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/GrantKycLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/GrantKycLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/MintLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/MintLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/PauseLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/PauseLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/RevokeKycLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/RevokeKycLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/TokenOpsValidator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/TokenOpsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/UnfreezeLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/UnfreezeLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/UnpauseLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/UnpauseLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/WipeLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/WipeLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/AbstractAutoCreationLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/AbstractAutoCreationLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/ApproveAllowanceLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/ApproveAllowanceLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/AutoCreationLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/AutoCreationLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/DeleteAllowanceLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/DeleteAllowanceLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/helpers/AllowanceHelpers.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/helpers/AllowanceHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/validators/AllowanceChecks.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/validators/AllowanceChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/validators/ApproveAllowanceChecks.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/validators/ApproveAllowanceChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/validators/DeleteAllowanceChecks.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/validators/DeleteAllowanceChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/span/ExpandHandleSpanMapAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/span/ExpandHandleSpanMapAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/util/PrngLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/util/PrngLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/util/TokenUpdateValidator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/util/TokenUpdateValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/validation/ContextOptionValidator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/validation/ContextOptionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/validation/OptionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/validation/PureValidation.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/validation/PureValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/validation/TokenListChecks.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/validation/TokenListChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/BitPackUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/BitPackUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/CustomFeeUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/CustomFeeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityNum.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityNum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/IdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/IdUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/MiscUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/MiscUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/NewRels.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/NewRels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/accessors/AccessorFactory.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/accessors/AccessorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/accessors/SignedTxnAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/accessors/SignedTxnAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/accessors/TxnAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/accessors/TxnAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/ContextExtension.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/ContextExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/Web3IntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/Web3IntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/common/ContractCallContextTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/common/ContractCallContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/config/LoggingFilterTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/config/LoggingFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/convert/BytesDecoderTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/convert/BytesDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/AccountAccessorImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorBaseTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/MirrorOperationTracerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/MirrorOperationTracerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/operations/HederaBlockHashOperationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/operations/HederaBlockHashOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoaderTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/StaticBlockMetaSourceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/StaticBlockMetaSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/BottomCachingStateFrame.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/BottomCachingStateFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/CachingStateFrameTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/CachingStateFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/DatabaseBackedStateFrameTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/DatabaseBackedStateFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/ROCachingStateFrameTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/ROCachingStateFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/RWCachingStateFrameTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/RWCachingStateFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StackedStateFramesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StackedStateFramesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/UpdatableReferenceCacheSpy.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/UpdatableReferenceCacheSpy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/UpdatableReferenceCacheTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/UpdatableReferenceCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/CustomFeeDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/CustomFeeDatabaseAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/DatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/DatabaseAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/EntityDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/EntityDatabaseAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/TokenAccountDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/TokenAccountDatabaseAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/TokenAllowanceDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/TokenAllowanceDatabaseAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/UniqueTokenDatabaseAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/accessor/UniqueTokenDatabaseAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/EntityAddressSequencerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/EntityAddressSequencerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdaterTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MirrorEntityAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MockLedgerWorldUpdater.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/MockLedgerWorldUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/HTSPrecompiledContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/HTSPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/MockPrecompile.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/MockPrecompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/PrecompileMapperTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/PrecompileMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/PrecompiledContractBaseTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/PrecompiledContractBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/PrngSystemPrecompiledContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/PrngSystemPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/utils/EvmTokenUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/utils/EvmTokenUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/AccountBalanceRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/AccountBalanceRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/ContractRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/ContractRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/ContractStateRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/ContractStateRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/CryptoAllowanceRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/CryptoAllowanceRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/CustomFeeRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/CustomFeeRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/EntityRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/FileDataRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/FileDataRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/NftAllowanceRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/NftAllowanceRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/RecordFileRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/RecordFileRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenAccountRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenAccountRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenAllowanceRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenAllowanceRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -35,7 +35,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.data.Percentage;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimatorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/FunctionEncodeDecoder.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/FunctionEncodeDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/validation/HexValidatorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/validation/HexValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/viewmodel/BlockTypeTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/viewmodel/BlockTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/contracts/execution/LivePricesSourceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/contracts/execution/LivePricesSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtilTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19Test.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/contracts/gascalculator/GasCalculatorHederaV19Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/BasicHbarCentExchangeTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/BasicHbarCentExchangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calc/OverflowCheckingCalcTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calc/OverflowCheckingCalcTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/BasicFcfsUsagePricesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/BasicFcfsUsagePricesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetTxnRecordResourceUsageTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/crypto/queries/GetTxnRecordResourceUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/usage/consensus/AdapterUtils.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/usage/consensus/AdapterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/utils/AccessorBasedUsagesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/utils/AccessorBasedUsagesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelperTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/utils/OpUsageCtxHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/utils/PricedUsageCalculatorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/utils/PricedUsageCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/pricing/AssetsLoaderTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/pricing/AssetsLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/pricing/RequiredPriceTypesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/pricing/RequiredPriceTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/state/UsageAccumulatorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/state/UsageAccumulatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/TokenDissociateUsageTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/TokenDissociateUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/TokenOpsUsageTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/TokenOpsUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/TokenOpsUsageUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/TokenOpsUsageUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenBurnMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenBurnMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenCreateMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenCreateMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenFreezeMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenFreezeMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenMintMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenMintMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenPauseMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenPauseMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenUnpauseMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenUnpauseMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenWipeMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/usage/token/meta/TokenWipeMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/SigUsageTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/SigUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/SigUtils.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/SigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/SingletonEstimatorUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/SingletonEstimatorUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/TxnUsageEstimatorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/TxnUsageEstimatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/TxnUtils.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/TxnUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/UsageUtils.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/UsageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoApproveAllowanceMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoApproveAllowanceMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoContextUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoContextUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoCreateMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoCreateMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoDeleteAllowanceMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoDeleteAllowanceMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoOpsUsageTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoOpsUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoTransferMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoTransferMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoUpdateMetaTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/fees/usage/crypto/CryptoUpdateMetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/utils/contracts/ParsingConstantsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/utils/contracts/ParsingConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/utils/fees/CryptoFeeBuilderTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/utils/fees/CryptoFeeBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/utils/fees/FeeBuilderTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/hapi/utils/fees/FeeBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/jproto/JEd25519KeyTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/jproto/JEd25519KeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/ledger/BalanceChangeTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/ledger/BalanceChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/ledger/TransferLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/ledger/TransferLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/sigs/utils/ImmutableKeyUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/sigs/utils/ImmutableKeyUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/state/submerkle/RichInstantTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/state/submerkle/RichInstantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/ApprovePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/ApprovePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/AssociatePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/BurnPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/DeleteTokenPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/DeleteTokenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/DissociatePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/DissociatePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/FreezeTokenPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/FreezeTokenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/FungibleTokenTransferTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/FungibleTokenTransferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/GrantKycPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/GrantKycPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/HTSTestsUtil.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/HTSTestsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/HbarTransferTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/HbarTransferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/MintPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/MintPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/NftExchangeTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/NftExchangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/PausePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/PausePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/RevokeKycPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/RevokeKycPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdateKeysPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdateKeysPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdateLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdateLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdatePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdatePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdateWrapperTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TokenUpdateWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/UnfreezeTokenPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/UnfreezeTokenPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/UnpausePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/UnpausePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/UpdateTokenExpiryInfoPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/UpdateTokenExpiryInfoPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/WipeFungiblePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/WipeFungiblePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/WipeNonFungiblePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/WipeNonFungiblePrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/DecodingFacadeTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/DecodingFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/EncodingFacadeTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/EncodingFacadeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/TokenCreateWrapperTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/TokenCreateWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/TokenExpiryWrapperTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/TokenExpiryWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/TokenKeyWrapperTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/TokenKeyWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/TokenTransferWrapperTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/TokenTransferWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/TransferWrapperTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/codec/TransferWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/impl/SetApprovalForAllPrecompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/AccountTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/AccountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/FcTokenAllowanceIdTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/FcTokenAllowanceIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/IdTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/IdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/NftIdTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/NftIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/UniqueTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/UniqueTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/AssociateLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/AssociateLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/BurnLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/BurnLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/CreateLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/CreateLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/DissociateLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/DissociateLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/FreezeLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/FreezeLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/GrantKycLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/GrantKycLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/MintLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/MintLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/PauseLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/PauseLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/RevokeKycLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/RevokeKycLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/TokenOpsValidatorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/TokenOpsValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/UnfreezeLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/UnfreezeLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/UnpauseLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/UnpauseLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/WipeLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/WipeLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/ApproveAllowanceLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/ApproveAllowanceLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/DeleteAllowanceLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/DeleteAllowanceLogicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/helpers/AllowanceHelpersTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/helpers/AllowanceHelpersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/validators/ApproveAllowanceChecksTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/validators/ApproveAllowanceChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/validators/DeleteAllowanceChecksTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/validators/DeleteAllowanceChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/span/ExpandHandleSpanMapAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/span/ExpandHandleSpanMapAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/validation/ContextOptionValidatorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/validation/ContextOptionValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/validation/TokenListChecksTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/validation/TokenListChecksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/BitPackUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/BitPackUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/CustomFeeUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/CustomFeeUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityNumTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityNumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/MiscUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/MiscUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/NewRelsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/NewRelsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/TxnUtils.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/TxnUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/accessors/AccessorFactoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/accessors/AccessorFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/accessors/RequestBuilderUtils.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/accessors/RequestBuilderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/accessors/SignedTxnAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/accessors/SignedTxnAccessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Description**:

Bump copyright year to 2024

**Related issue(s)**:

Fixes #7518

**Notes for reviewer**:

The only change in the PR is the automated result of running `./gradlew spotlessApply` without a ratchetFrom set.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
