### PR TITLE
HIP-584: Update web3 docs to cover historical support

### DIFF
--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -40,27 +40,14 @@ _Note:_ To test against an instance running on the same machine as Docker use yo
 
 ### Supported/unsupported operations
 
-| Estimate | Static | Operation Type                                                                            | Supported | Historical data support - eth_call| Reads | Modifications |
-| -------- | ------ | ----------------------------------------------------------------------------------------- | --------- |-----------------------------------| ----- | ------------- |
-| Y        | Y      | non precompile functions                                                                  | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for Hts system contract AssociatePrecompile                                    | Y         | Y                                 | Y     | Y             |
-| Y        | N      | non precompile functions with lazy account creation                                       | Y         | Y                                 | Y     | Y             |
-| Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | Y                                 | Y     | N             |
-| Y        | N      | operations for HTS system contract MintPrecompile                                         | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract GrantKycPrecompile                                     | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract WipePrecompile                                         | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract BurnPrecompile                                         | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract DissociatePrecompile                                   | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract SetApprovalForAllPrecompile                            | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract ApprovePrecompile                                      | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract RevokeKycPrecompile                                    | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract UnpausePrecompile                                      | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract PausePrecompile                                        | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract DeleteTokenPrecompile                                  | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract PausePrecompile                                        | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract FreezePrecompile                                       | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for HTS system contract UnfreezePrecompile                                     | Y         | Y                                 | Y     | Y             |
-| Y        | N      | operations for IsApprovedForAllPrecompile                                                 | Y         | Y                                 | Y     | N             |
-| Y        | N      | operations for AllowancePrecompile                                                        | Y         | Y                                 | Y     | N             |
-| Y        | N      | operations for GetApprovedPrecompile                                                      | Y         | Y                                 | Y     | N             |
-| Y        | N      | operations for HTS system contract UpdateTokenKeysPrecompile                              | Y         | Y                                 | Y     | Y             |
+| Estimate | Static | Operation Type                                                                            | Supported | Historical | Reads | Modifications |
+| -------- | ------ |-------------------------------------------------------------------------------------------| --------- |------------| ----- | ------------- |
+| Y        | Y      | non precompile functions                                                                  | Y         | Y          | Y     | Y             |
+| Y        | N      | non precompile functions with lazy account creation                                       | Y         | Y          | Y     | Y             |
+| Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | Y          | Y     | N             |
+| Y        | N      | operations for IsApprovedForAllPrecompile                                                 | Y         | Y          | Y     | N             |
+| Y        | N      | operations for AllowancePrecompile                                                        | Y         | Y          | Y     | N             |
+| Y        | N      | operations for GetApprovedPrecompile                                                      | Y         | Y          | Y     | N             |
+| Y        | N      | operations for HTS system contract                                                        | Y         | Y          | Y     | Y             |
+
+_Note:_ Gas estimation only supports the `latest` block

--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -41,13 +41,14 @@ _Note:_ To test against an instance running on the same machine as Docker use yo
 ### Supported/unsupported operations
 
 | Estimate | Static | Operation Type                                                                            | Supported | Historical | Reads | Modifications |
-| -------- | ------ |-------------------------------------------------------------------------------------------| --------- |------------| ----- | ------------- |
+| -------- |--------|-------------------------------------------------------------------------------------------| --------- |------------| ----- |---------------|
 | Y        | Y      | non precompile functions                                                                  | Y         | Y          | Y     | Y             |
 | Y        | N      | non precompile functions with lazy account creation                                       | Y         | Y          | Y     | Y             |
 | Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | Y          | Y     | N             |
-| Y        | N      | operations for IsApprovedForAllPrecompile                                                 | Y         | Y          | Y     | N             |
-| Y        | N      | operations for AllowancePrecompile                                                        | Y         | Y          | Y     | N             |
-| Y        | N      | operations for GetApprovedPrecompile                                                      | Y         | Y          | Y     | N             |
-| Y        | N      | operations for HTS system contract                                                        | Y         | Y          | Y     | Y             |
+| Y        | Y      | operations for IsApprovedForAllPrecompile                                                 | Y         | Y          | Y     | N             |
+| Y        | Y      | operations for AllowancePrecompile                                                        | Y         | Y          | Y     | N             |
+| Y        | Y      | operations for GetApprovedPrecompile                                                      | Y         | Y          | Y     | N             |
+| Y        | Y      | read-only operations from HTS system contract                                             | Y         | Y          | Y     | N             |
+| Y        | N      | modifying operations from HTS system contract                                             | Y         | Y          | Y     | Y             |
 
 _Note:_ Gas estimation only supports the `latest` block

--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -40,15 +40,15 @@ _Note:_ To test against an instance running on the same machine as Docker use yo
 
 ### Supported/unsupported operations
 
-| Estimate | Static | Operation Type                                                                            | Supported | Historical | Reads | Modifications |
-| -------- |--------|-------------------------------------------------------------------------------------------| --------- |------------| ----- |---------------|
-| Y        | Y      | non precompile functions                                                                  | Y         | Y          | Y     | Y             |
-| Y        | N      | non precompile functions with lazy account creation                                       | Y         | Y          | Y     | Y             |
+| Estimate | Static | Operation Type                                                                          | Supported | Historical | Reads | Modifications |
+| -------- |--------|-----------------------------------------------------------------------------------------| --------- |------------| ----- |---------------|
+| Y        | Y      | non precompile functions                                                                | Y         | Y          | Y     | Y             |
+| Y        | N      | non precompile functions with lazy account creation                                     | Y         | Y          | Y     | Y             |
 | Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | Y          | Y     | N             |
-| Y        | Y      | operations for IsApprovedForAllPrecompile                                                 | Y         | Y          | Y     | N             |
-| Y        | Y      | operations for AllowancePrecompile                                                        | Y         | Y          | Y     | N             |
-| Y        | Y      | operations for GetApprovedPrecompile                                                      | Y         | Y          | Y     | N             |
-| Y        | Y      | read-only operations from HTS system contract                                             | Y         | Y          | Y     | N             |
-| Y        | N      | modifying operations from HTS system contract                                             | Y         | Y          | Y     | Y             |
+| Y        | Y      | operations for IsApprovedForAllPrecompile                                               | Y         | Y          | Y     | N             |
+| Y        | Y      | operations for AllowancePrecompile                                                      | Y         | Y          | Y     | N             |
+| Y        | Y      | operations for GetApprovedPrecompile                                                    | Y         | Y          | Y     | N             |
+| Y        | Y      | read-only operations fom HTS system contract                                            | Y         | Y          | Y     | N             |
+| Y        | N      | modifying operations fom HTS system contract                                            | Y         | Y          | Y     | Y             |
 
 _Note:_ Gas estimation only supports the `latest` block

--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -40,27 +40,27 @@ _Note:_ To test against an instance running on the same machine as Docker use yo
 
 ### Supported/unsupported operations
 
-| Estimate | Static | Operation Type                                                                            | Supported | Historical data support | Reads | Modifications |
-| -------- | ------ | ----------------------------------------------------------------------------------------- | --------- | ----------------------- | ----- | ------------- |
-| Y        | Y      | non precompile functions                                                                  | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for Hts system contract AssociatePrecompile                                    | Y         | N                       | Y     | Y             |
-| Y        | N      | non precompile functions with lazy account creation                                       | Y         | N                       | Y     | Y             |
-| Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | N                       | Y     | N             |
-| Y        | N      | operations for HTS system contract MintPrecompile                                         | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract GrantKycPrecompile                                     | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract WipePrecompile                                         | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract BurnPrecompile                                         | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract DissociatePrecompile                                   | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract SetApprovalForAllPrecompile                            | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract ApprovePrecompile                                      | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract RevokeKycPrecompile                                    | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract UnpausePrecompile                                      | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract PausePrecompile                                        | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract DeleteTokenPrecompile                                  | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract PausePrecompile                                        | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract FreezePrecompile                                       | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for HTS system contract UnfreezePrecompile                                     | Y         | N                       | Y     | Y             |
-| Y        | N      | operations for IsApprovedForAllPrecompile                                                 | Y         | N                       | Y     | N             |
-| Y        | N      | operations for AllowancePrecompile                                                        | Y         | N                       | Y     | N             |
-| Y        | N      | operations for GetApprovedPrecompile                                                      | Y         | N                       | Y     | N             |
-| Y        | N      | operations for HTS system contract UpdateTokenKeysPrecompile                              | Y         | N                       | Y     | Y             |
+| Estimate | Static | Operation Type                                                                            | Supported | Historical data support - eth_call| Reads | Modifications |
+| -------- | ------ | ----------------------------------------------------------------------------------------- | --------- |-----------------------------------| ----- | ------------- |
+| Y        | Y      | non precompile functions                                                                  | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for Hts system contract AssociatePrecompile                                    | Y         | Y                                 | Y     | Y             |
+| Y        | N      | non precompile functions with lazy account creation                                       | Y         | Y                                 | Y     | Y             |
+| Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | Y                                 | Y     | N             |
+| Y        | N      | operations for HTS system contract MintPrecompile                                         | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract GrantKycPrecompile                                     | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract WipePrecompile                                         | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract BurnPrecompile                                         | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract DissociatePrecompile                                   | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract SetApprovalForAllPrecompile                            | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract ApprovePrecompile                                      | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract RevokeKycPrecompile                                    | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract UnpausePrecompile                                      | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract PausePrecompile                                        | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract DeleteTokenPrecompile                                  | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract PausePrecompile                                        | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract FreezePrecompile                                       | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for HTS system contract UnfreezePrecompile                                     | Y         | Y                                 | Y     | Y             |
+| Y        | N      | operations for IsApprovedForAllPrecompile                                                 | Y         | Y                                 | Y     | N             |
+| Y        | N      | operations for AllowancePrecompile                                                        | Y         | Y                                 | Y     | N             |
+| Y        | N      | operations for GetApprovedPrecompile                                                      | Y         | Y                                 | Y     | N             |
+| Y        | N      | operations for HTS system contract UpdateTokenKeysPrecompile                              | Y         | Y                                 | Y     | Y             |

--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -40,15 +40,15 @@ _Note:_ To test against an instance running on the same machine as Docker use yo
 
 ### Supported/unsupported operations
 
-| Estimate | Static | Operation Type                                                                          | Supported | Historical | Reads | Modifications |
-| -------- |--------|-----------------------------------------------------------------------------------------| --------- |------------| ----- |---------------|
-| Y        | Y      | non precompile functions                                                                | Y         | Y          | Y     | Y             |
-| Y        | N      | non precompile functions with lazy account creation                                     | Y         | Y          | Y     | Y             |
+| Estimate | Static | Operation Type                                                                            | Supported | Historical | Reads | Modifications |
+| -------- |--------|-------------------------------------------------------------------------------------------| --------- |------------| ----- |---------------|
+| Y        | Y      | non precompile functions                                                                  | Y         | Y          | Y     | Y             |
+| Y        | N      | non precompile functions with lazy account creation                                       | Y         | Y          | Y     | Y             |
 | Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | Y          | Y     | N             |
-| Y        | Y      | operations for IsApprovedForAllPrecompile                                               | Y         | Y          | Y     | N             |
-| Y        | Y      | operations for AllowancePrecompile                                                      | Y         | Y          | Y     | N             |
-| Y        | Y      | operations for GetApprovedPrecompile                                                    | Y         | Y          | Y     | N             |
-| Y        | Y      | read-only operations fom HTS system contract                                            | Y         | Y          | Y     | N             |
-| Y        | N      | modifying operations fom HTS system contract                                            | Y         | Y          | Y     | Y             |
+| Y        | Y      | operations for IsApprovedForAllPrecompile                                                 | Y         | Y          | Y     | N             |
+| Y        | Y      | operations for AllowancePrecompile                                                        | Y         | Y          | Y     | N             |
+| Y        | Y      | operations for GetApprovedPrecompile                                                      | Y         | Y          | Y     | N             |
+| Y        | Y      | read-only operations for HTS system contract                                              | Y         | Y          | Y     | N             |
+| Y        | N      | modifying operations for HTS system contract                                              | Y         | Y          | Y     | Y             |
 
 _Note:_ Gas estimation only supports the `latest` block

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -303,9 +303,10 @@ paths:
   /api/v1/contracts/call:
     post:
       summary: Invoke a smart contract
-      description: |
-
-        Returns a result from EVM execution such as cost-free execution of read-only smart contract queries, gas estimation, and transient simulation of read-write operations. If `estimate` field is set to true gas estimation is executed. Currently we support only `latest` block.
+      description:
+        Returns a result from EVM execution such as cost-free execution of read-only smart contract queries, gas estimation, and transient simulation of read-write operations. If `estimate` field is set to true gas estimation is executed.
+        The endpoint supports `latest` block. Additionally, it can process calls against the `earliest` block and specific historical blocks when a hexadecimal block number is provided in the `block` field for `eth_call` operations.
+        For gas estimation indicated by `estimate` set to true, only the `latest` block can be used.
         [Link to Supported/Unsupported Operations Table](https://github.com/hashgraph/hedera-mirror-node/blob/main/docs/web3/README.md#supported/unsupported-operations)
 
         The operations types which are not currently supported should return 501 error status.

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -304,9 +304,8 @@ paths:
     post:
       summary: Invoke a smart contract
       description:
-        Returns a result from EVM execution such as cost-free execution of read-only smart contract queries, gas estimation, and transient simulation of read-write operations. If `estimate` field is set to true gas estimation is executed.
-        The endpoint supports `latest` block. Additionally, it can process calls against the `earliest` block and specific historical blocks when a hexadecimal block number is provided in the `block` field for `eth_call` operations.
-        For gas estimation indicated by `estimate` set to true, only the `latest` block can be used.
+        Returns a result from EVM execution such as cost-free execution of read-only smart contract queries, gas estimation, and transient simulation of read-write operations. If the `estimate` field is set to true gas estimation is executed. However, gas estimation only supports the `latest` block.
+        When `estimate` is false, it can process calls against the `earliest` block and specific historical blocks when a hexadecimal or decimal block number is provided in the `block` field for `eth_call` operations.
         [Link to Supported/Unsupported Operations Table](https://github.com/hashgraph/hedera-mirror-node/blob/main/docs/web3/README.md#supported/unsupported-operations)
 
         The operations types which are not currently supported should return 501 error status.


### PR DESCRIPTION
**Description**:
This updates web3 documentation to cover the new historical block support implementation for eth call

Modified classes:
docs/web3/README.md
hedera-mirror-rest/api/v1/openapi.yml

**Related issue(s)**:

Fixes #7482

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
