### PR TITLE
Improve temp schema script (0.96)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,42 +1,12 @@
-version: "3.7"
+version: "3.8"
 services:
-  citus:
-    image: gcr.io/mirrornode/citus:12.0.0
-    deploy:
-      replicas: 0
-    environment:
-      PGDATA: /var/lib/postgresql/data
-      # These should all be changed from the default before running in production
-      GRAPHQL_PASSWORD: mirror_graphql_pass
-      GRPC_PASSWORD: mirror_grpc_pass
-      IMPORTER_PASSWORD: mirror_importer_pass
-      OWNER_PASSWORD: mirror_node_pass
-      POSTGRES_PASSWORD: postgres_password
-      REST_PASSWORD: mirror_api_pass
-      ROSETTA_PASSWORD: mirror_rosetta_pass
-      SCHEMA_V2: "true"
-    ports:
-      - 5432:5432
-    restart: unless-stopped
-    stop_grace_period: 2m
-    stop_signal: SIGTERM
-    tty: true
-    volumes:
-      - ./db:/var/lib/postgresql/data
-      - ./hedera-mirror-importer/src/main/resources/db/scripts/init.sh:/docker-entrypoint-initdb.d/init.sh
   db:
     image: postgres:14-alpine
     environment:
       PGDATA: /var/lib/postgresql/data
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
-      # These should all be changed from the default before running in production
-      GRPC_PASSWORD: mirror_grpc_pass
-      IMPORTER_PASSWORD: mirror_importer_pass
-      OWNER_PASSWORD: mirror_node_pass
       POSTGRES_PASSWORD: postgres_password
-      REST_PASSWORD: mirror_api_pass
-      ROSETTA_PASSWORD: mirror_rosetta_pass
     ports:
       - 5432:5432
     restart: unless-stopped
@@ -50,6 +20,8 @@ services:
   graphql:
     image: gcr.io/mirrornode/hedera-mirror-graphql:0.96.0
     pull_policy: always
+    deploy:
+      replicas: 0
     environment:
       HEDERA_MIRROR_GRAPHQL_DB_HOST: db
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-graphql/
@@ -117,6 +89,8 @@ services:
   rest-java:
     image: gcr.io/mirrornode/hedera-mirror-rest-java:0.96.0
     pull_policy: always
+    deploy:
+      replicas: 0
     environment:
       HEDERA_MIRROR_RESTJAVA_DB_HOST: db
       SPRING_CONFIG_ADDITIONAL_LOCATION: file:/usr/etc/hedera-mirror-rest-java/
@@ -129,6 +103,8 @@ services:
 
   rosetta:
     image: gcr.io/mirrornode/hedera-mirror-rosetta:0.96.0
+    deploy:
+      replicas: 0
     pull_policy: always
     environment:
       HEDERA_MIRROR_ROSETTA_DB_HOST: db

--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -209,11 +209,15 @@ transactions in the balance and record streams. These issues should only appear 
 
 ## Breaking Schema Changes Introduced in 0.96.0
 
-In version 0.96.0 a new schema was introduced to handle processing of upsertable entities. This change doesn't require any
-manual steps for new operators that use one of our init scripts or helm charts to configure the database. However, existing operators 
-upgrading to 0.96.0 or a later version from an earlier version are required to configure the schema by configuring and executing the script 
-[here](/hedera-mirror-importer/src/main/resources/db/scripts/init-temp-schema.sh) a single time before the upgrade.
+In version 0.96.0, a new database schema was introduced to handle the processing of upsertable entities. This change
+doesn't require any manual steps for new operators that use one of our initialization scripts or helm charts to
+configure the database. However, existing operators upgrading to 0.96.0 or later are required to create the schema by
+configuring and executing the script [here](/hedera-mirror-importer/src/main/resources/db/scripts/init-temp-schema.sh)
+before the upgrade.
 
+```shell
+PGHOST=127.0.0.1 ./init-temp-schema.sh
+```
 
 ## Database migration from V1 to V2
 

--- a/docs/importer/README.md
+++ b/docs/importer/README.md
@@ -183,7 +183,7 @@ Build the image for both amd64 (Github CI) and arm64 (local testing). Don't forg
 can take some time depending on your internet speed. You will see activity around both arm64 and amd64.
 
 ```console
-$ docker buildx build --platform linux/arm64,linux/amd64 -t gcr.io/mirrornode/citus:12.0.0 --file alpine/Dockerfile  .
+$ docker buildx build --platform linux/arm64,linux/amd64 -t gcr.io/mirrornode/citus:12.1.1 --file alpine/Dockerfile  .
 [+] Building 351.1s (28/28) FINISHED
  => [internal] load .dockerignore                                                                                                                         0.0s
  => => transferring context: 2B                                                                                                                           0.0s
@@ -205,5 +205,5 @@ rather than as a separate step below.
 If you did not utilize `--push` with `docker buildx` when building the alpine image, push it now to Docker Hub.
 
 ```console
-docker push gcr.io/mirrornode/citus:12.0.0
+docker push gcr.io/mirrornode/citus:12.1.1
 ```

--- a/hedera-mirror-importer/src/main/resources/db/scripts/init-temp-schema.sh
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/init-temp-schema.sh
@@ -1,24 +1,25 @@
 #!/bin/bash
 set -e
 
-DB_TEMP_SCHEMA="${DB_TEMP_SCHEMA:-temporary}"
-DB_NAME="${DB_NAME:-mirror_node}"
+export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-3}"
+export PGDATABASE="${PGDATABASE:-mirror_node}"
+export PGHOST="${PGHOST}"
+export PGUSER="${PGUSER:-mirror_node}"
 
-SCHEMA_EXISTS="$(psql -d "user=postgres connect_timeout=3 dbname=${DB_NAME}" \
-                  -XAt \
+DB_TEMP_SCHEMA="${DB_TEMP_SCHEMA:-temporary}"
+SCHEMA_EXISTS="$(psql -XAt \
                   -c "select exists (select schema_name from information_schema.schemata where schema_name = '${DB_TEMP_SCHEMA}')")"
 
 if [[ $SCHEMA_EXISTS == 't' ]]
 then
-  echo "Temp schema ${DB_TEMP_SCHEMA} already exists";
-  exit 0;
+  echo "Temp schema ${DB_TEMP_SCHEMA} already exists"
+  exit 0
 fi
 
 echo "Creating temp schema ${DB_TEMP_SCHEMA}"
 
-psql -d "user=postgres connect_timeout=3" \
-  --set ON_ERROR_STOP=1 \
-  --set "dbName=${DB_NAME}" \
+psql --set ON_ERROR_STOP=1 \
+  --set "dbName=${PGDATABASE}" \
   --set "dbSchema=${DB_SCHEMA:-public}" \
   --set "importerUsername=${IMPORTER_USERNAME:-mirror_importer}" \
   --set "ownerUsername=${OWNER_USERNAME:-mirror_node}" \

--- a/hedera-mirror-importer/src/main/resources/db/scripts/init.sh
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/init.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -e
 
-PGCONF="${PGCONF:-/var/lib/postgresql/data}"
-PGHBA="${PGCONF}/pg_hba.conf"
+export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-3}"
+export PGDATABASE="${POSTGRES_DB:-postgres}"
+export PGHOST="${PGHOST}"
+export PGUSER="${POSTGRES_USER:-postgres}"
+
 DB_SPECIFIC_EXTENSION_SQL=
 # PostgreSQL 16 requires role A to have Admin privilege on role B in order to grant role B to any other role, and there
 # are several versioned v1 migrations that grant :importerUsername to :ownerUsername.
@@ -23,12 +26,7 @@ if [[ "${SCHEMA_V2}" == "true" ]]; then
   DB_SPECIFIC_SQL="create user :restUsername with login password :'restPassword' in role readonly;"
 fi
 
-cp "${PGHBA}" "${PGHBA}.bak"
-echo "local all all trust" > "${PGHBA}"
-pg_ctl reload
-
-psql -d "user=postgres connect_timeout=3" \
-  --set ON_ERROR_STOP=1 \
+psql --set ON_ERROR_STOP=1 \
   --set "dbName=${DB_NAME:-mirror_node}" \
   --set "dbSchema=${DB_SCHEMA:-public}" \
   --set "graphqlPassword=${GRAPHQL_PASSWORD:-mirror_graphql_pass}" \
@@ -111,6 +109,3 @@ ${DB_SPECIFIC_EXTENSION_SQL}
 \connect postgres postgres
 alter database :dbName set search_path = :dbSchema, public, :tempSchema;
 __SQL__
-
-mv "${PGHBA}.bak" "${PGHBA}"
-pg_ctl reload

--- a/hedera-mirror-test/build.gradle.kts
+++ b/hedera-mirror-test/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,9 +56,6 @@ dependencies {
 // Disable the default test task and only run acceptance tests during the standalone "acceptance"
 // task
 tasks.named("test") { enabled = false }
-
-// Resolve warning about using the deprecated '-debug' fallback
-tasks.compileTestJava { options.compilerArgs.addAll(listOf("-parameters")) }
 
 tasks.register<Test>("acceptance") {
     val maxParallelism = project.property("maxParallelism") as String


### PR DESCRIPTION
**Description**:

Cherry pick of #7485 to `release/0.96`:

For 0.96, we need to ensure the migration path for operators is as smooth as possible. The `init-temp-schema.sh` did not support remote databases so we enhance it so it does.

* Change `init.sh` and `init-temp-schema.sh` so they can be ran remotely
* Change `init-temp-schema.sh` to run as the `mirror_node` user
* Disable graphql, rest-java, and rosetta in `docker-compose.yml`
* Remove citus from `docker-compose.yml`
* Remove unneeded compiler warning suppression in test module

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
