### PR TITLE
Support Kubernetes 1.28

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Stackgres
         run: |
           helm repo add stackgres https://stackgres.io/downloads/stackgres-k8s/stackgres/helm
-          helm install stackgres stackgres/stackgres-operator --version 1.6.1 --create-namespace -n stackgres
+          helm install stackgres stackgres/stackgres-operator --version 1.7.0 --create-namespace -n stackgres
 
       - name: Install ct
         uses: helm/chart-testing-action@v2.6.1

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -123,7 +123,7 @@ jobs:
         run: curl --retry 3 -fsL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
       - name: Create k3d cluster
-        run: k3d cluster create mirror --agents 1 --wait --image rancher/k3s:v1.27.7-k3s1
+        run: k3d cluster create mirror --agents 1 --wait --image rancher/k3s:v1.28.5-k3s1
 
       - name: Get tag
         run: echo "TAG=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV

--- a/charts/README.md
+++ b/charts/README.md
@@ -14,7 +14,7 @@ Installs the Hedera Mirror Node Helm wrapper chart. This chart will install the 
 ## Requirements
 
 - [Helm 3+](https://helm.sh)
-- [Kubernetes 1.27+](https://kubernetes.io)
+- [Kubernetes 1.28+](https://kubernetes.io)
 
 Set environment variables that will be used for the remainder of the document:
 
@@ -92,7 +92,7 @@ a [Standalone NEG](https://cloud.google.com/kubernetes-engine/docs/how-to/standa
        --create-subnetwork="" \
        --network=default \
        --zone=us-central1-a \
-       --cluster-version=1.27 \
+       --cluster-version=1.28 \
        --machine-type=n1-standard-4
    ```
 

--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -3,17 +3,17 @@ appVersion: 0.97.0-SNAPSHOT
 dependencies:
   - name: loki
     condition: loki.enabled
-    version: 5.36.0
+    version: 5.41.6
     repository: https://grafana.github.io/helm-charts
   - condition: prometheus-adapter.enabled
     name: prometheus-adapter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 4.7.1
+    version: 4.9.0
   - alias: prometheus
     condition: prometheus.enabled
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 52.1.0
+    version: 55.8.3
   - name: promtail
     condition: promtail.enabled
     version: 6.15.3
@@ -22,11 +22,11 @@ dependencies:
     condition: stackgres.enabled
     name: stackgres-operator
     repository: https://stackgres.io/downloads/stackgres-k8s/stackgres/helm/
-    version: 1.6.1
+    version: 1.7.0
   - condition: traefik.enabled
     name: traefik
     repository: https://helm.traefik.io/traefik
-    version: 25.0.0
+    version: 26.0.0
   - alias: zfs
     condition: zfs.enabled
     name: zfs-localpv

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -356,7 +356,7 @@ testkube:
     image:
       registry: docker.io
       repository: grafana/k6
-      tag: 0.47.0
+      tag: 0.48.0
   namespace: testkube
   test:
     config:

--- a/charts/hedera-mirror-graphql/values.yaml
+++ b/charts/hedera-mirror-graphql/values.yaml
@@ -308,7 +308,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
-    tag: 5.3.1-alpine
+    tag: 6.1.0-alpine
   postman: ""  # Custom postman.json in base64 encoding
 
 tolerations: []

--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -292,7 +292,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
-    tag: 5.3.1-alpine
+    tag: 6.1.0-alpine
   postman: ""  # Custom postman.json in base64 encoding
 
 tolerations: []

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -239,7 +239,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
-    tag: 5.3.1-alpine
+    tag: 6.1.0-alpine
   postman: ""  # Custom postman.json in base64 encoding
 
 tolerations: []

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -291,7 +291,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
-    tag: 5.3.1-alpine
+    tag: 6.1.0-alpine
   postman: ""  # Custom postman.json in base64 encoding
 
 tolerations: []

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -29,11 +29,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: 12.3.2
+    version: 12.6.0
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 18.2.0
+    version: 18.6.3
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest

--- a/charts/hedera-mirror/values-v2.yml
+++ b/charts/hedera-mirror/values-v2.yml
@@ -5,7 +5,6 @@ importer:
         importer:
           db:
             loadBalance: false
-          downloader:
           parser:
             record:
               entity:

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -175,7 +175,7 @@ postgresql:
     extraEnvVarsSecret: mirror-passwords
     image:
       debug: true
-      tag: 14.10.0-debian-11-r10
+      tag: 14.10.0-debian-11-r16
     initdbScriptsCM: "{{ .Release.Name }}-init"
     maxConnections: 200
     password: ""  # Randomly generated if left blank
@@ -190,8 +190,6 @@ postgresql:
         cpu: 250m
         memory: 500Mi
     repmgrLogLevel: DEBUG
-  serviceAccount:
-    create: true
 
 redis:
   auth:

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -21,7 +21,7 @@ fi
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="v1.10.0"
-postgresql_tag="14.10.0-debian-11-r10"
+postgresql_tag="14.10.0-debian-11-r16"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {

--- a/hedera-mirror-graphql/src/main/resources/application.yml
+++ b/hedera-mirror-graphql/src/main/resources/application.yml
@@ -13,6 +13,7 @@ logging:
   level:
     root: warn
     com.hedera.mirror.graphql: info
+    org.hibernate.orm.deprecation: error # Suppress hibernate.dialect warnings
     org.springframework.cloud.kubernetes.fabric8.config: error
   pattern:
     console: "%clr(%date{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSS}, UTC}Z){faint} %clr(${LOG_LEVEL_PATTERN:%5level}) %clr(%thread){magenta} %clr(%logger{20}){cyan} %m %exception%n"
@@ -40,7 +41,7 @@ server:
     enabled: true
   http2:
     enabled: true
-  max-http-header-size: 1KB
+  max-http-request-header-size: 1KB
   netty:
     connection-timeout: 3s
   port: 8083
@@ -74,6 +75,7 @@ spring:
       enabled: true
     path: /graphql/alpha
   jpa:
+    database: PostgreSQL
     properties:
       hibernate.criteria.literal_handling_mode: BIND # Ensure Criteria API queries use bind parameters and not literals
       hibernate.generate_statistics: true

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -21,6 +21,7 @@ logging:
     root: warn
     com.hedera.mirror.grpc: info
     io.grpc.netty.shaded.io.grpc.netty.NettyServerHandler: error
+    org.hibernate.orm.deprecation: error # Suppress hibernate.dialect warnings
     org.springframework.cloud.kubernetes.fabric8.config: error
     # io.grpc: debug
     # org.hibernate.SQL: debug
@@ -51,6 +52,7 @@ server:
     enabled: true
   http2:
     enabled: true
+  max-http-request-header-size: 1KB
   port: 8081
   shutdown: graceful
 spring:
@@ -80,6 +82,7 @@ spring:
       minimum-idle: 4
       validation-timeout: 3000
   jpa:
+    database: PostgreSQL
     properties:
       hibernate.criteria.literal_handling_mode: BIND # Ensure Criteria API queries use bind parameters and not literals
       hibernate.generate_statistics: true

--- a/hedera-mirror-rest-java/src/main/resources/application.yml
+++ b/hedera-mirror-rest-java/src/main/resources/application.yml
@@ -13,6 +13,7 @@ logging:
   level:
     root: warn
     com.hedera.mirror.restjava: info
+    org.hibernate.orm.deprecation: error # Suppress hibernate.dialect warnings
     org.springframework.cloud.kubernetes.fabric8.config: error
   pattern:
     console: "%clr(%date{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSS}, UTC}Z){faint} %clr(${LOG_LEVEL_PATTERN:%5level}) %clr(%thread){magenta} %clr(%logger{20}){cyan} %m %exception%n"
@@ -41,7 +42,7 @@ server:
   forward-headers-strategy: framework #Enable spring ForwardedHeaderFilter
   http2:
     enabled: true
-  max-http-header-size: 1KB
+  max-http-request-header-size: 1KB
   port: 8084
   shutdown: graceful
   tomcat:
@@ -73,6 +74,8 @@ spring:
       minimum-idle: 4
       validation-timeout: 3000
   jpa:
+    database: PostgreSQL
+    open-in-view: false
     properties:
       hibernate.criteria.literal_handling_mode: BIND # Ensure Criteria API queries use bind parameters and not literals
       hibernate.generate_statistics: true

--- a/hedera-mirror-web3/src/main/resources/application.yml
+++ b/hedera-mirror-web3/src/main/resources/application.yml
@@ -13,6 +13,7 @@ logging:
   level:
     root: warn
     com.hedera.mirror.web3: info
+    org.hibernate.orm.deprecation: error # Suppress hibernate.dialect warnings
     org.springframework.cloud.kubernetes.fabric8.config: error
   pattern:
     console: "%clr(%date{${LOG_DATEFORMAT_PATTERN:yyyy-MM-dd'T'HH:mm:ss.SSS}, UTC}Z){faint} %clr(${LOG_LEVEL_PATTERN:%5level}) %clr(%thread){magenta} %clr(%logger{20}){cyan} %m %exception%n"
@@ -40,7 +41,7 @@ server:
     enabled: true
   http2:
     enabled: true
-  max-http-header-size: 1KB
+  max-http-request-header-size: 1KB
   netty:
     connection-timeout: 3s
   port: 8545
@@ -72,6 +73,7 @@ spring:
       minimum-idle: 4
       validation-timeout: 3000
   jpa:
+    database: PostgreSQL
     properties:
       hibernate.criteria.literal_handling_mode: BIND # Ensure Criteria API queries use bind parameters and not literals
       hibernate.generate_statistics: true


### PR DESCRIPTION
**Description**:

* Add support for Kubernetes 1.28
* Bump chart dependencies
* Bump Stackgres from 1.6.1 to 1.7.0
* Fix Java modules crashing on startup when database is unavailable due to dialect detection
* Fix `spring.jpa.open-in-view` warning in rest-java
* Fix use of deprecated `max-http-header-size` property
* Suppress `hibernate.dialect` warning

**Related issue(s)**:

Fixes #7563

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
