### PR TITLE
Support RFC5988 next link

### DIFF
--- a/hedera-mirror-rest/__tests__/middleware/responseHandler.test.js
+++ b/hedera-mirror-rest/__tests__/middleware/responseHandler.test.js
@@ -25,13 +25,11 @@ const {
   response: {headers},
 } = config;
 
-const responseData = {transactions: [], links: {next: null}};
-
 describe('Response middleware', () => {
-  let mockRequest;
-  let mockResponse;
+  let mockRequest, mockResponse, responseData
 
   beforeEach(() => {
+    responseData = {transactions: [], links: {next: null}};
     mockRequest = {
       ip: '127.0.0.1',
       method: 'GET',
@@ -85,5 +83,18 @@ describe('Response middleware', () => {
     expect(mockResponse.set).toHaveBeenNthCalledWith(2, headers.path[mockRequest.route.path]);
     expect(mockResponse.set).toHaveBeenNthCalledWith(3, 'Content-Type', mockResponse.locals.responseContentType);
     expect(mockResponse.status).toBeCalledWith(mockResponse.locals.statusCode);
+  });
+
+  test('should set the Link next header and confirm it exists', async () => {
+    const MOCK_URL = 'http://mock.url/next'
+    mockResponse.locals.responseData.links.next = MOCK_URL;
+    const assertNextValue = `<${MOCK_URL}>; rel=\"next\"`
+    await responseHandler(mockRequest, mockResponse, null);
+    expect(mockResponse.set).toHaveBeenNthCalledWith(4, 'Link', assertNextValue);
+  });
+
+  test('should NOT set the Link next header and confirm it exists', async () => {
+    await responseHandler(mockRequest, mockResponse, null);
+    expect(mockResponse.set).toHaveBeenCalledTimes(3);
   });
 });

--- a/hedera-mirror-rest/__tests__/specs/accounts/accounts-range.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts/accounts-range.json
@@ -173,5 +173,8 @@
     "links": {
       "next": "/api/v1/accounts?account.id=lt:0.0.21&account.id=gt:0.0.20&limit=3"
     }
+  },
+  "responseHeaders": {
+    "Link": "</api/v1/accounts?account.id=lt:0.0.21&account.id=gt:0.0.20&limit=3>; rel=\"next\""
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/accounts/accounts-range.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts/accounts-range.json
@@ -175,6 +175,6 @@
     }
   },
   "responseHeaders": {
-    "Link": "</api/v1/accounts?account.id=lt:0.0.21&account.id=gt:0.0.20&limit=3>; rel=\"next\""
+    "link": "</api/v1/accounts?account.id=lt:0.0.21&account.id=gt:0.0.20&limit=3>; rel=\"next\""
   }
 }

--- a/hedera-mirror-rest/middleware/responseHandler.js
+++ b/hedera-mirror-rest/middleware/responseHandler.js
@@ -23,8 +23,10 @@ const {
   response: {headers},
 } = config;
 
-const contentTypeHeader = 'Content-Type';
-const applicationJson = 'application/json; charset=utf-8';
+const CONTENT_TYPE_HEADER = 'Content-Type';
+const APPLICATION_JSON = 'application/json; charset=utf-8';
+const LINK_NEXT_HEADER = 'Link';
+const linkNextHeaderValue = (linksNext) => `${linksNext}; rel="next"`
 
 // Response middleware that pulls response data passed through request and sets in response.
 // Next param is required to ensure express maps to this middleware and can also be used to pass onto future middleware
@@ -38,11 +40,16 @@ const responseHandler = async (req, res, next) => {
     res.set(headers.path[req.route.path]);
 
     const code = res.locals.statusCode;
-    const contentType = res.locals[responseContentType] || applicationJson;
+    const contentType = res.locals[responseContentType] || APPLICATION_JSON;
+    const linksNext = res.locals.responseData.links?.next;
     res.status(code);
-    res.set(contentTypeHeader, contentType);
+    res.set(CONTENT_TYPE_HEADER, contentType);
 
-    if (contentType === applicationJson) {
+    if (linksNext) {
+      res.set(LINK_NEXT_HEADER, linkNextHeaderValue(linksNext));
+    }
+
+    if (contentType === APPLICATION_JSON) {
       res.send(JSONStringify(responseData));
     } else {
       res.send(responseData);

--- a/hedera-mirror-rest/middleware/responseHandler.js
+++ b/hedera-mirror-rest/middleware/responseHandler.js
@@ -26,7 +26,7 @@ const {
 const CONTENT_TYPE_HEADER = 'Content-Type';
 const APPLICATION_JSON = 'application/json; charset=utf-8';
 const LINK_NEXT_HEADER = 'Link';
-const linkNextHeaderValue = (linksNext) => `${linksNext}; rel="next"`
+const linkNextHeaderValue = (linksNext) => `<${linksNext}>; rel="next"`
 
 // Response middleware that pulls response data passed through request and sets in response.
 // Next param is required to ensure express maps to this middleware and can also be used to pass onto future middleware


### PR DESCRIPTION
**Description**:

Inside a middleware, inspect the payload for a `links.next` and set it in the `Link` response header:

`Link: <${links.next}>; rel="next"`

**Related issue(s)**:

Fixes #5879
