### PR TITLE
Change error handling for invalid redirect ERC function cases

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -23,6 +23,7 @@ import static com.hedera.node.app.service.evm.store.contracts.utils.DescriptorUt
 import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.esaulpaugh.headlong.abi.TupleType;
@@ -33,6 +34,7 @@ import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
+import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExceptionalHaltReason;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
@@ -63,6 +65,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -455,7 +458,8 @@ public class HTSPrecompiledContract extends EvmHTSPrecompiledContract {
         final var result = executor.computeCosted();
 
         if (result.getRight() == null) {
-            throw new InvalidTransactionException(PRECOMPILE_RESULT_IS_NULL, FAIL_INVALID);
+            throw new MirrorEvmTransactionException(
+                    INVALID_TOKEN_ID, "Invalid token id or unsupported operation.", StringUtils.EMPTY);
         }
 
         return result;

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -89,7 +89,6 @@ public class HTSPrecompiledContract extends EvmHTSPrecompiledContract {
             null, true, MessageFrame.State.COMPLETED_FAILED, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
     private static final Logger log = LogManager.getLogger(HTSPrecompiledContract.class);
     private static final Bytes STATIC_CALL_REVERT_REASON = Bytes.of("HTS precompiles are not static".getBytes());
-    private static final String PRECOMPILE_RESULT_IS_NULL = "Precompile result is null";
 
     private final MirrorNodeEvmProperties evmProperties;
     private final EvmInfrastructureFactory infrastructureFactory;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -171,6 +171,20 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
     }
 
     @ParameterizedTest
+    @EnumSource(ErcContractReadOnlyFunctionsNegative.class)
+    void supportedErcReadOnlyRedirectPrecompileNegativeOperationsTest(
+            final ErcContractReadOnlyFunctionsNegative ercFunction) {
+        final var functionName = ercFunction.name + REDIRECT_SUFFIX;
+        final var functionHash = functionEncodeDecoder.functionHashFor(
+                functionName, REDIRECT_CONTRACT_ABI_PATH, ercFunction.functionParameters);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, REDIRECT_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
+
+        assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
+                .isInstanceOf(MirrorEvmTransactionException.class);
+    }
+
+    @ParameterizedTest
     @EnumSource(ErcContractModificationFunctions.class)
     void supportedErcModificationsRedirectPrecompileOperationsTest(final ErcContractModificationFunctions ercFunction) {
         final var functionName = ercFunction.name + "Redirect";
@@ -224,6 +238,17 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
         public String getName(final boolean isStatic) {
             return isStatic ? name : name + NON_STATIC_SUFFIX;
         }
+    }
+
+    @RequiredArgsConstructor
+    public enum ErcContractReadOnlyFunctionsNegative {
+        // Negative scenarios - expected to throw an exception
+        ERC_DECIMALS_NEGATIVE("decimals", new Address[] {NFT_ADDRESS}),
+        OWNER_OF_NEGATIVE("getOwnerOf", new Object[] {FUNGIBLE_TOKEN_ADDRESS, 1L}),
+        TOKEN_URI_NEGATIVE("tokenURI", new Object[] {FUNGIBLE_TOKEN_ADDRESS, 1L});
+
+        private final String name;
+        private final Object[] functionParameters;
     }
 
     @RequiredArgsConstructor

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -30,7 +30,6 @@ import com.hedera.mirror.web3.exception.BlockNumberNotFoundException;
 import com.hedera.mirror.web3.exception.BlockNumberOutOfRangeException;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.viewmodel.BlockType;
-import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -258,8 +257,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
                 functionHash, MODIFICATION_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 
         assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
-                .isInstanceOf(InvalidTransactionException.class)
-                .hasMessage("Precompile result is null");
+                .isInstanceOf(MirrorEvmTransactionException.class);
     }
 
     private static long getValue(SupportedContractModificationFunctions contractFunc) {


### PR DESCRIPTION
**Description**:
In case of invalid input for ERC redirect function cases an HTTP 500 internal server error is returned. This PR introduces a change where in such cases a proper HTTP 400 error is returned.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/7564