### PR TITLE
Fix failing selfdestruct estimate gas test

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
@@ -81,6 +81,32 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
     }
 
     /**
+     * Validates the gas estimation for a specific contract call, including the sender's address.
+     * <p>
+     * This method estimates the gas cost for a given contract call considering the sender's address, and then checks
+     * whether the actual gas used falls within an acceptable deviation range. It utilizes the provided call endpoint
+     * to perform the contract call and then compares the estimated gas with the actual gas used.
+     *
+     * @param data            The function signature and method data of the contract call.
+     * @param actualGasUsed   The actual gas amount that was used for the call.
+     * @param solidityAddress The address of the solidity contract.
+     * @throws AssertionError If the actual gas used is not within the acceptable deviation range.
+     */
+    protected void validateGasEstimationWithSender(
+            String data, ContractMethodInterface actualGasUsed, String solidityAddress) {
+        var contractCallRequestBody = ContractCallRequest.builder()
+                .data(data)
+                .to(solidityAddress)
+                .from(contractClient.getClientAddress())
+                .estimate(true)
+                .build();
+        ContractCallResponse msgSenderResponse = mirrorClient.contractsCall(contractCallRequestBody);
+        int estimatedGas = msgSenderResponse.getResultAsNumber().intValue();
+
+        assertWithinDeviation(actualGasUsed.getActualGas(), estimatedGas, lowerDeviation, upperDeviation);
+    }
+
+    /**
      * Asserts that a specific contract call results in a "400 Bad Request" response.
      * <p>
      * This method constructs a contract call request using the given encoded function call and contract address, and

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
 import com.hedera.mirror.test.e2e.acceptance.props.ContractCallRequest;
 import com.hedera.mirror.test.e2e.acceptance.response.ContractCallResponse;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
@@ -66,44 +67,20 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
      * @param data            The function signature and method data of the contract call.
      * @param actualGasUsed   The actual gas amount that was used for the call.
      * @param solidityAddress The address of the solidity contract.
+     * @param sender          The sender's address (optional).
      * @throws AssertionError If the actual gas used is not within the acceptable deviation range.
      */
-    protected void validateGasEstimation(String data, ContractMethodInterface actualGasUsed, String solidityAddress) {
-        var contractCallRequestBody = ContractCallRequest.builder()
-                .data(data)
-                .to(solidityAddress)
-                .estimate(true)
-                .build();
+    protected void validateGasEstimation(
+            String data, ContractMethodInterface actualGasUsed, String solidityAddress, Optional<String> sender) {
+        var contractCallRequestBody = buildContractCallRequest(data, solidityAddress, sender);
         ContractCallResponse msgSenderResponse = mirrorClient.contractsCall(contractCallRequestBody);
         int estimatedGas = msgSenderResponse.getResultAsNumber().intValue();
 
         assertWithinDeviation(actualGasUsed.getActualGas(), estimatedGas, lowerDeviation, upperDeviation);
     }
 
-    /**
-     * Validates the gas estimation for a specific contract call, including the sender's address.
-     * <p>
-     * This method estimates the gas cost for a given contract call considering the sender's address, and then checks
-     * whether the actual gas used falls within an acceptable deviation range. It utilizes the provided call endpoint
-     * to perform the contract call and then compares the estimated gas with the actual gas used.
-     *
-     * @param data            The function signature and method data of the contract call.
-     * @param actualGasUsed   The actual gas amount that was used for the call.
-     * @param solidityAddress The address of the solidity contract.
-     * @throws AssertionError If the actual gas used is not within the acceptable deviation range.
-     */
-    protected void validateGasEstimationWithSender(
-            String data, ContractMethodInterface actualGasUsed, String solidityAddress) {
-        var contractCallRequestBody = ContractCallRequest.builder()
-                .data(data)
-                .to(solidityAddress)
-                .from(contractClient.getClientAddress())
-                .estimate(true)
-                .build();
-        ContractCallResponse msgSenderResponse = mirrorClient.contractsCall(contractCallRequestBody);
-        int estimatedGas = msgSenderResponse.getResultAsNumber().intValue();
-
-        assertWithinDeviation(actualGasUsed.getActualGas(), estimatedGas, lowerDeviation, upperDeviation);
+    protected void validateGasEstimation(String data, ContractMethodInterface actualGasUsed, String solidityAddress) {
+        validateGasEstimation(data, actualGasUsed, solidityAddress, Optional.empty());
     }
 
     /**
@@ -127,5 +104,14 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
         assertThatThrownBy(() -> mirrorClient.contractsCall(contractCallRequestBody))
                 .isInstanceOf(WebClientResponseException.class)
                 .hasMessageContaining("400 Bad Request from POST");
+    }
+
+    private ContractCallRequest buildContractCallRequest(String data, String solidityAddress, Optional<String> sender) {
+        var requestBuilder =
+                ContractCallRequest.builder().data(data).to(solidityAddress).estimate(true);
+
+        sender.ifPresent(requestBuilder::from);
+
+        return requestBuilder.build();
     }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -202,7 +202,7 @@ public class EstimateFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with function that performs self destruct")
     public void destroyEstimateCall() {
-        validateGasEstimation(encodeData(ESTIMATE_GAS, DESTROY), DESTROY, contractSolidityAddress);
+        validateGasEstimationWithSender(encodeData(ESTIMATE_GAS, DESTROY), DESTROY, contractSolidityAddress);
     }
 
     @Then("I call estimateGas with request body that contains wrong method signature")

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -67,6 +67,7 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Optional;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -202,7 +203,11 @@ public class EstimateFeature extends AbstractEstimateFeature {
 
     @Then("I call estimateGas with function that performs self destruct")
     public void destroyEstimateCall() {
-        validateGasEstimationWithSender(encodeData(ESTIMATE_GAS, DESTROY), DESTROY, contractSolidityAddress);
+        validateGasEstimation(
+                encodeData(ESTIMATE_GAS, DESTROY),
+                DESTROY,
+                contractSolidityAddress,
+                Optional.of(contractClient.getClientAddress()));
     }
 
     @Then("I call estimateGas with request body that contains wrong method signature")


### PR DESCRIPTION
**Description**:
The self destruct estimate gas test is failing since currently estimate gas tests do not pass from value in request body.
The newly added custom self destruct operation makes validations on the from address which causes the test to fail.
Passing a valid from address in request body fixes the issue. 

Modified classes:
Added new method in `AbstractEstimateFeature` -> `validateGasEstimationWithSender` which now passes a from address
Modified self destruct test to use the new method 

**Related issue(s)**:

Fixes #7592

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
