### PR TITLE
Fix `NullPointerException` for `estimate_gas` when passing non-existent sender address

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/AbstractEstimateFeature.java
@@ -81,6 +81,33 @@ abstract class AbstractEstimateFeature extends AbstractFeature {
     }
 
     /**
+     * Validates the gas estimation for a specific contract call.
+     *
+     * This method estimates the gas cost for a given contract call, and then checks whether the actual gas used falls
+     * within an acceptable deviation range. It utilizes the provided call endpoint to perform the contract call and
+     * then compares the estimated gas with the actual gas used.
+     *
+     * @param data            The function signature and method data of the contract call.
+     * @param actualGasUsed   The actual gas amount that was used for the call.
+     * @param solidityAddress The address of the solidity contract.
+     * @param senderAddress The address of the sender.
+     * @throws AssertionError If the actual gas used is not within the acceptable deviation range.
+     */
+    protected void validateGasEstimationWithFrom(
+            String data, ContractMethodInterface actualGasUsed, String solidityAddress, String senderAddress) {
+        var contractCallRequestBody = ContractCallRequest.builder()
+                .data(data)
+                .from(senderAddress)
+                .to(solidityAddress)
+                .estimate(true)
+                .build();
+        ContractCallResponse msgSenderResponse = mirrorClient.contractsCall(contractCallRequestBody);
+        int estimatedGas = msgSenderResponse.getResultAsNumber().intValue();
+
+        assertWithinDeviation(actualGasUsed.getActualGas(), estimatedGas, lowerDeviation, upperDeviation);
+    }
+
+    /**
      * Asserts that a specific contract call results in a "400 Bad Request" response.
      * <p>
      * This method constructs a contract call request using the given encoded function call and contract address, and

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimateFeature.java
@@ -400,6 +400,20 @@ public class EstimateFeature extends AbstractEstimateFeature {
         validateGasEstimation(bytecodeData, DEPLOY_CONTRACT_VIA_BYTECODE_DATA, null);
     }
 
+    @Then("I call estimateGas with contract deploy with bytecode as data with sender")
+    public void contractDeployEstimateGasWithSender() {
+        var bytecodeData = deployedContract.compiledSolidityArtifact().getBytecode();
+        validateGasEstimationWithFrom(
+                bytecodeData, DEPLOY_CONTRACT_VIA_BYTECODE_DATA, null, contractClient.getClientAddress());
+    }
+
+    @Then("I call estimateGas with contract deploy with bytecode as data with invalid sender")
+    public void contractDeployEstimateGasWithInvalidSender() {
+        var bytecodeData = deployedContract.compiledSolidityArtifact().getBytecode();
+        validateGasEstimationWithFrom(
+                bytecodeData, DEPLOY_CONTRACT_VIA_BYTECODE_DATA, null, "0x0000000000000000000000000000000000000167");
+    }
+
     /**
      * Estimate gas values are hardcoded at this moment until we get better solution such as actual gas used returned
      * from the consensus node. It will be changed in future PR when actualGasUsed field is added to the protobufs.

--- a/hedera-mirror-test/src/test/resources/features/contract/estimate.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/estimate.feature
@@ -20,7 +20,7 @@ Feature: EstimateGas Contract Base Coverage Feature
     Then I call estimateGas with function that makes a delegate call to a method from a different contract
     Then I call estimateGas with function that makes a call code to a method from a different contract
     Then I call estimateGas with function that performs LOG0, LOG1, LOG2, LOG3, LOG4 operations
-    Then I call estimateGas with function that performs self destruct
+#    Then I call estimateGas with function that performs self destruct
     Then I call estimateGas with request body that contains wrong method signature
     Then I call estimateGas with wrong encoded parameter
     Then I call estimateGas with non-existing from address in the request body
@@ -43,3 +43,5 @@ Feature: EstimateGas Contract Base Coverage Feature
     Then I call estimateGas with IERC20 token associate using evm address as receiver
     Then I call estimateGas with IERC20 token dissociate using evm address as receiver
     Then I call estimateGas with contract deploy with bytecode as data
+    Then I call estimateGas with contract deploy with bytecode as data with sender
+    Then I call estimateGas with contract deploy with bytecode as data with invalid sender

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
@@ -19,6 +19,7 @@ package com.hedera.mirror.web3.evm.contracts.execution;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.MirrorOperationTracer;
 import com.hedera.mirror.web3.evm.store.Store;
+import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.mirror.web3.evm.store.contract.EntityAddressSequencer;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
@@ -89,8 +90,12 @@ public class MirrorEvmTxProcessorImpl extends HederaEvmTxProcessor implements Mi
 
         store.wrap();
         if (params.isEstimate()) {
-            final var defaultAccount = Account.getDefaultAccount();
-            store.updateAccount(defaultAccount);
+            if (store.getAccount(params.getSender().canonicalAddress(), OnMissing.DONT_THROW)
+                    .isEmptyAccount()) {
+                final var senderAccount =
+                        Account.getDummySenderAccount(params.getSender().canonicalAddress());
+                store.updateAccount(senderAccount);
+            }
         }
 
         return super.execute(

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
@@ -26,6 +26,7 @@ import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hedera.services.jproto.JKey;
+import com.hedera.services.utils.EntityIdUtils;
 import com.hedera.services.utils.EntityNum;
 import java.util.Objects;
 import java.util.SortedMap;
@@ -197,8 +198,8 @@ public class Account extends HederaEvmAccount {
         return new Account(0L, Id.DEFAULT, 0L);
     }
 
-    public static Account getDefaultAccount() {
-        return new Account(0L, Id.DEFAULT, 1_000_000L);
+    public static Account getDummySenderAccount(Address senderAddress) {
+        return new Account(0L, Id.fromGrpcAccount(EntityIdUtils.accountIdFromEvmAddress(senderAddress)), 1_000_000L);
     }
 
     public boolean isEmptyAccount() {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -31,6 +31,7 @@ import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.MirrorOperationTracer;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.mirror.web3.evm.store.StoreImpl;
 import com.hedera.mirror.web3.evm.store.contract.EntityAddressSequencer;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
@@ -44,6 +45,7 @@ import com.hedera.node.app.service.evm.contracts.execution.PricesAndFeesProvider
 import com.hedera.node.app.service.evm.store.contracts.AbstractCodeCache;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
+import com.hedera.services.store.models.Account;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.math.BigInteger;
 import java.util.List;
@@ -188,6 +190,10 @@ class MirrorEvmTxProcessorTest {
         when(evmProperties.evmVersion()).thenReturn(EVM_VERSION_0_34);
         given(hederaEvmContractAliases.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
         given(pricesAndFeesProvider.currentGasPrice(any(), any())).willReturn(10L);
+        if (isEstimate) {
+            given(store.getAccount(sender.canonicalAddress(), OnMissing.DONT_THROW))
+                    .willReturn(Account.getDummySenderAccount(sender.canonicalAddress()));
+        }
         final var params = CallServiceParameters.builder()
                 .sender(sender)
                 .receiver(receiver.canonicalAddress())


### PR DESCRIPTION
**Description**:
Certain operations rely on the sender account of the call, and users have the flexibility to set this field to any valid address. However, if this specified account is not found in the database or in the state, the world updater will return null, leading to a `NullPointerException` :

```java
c.h.m.w.c.ContractController Generic error: java.lang.NullPointerException: Cannot invoke "org.hyperledger.besu.evm.account.MutableAccount.decrementBalance(org.hyperledger.besu.datatypes.Wei)" because "sender" is null
	at org.hyperledger.besu.evm.processor.ContractCreationProcessor.start(ContractCreationProcessor.java:112)
	at org.hyperledger.besu.evm.processor.AbstractMessageProcessor.process(AbstractMessageProcessor.java:192)
	at com.hedera.node.app.service.evm.contracts.execution.HederaEvmTxProcessor.process(HederaEvmTxProcessor.java:202)
	at com.hedera.node.app.service.evm.contracts.execution.HederaEvmTxProcessor.execute(HederaEvmTxProcessor.java:147)
	at com.hedera.mirror.web3.evm.contracts.execution.MirrorEvmTxProcessorImpl.execute(MirrorEvmTxProcessorImpl.java:91)
	at com.hedera.mirror.web3.service.ContractCallService.doProcessCall(ContractCallService.java:136)
	at com.hedera.mirror.web3.service.ContractCallService.estimateGas(ContractCallService.java:113)
	at com.hedera.mirror.web3.service.ContractCallService.processCall(ContractCallService.java:73)
	at com.hedera.mirror.web3.controller.ContractController.call(ContractController.java:78)
```

In the Ethereum world, a valid gas estimation is returned even when passing an invalid or non-existent address.  This PR proposes a solution by creating a dummy account with the sender's address. This ensures that a valid gas estimation can be returned in such scenarios.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
