### PR TITLE
Replace responseContentType with responseHeaders in REST specs

### DIFF
--- a/hedera-mirror-rest/__tests__/integration/template.js
+++ b/hedera-mirror-rest/__tests__/integration/template.js
@@ -45,6 +45,7 @@ import {JSONParse} from '../../utils';
 import {defaultBeforeAllTimeoutMillis, setupIntegrationTest} from '../integrationUtils';
 import {CreateBucketCommand, PutObjectCommand, S3} from '@aws-sdk/client-s3';
 import sinon from 'sinon';
+
 const groupSpecPath = $$GROUP_SPEC_PATH$$;
 
 const defaultResponseHeaders = {
@@ -142,7 +143,6 @@ describe(`API specification tests - ${groupSpecPath}`, () => {
       {
         url: spec.url,
         urls: spec.urls,
-        responseContentType: spec.responseContentType,
         responseJson: spec.responseJson,
         responseStatus: spec.responseStatus,
       },
@@ -150,8 +150,8 @@ describe(`API specification tests - ${groupSpecPath}`, () => {
     return _.flatten(
       tests.map((test) => {
         const urls = test.urls || [test.url];
-        const {responseContentType, responseJson, responseStatus} = test;
-        return urls.map((url) => ({url, responseContentType, responseJson, responseStatus}));
+        const {responseJson, responseStatus} = test;
+        return urls.map((url) => ({url, responseJson, responseStatus}));
       })
     );
   };
@@ -335,12 +335,11 @@ describe(`API specification tests - ${groupSpecPath}`, () => {
                 }
                 expect(jsonObj).toEqual(tt.responseJson);
               } else {
-                expect(contentType).toEqual(tt.responseContentType);
                 expect(response.text).toEqual(tt.responseJson);
               }
 
               if (response.status >= 200 && response.status < 300) {
-                expect(response.headers).toMatchObject(spec.responseHeaders);
+                expect(lowercaseKeys(response.headers)).toMatchObject(lowercaseKeys(spec.responseHeaders));
               }
             });
           });
@@ -349,3 +348,5 @@ describe(`API specification tests - ${groupSpecPath}`, () => {
     });
   });
 });
+
+var lowercaseKeys = (object) => _.mapKeys(object, (v, k) => k.toLowerCase());

--- a/hedera-mirror-rest/__tests__/integration/template.js
+++ b/hedera-mirror-rest/__tests__/integration/template.js
@@ -349,4 +349,4 @@ describe(`API specification tests - ${groupSpecPath}`, () => {
   });
 });
 
-var lowercaseKeys = (object) => _.mapKeys(object, (v, k) => k.toLowerCase());
+const lowercaseKeys = (object) => _.mapKeys(object, (v, k) => k.toLowerCase());

--- a/hedera-mirror-rest/__tests__/specs/accounts/accounts-range.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts/accounts-range.json
@@ -175,6 +175,6 @@
     }
   },
   "responseHeaders": {
-    "link": "</api/v1/accounts?account.id=lt:0.0.21&account.id=gt:0.0.20&limit=3>; rel=\"next\""
+    "Link": "</api/v1/accounts?account.id=lt:0.0.21&account.id=gt:0.0.20&limit=3>; rel=\"next\""
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-BOTH.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-BOTH.json
@@ -30,7 +30,9 @@
     ]
   },
   "url": "/api/v1/network/supply?q=circulating",
-  "responseContentType": "text/plain; charset=utf-8",
+  "responseHeaders": {
+    "Content-Type": "text/plain; charset=utf-8"
+  },
   "responseStatus": 200,
   "responseJson": "9999999999.99999949"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-HBARS.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-HBARS.json
@@ -30,7 +30,9 @@
     ]
   },
   "url": "/api/v1/network/supply?q=circulating",
-  "responseContentType": "text/plain; charset=utf-8",
+  "responseHeaders": {
+    "Content-Type": "text/plain; charset=utf-8"
+  },
   "responseStatus": 200,
   "responseJson": "9999999999"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-TINYBARS.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating-TINYBARS.json
@@ -30,7 +30,9 @@
     ]
   },
   "url": "/api/v1/network/supply?q=circulating",
-  "responseContentType": "text/plain; charset=utf-8",
+  "responseHeaders": {
+    "Content-Type": "text/plain; charset=utf-8"
+  },
   "responseStatus": 200,
   "responseJson": "999999999999999949"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-circulating.json
@@ -25,7 +25,9 @@
     ]
   },
   "url": "/api/v1/network/supply?q=circulating",
-  "responseContentType": "text/plain; charset=utf-8",
+  "responseHeaders": {
+    "Content-Type": "text/plain; charset=utf-8"
+  },
   "responseStatus": 200,
   "responseJson": "9999999999.99999949"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-BOTH.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-BOTH.json
@@ -30,7 +30,9 @@
     ]
   },
   "url": "/api/v1/network/supply?q=totalcoins",
-  "responseContentType": "text/plain; charset=utf-8",
+  "responseHeaders": {
+    "Content-Type": "text/plain; charset=utf-8"
+  },
   "responseStatus": 200,
   "responseJson": "50000000000.00000000"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-HBARS.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-HBARS.json
@@ -30,7 +30,9 @@
     ]
   },
   "url": "/api/v1/network/supply?q=totalcoins",
-  "responseContentType": "text/plain; charset=utf-8",
+  "responseHeaders": {
+    "Content-Type": "text/plain; charset=utf-8"
+  },
   "responseStatus": 200,
   "responseJson": "50000000000"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-TINYBARS.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins-TINYBARS.json
@@ -30,7 +30,9 @@
     ]
   },
   "url": "/api/v1/network/supply?q=totalcoins",
-  "responseContentType": "text/plain; charset=utf-8",
+  "responseHeaders": {
+    "Content-Type": "text/plain; charset=utf-8"
+  },
   "responseStatus": 200,
   "responseJson": "5000000000000000000"
 }

--- a/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/q-totalcoins.json
@@ -25,7 +25,9 @@
     ]
   },
   "url": "/api/v1/network/supply?q=totalcoins",
-  "responseContentType": "text/plain; charset=utf-8",
+  "responseHeaders": {
+    "Content-Type": "text/plain; charset=utf-8"
+  },
   "responseStatus": 200,
   "responseJson": "50000000000.00000000"
 }


### PR DESCRIPTION
**Description**:

* Replace `responseContentType` with `responseHeaders`
* Support case insensitive header comparison

**Related issue(s)**:

Fixes #7598

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
