### PR TITLE
Enable direct calls to precompile addresses

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/CallFeature.java
@@ -401,6 +401,31 @@ public class CallFeature extends AbstractFeature {
         assertEquals(Integer.parseInt(balances[1], 16), 990000);
     }
 
+    @Then("I directly call Ethereum precompile 0x01")
+    public void directCallTowardsEthereumPrecompileECRecover() {
+        final var precompileAddress = "0x0000000000000000000000000000000000000001";
+        final var hash = "0x456e9aea5e197a1f1af7a3e85a3212fa4049a3ba34c2289b4c860fc0b0c64ef3";
+        final var v = "000000000000000000000000000000000000000000000000000000000000001c";
+        final var r = "9242685bf161793cc25603c231bc2f568eb630ea16aa137d2664ac8038825608";
+        final var s = "4f8ae3bd7535248d0bd448298cc2e2071e56992d0774dc340c368ae950852ada";
+        final var correctResult = "0x0000000000000000000000007156526fbd7a3c72969b54f64e42c10fbb768c8a";
+
+        final var data = hash.concat(v).concat(r).concat(s);
+
+        var response = callContract(data, precompileAddress);
+        assertThat(response.getResult()).isEqualTo(correctResult);
+    }
+
+    @Then("I directly call Ethereum precompile 0x02")
+    public void directCallTowardsEthereumPrecompileSHA256() {
+        final var precompileAddress = "0x0000000000000000000000000000000000000002";
+        final var data = "0xFF";
+        final var correctResult = "0xa8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89";
+
+        var response = callContract(data, precompileAddress);
+        assertThat(response.getResult()).isEqualTo(correctResult);
+    }
+
     @Then("I mint FUNGIBLE token and get the total supply and balance")
     public void ethCallMintFungibleTokenGetTotalSupplyAndBalanceOfTreasury() {
         var data = encodeData(

--- a/hedera-mirror-test/src/test/resources/features/contract/call.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/call.feature
@@ -22,6 +22,8 @@ Feature: eth_call Contract Base Coverage Feature
     Then I call function with nested deploy using create function
     Then I call function with nested deploy using create2 function
     Then I call function with transfer that returns the balance
+    Then I directly call Ethereum precompile 0x01
+    Then I directly call Ethereum precompile 0x02
     Then I burn FUNGIBLE token and get the total supply and balance
     Given I mint a NFT
     Then the mirror node should return status 200 for the HAPI transaction

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
@@ -78,6 +78,11 @@ public class MirrorEvmContractAliases extends HederaEvmContractAliases {
         }
     }
 
+    public boolean isPrecompileAddress(Address addressOrAlias) {
+        final var addressDecimals = Long.parseLong(addressOrAlias.toHexString().substring(2), 16);
+        return addressDecimals > 0 && addressDecimals < 10;
+    }
+
     public boolean isInUse(final Address address) {
         return store.exists(address);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
@@ -78,7 +78,7 @@ public class MirrorEvmContractAliases extends HederaEvmContractAliases {
         }
     }
 
-    public boolean isPrecompileAddress(Address addressOrAlias) {
+    public boolean isNativePrecompileAddress(Address addressOrAlias) {
         final var addressDecimals = Long.parseLong(addressOrAlias.toHexString().substring(2), 16);
         return addressDecimals > 0 && addressDecimals < 10;
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
@@ -80,7 +80,8 @@ public class MirrorEvmContractAliases extends HederaEvmContractAliases {
 
     public boolean isNativePrecompileAddress(Address addressOrAlias) {
         return addressOrAlias != null
-                && addressOrAlias.compareTo(Address.ZERO) > 0 & addressOrAlias.compareTo(Address.KZG_POINT_EVAL) < 0;
+                && addressOrAlias.compareTo(Address.ZERO) > 0
+                && addressOrAlias.compareTo(Address.KZG_POINT_EVAL) < 0;
     }
 
     public boolean isInUse(final Address address) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliases.java
@@ -79,8 +79,8 @@ public class MirrorEvmContractAliases extends HederaEvmContractAliases {
     }
 
     public boolean isNativePrecompileAddress(Address addressOrAlias) {
-        final var addressDecimals = Long.parseLong(addressOrAlias.toHexString().substring(2), 16);
-        return addressDecimals > 0 && addressDecimals < 10;
+        return addressOrAlias != null
+                && addressOrAlias.compareTo(Address.ZERO) > 0 & addressOrAlias.compareTo(Address.KZG_POINT_EVAL) < 0;
     }
 
     public boolean isInUse(final Address address) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
@@ -125,10 +125,11 @@ public class MirrorEvmTxProcessorImpl extends HederaEvmTxProcessor implements Mi
         } else {
             final var resolvedForEvm = aliasManager.resolveForEvm(to);
             final var code = aliasManager.isMirror(resolvedForEvm) ? codeCache.getIfPresent(resolvedForEvm) : null;
-            final var isNotCallingPrecompile = !aliasManager.isPrecompileAddress(resolvedForEvm);
+            final var isNotNativePrecompileAddress = !aliasManager.isNativePrecompileAddress(resolvedForEvm);
+
             // If there is no bytecode, it means we have a non-token and non-contract account,
             // hence the code should be null and there must be a value transfer.
-            if (code == null && value <= 0 && !payload.isEmpty() && isNotCallingPrecompile) {
+            if (code == null && value <= 0 && !payload.isEmpty() && isNotNativePrecompileAddress) {
                 throw new MirrorEvmTransactionException(
                         ResponseCodeEnum.INVALID_TRANSACTION, StringUtils.EMPTY, StringUtils.EMPTY);
             }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
@@ -125,10 +125,10 @@ public class MirrorEvmTxProcessorImpl extends HederaEvmTxProcessor implements Mi
         } else {
             final var resolvedForEvm = aliasManager.resolveForEvm(to);
             final var code = aliasManager.isMirror(resolvedForEvm) ? codeCache.getIfPresent(resolvedForEvm) : null;
-
+            final var isNotCallingPrecompile = !aliasManager.isPrecompileAddress(resolvedForEvm);
             // If there is no bytecode, it means we have a non-token and non-contract account,
             // hence the code should be null and there must be a value transfer.
-            if (code == null && value <= 0 && !payload.isEmpty()) {
+            if (code == null && value <= 0 && !payload.isEmpty() && isNotCallingPrecompile) {
                 throw new MirrorEvmTransactionException(
                         ResponseCodeEnum.INVALID_TRANSACTION, StringUtils.EMPTY, StringUtils.EMPTY);
             }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
@@ -125,11 +125,11 @@ public class MirrorEvmTxProcessorImpl extends HederaEvmTxProcessor implements Mi
         } else {
             final var resolvedForEvm = aliasManager.resolveForEvm(to);
             final var code = aliasManager.isMirror(resolvedForEvm) ? codeCache.getIfPresent(resolvedForEvm) : null;
-            final var isNotNativePrecompileAddress = !aliasManager.isNativePrecompileAddress(resolvedForEvm);
+            final var isNotCallingNativePrecompile = !aliasManager.isNativePrecompileAddress(resolvedForEvm);
 
             // If there is no bytecode, it means we have a non-token and non-contract account,
             // hence the code should be null and there must be a value transfer.
-            if (code == null && value <= 0 && !payload.isEmpty() && isNotNativePrecompileAddress) {
+            if (code == null && value <= 0 && !payload.isEmpty() && isNotCallingNativePrecompile) {
                 throw new MirrorEvmTransactionException(
                         ResponseCodeEnum.INVALID_TRANSACTION, StringUtils.EMPTY, StringUtils.EMPTY);
             }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
@@ -41,6 +41,8 @@ import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -99,18 +101,18 @@ class MirrorEvmContractAliasesTest {
         assertThat(mirrorEvmContractAliases.resolveForEvm(ALIAS)).isEqualTo(Bytes.wrap(toEvmAddress(entityId)));
     }
 
-    @Test
-    void isPrecompileAddressShouldReturnTrue() {
-        final var precompileAddress = Address.ECREC;
-        assertTrue(mirrorEvmContractAliases.isNativePrecompileAddress(precompileAddress));
+    @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9})
+    @ParameterizedTest
+    void isPrecompileAddressShouldReturnTrue(int address) {
+        assertThat(mirrorEvmContractAliases.isNativePrecompileAddress(Address.precompiled(address)))
+                .isEqualTo(true);
     }
 
-    @Test
-    void isPrecompileAddressShouldReturnFalse() {
-        final var zeroAddress = Address.ZERO;
-
-        assertFalse(mirrorEvmContractAliases.isNativePrecompileAddress(zeroAddress));
-        assertFalse(mirrorEvmContractAliases.isNativePrecompileAddress(Address.fromHexString(HEX)));
+    @ValueSource(ints = {0, 10, 100})
+    @ParameterizedTest
+    void isPrecompileAddressShouldReturnFalse(int address) {
+        assertThat(mirrorEvmContractAliases.isNativePrecompileAddress(Address.precompiled(address)))
+                .isEqualTo(false);
     }
 
     //    @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
@@ -102,15 +102,15 @@ class MirrorEvmContractAliasesTest {
     @Test
     void isPrecompileAddressShouldReturnTrue() {
         final var precompileAddress = Address.ECREC;
-        assertTrue(mirrorEvmContractAliases.isPrecompileAddress(precompileAddress));
+        assertTrue(mirrorEvmContractAliases.isNativePrecompileAddress(precompileAddress));
     }
 
     @Test
     void isPrecompileAddressShouldReturnFalse() {
         final var zeroAddress = Address.ZERO;
 
-        assertFalse(mirrorEvmContractAliases.isPrecompileAddress(zeroAddress));
-        assertFalse(mirrorEvmContractAliases.isPrecompileAddress(Address.fromHexString(HEX)));
+        assertFalse(mirrorEvmContractAliases.isNativePrecompileAddress(zeroAddress));
+        assertFalse(mirrorEvmContractAliases.isNativePrecompileAddress(Address.fromHexString(HEX)));
     }
 
     //    @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
@@ -99,6 +99,20 @@ class MirrorEvmContractAliasesTest {
         assertThat(mirrorEvmContractAliases.resolveForEvm(ALIAS)).isEqualTo(Bytes.wrap(toEvmAddress(entityId)));
     }
 
+    @Test
+    void isPrecompileAddressShouldReturnTrue() {
+        final var precompileAddress = Address.ECREC;
+        assertTrue(mirrorEvmContractAliases.isPrecompileAddress(precompileAddress));
+    }
+
+    @Test
+    void isPrecompileAddressShouldReturnFalse() {
+        final var zeroAddress = Address.ZERO;
+
+        assertFalse(mirrorEvmContractAliases.isPrecompileAddress(zeroAddress));
+        assertFalse(mirrorEvmContractAliases.isPrecompileAddress(Address.fromHexString(HEX)));
+    }
+
     //    @Test
     //    void link() {
     //        mirrorEvmContractAliases.link(ALIAS, ADDRESS);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
@@ -105,14 +105,14 @@ class MirrorEvmContractAliasesTest {
     @ParameterizedTest
     void isPrecompileAddressShouldReturnTrue(int address) {
         assertThat(mirrorEvmContractAliases.isNativePrecompileAddress(Address.precompiled(address)))
-                .isEqualTo(true);
+                .isTrue();
     }
 
     @ValueSource(ints = {0, 10, 100})
     @ParameterizedTest
     void isPrecompileAddressShouldReturnFalse(int address) {
         assertThat(mirrorEvmContractAliases.isNativePrecompileAddress(Address.precompiled(address)))
-                .isEqualTo(false);
+                .isFalse();
     }
 
     //    @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/account/MirrorEvmContractAliasesTest.java
@@ -113,6 +113,7 @@ class MirrorEvmContractAliasesTest {
     void isPrecompileAddressShouldReturnFalse(int address) {
         assertThat(mirrorEvmContractAliases.isNativePrecompileAddress(Address.precompiled(address)))
                 .isFalse();
+        assertThat(mirrorEvmContractAliases.isNativePrecompileAddress(null)).isFalse();
     }
 
     //    @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -293,7 +293,7 @@ class MirrorEvmTxProcessorTest {
                 commonInitialFrame, precompileAddress, validPrecompilePayload, 0L);
 
         assertThat(sender.canonicalAddress()).isEqualTo(buildMessageFrame.getSenderAddress());
-        assertThat(Wei.ZERO).isEqualTo(buildMessageFrame.getApparentValue());
+        assertThat(buildMessageFrame.getApparentValue()).isEqualTo(Wei.ZERO);
         assertThat(precompileAddress).isEqualTo(buildMessageFrame.getRecipientAddress());
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -265,7 +265,7 @@ class MirrorEvmTxProcessorTest {
     }
 
     @Test
-    void precompileCallSucceds() {
+    void precompileCallSucceeds() {
         final var validPrecompilePayload =
                 Bytes.fromHexString("0x8dac847b6279746573333200000000000000000000000000000000000000000000000000");
         // setup:


### PR DESCRIPTION
**Description**:
This PR enables direct calls to ethereum precompile addresses, by bypassing the `INVALID_TRANSACTION` check, when to address is between `0x01` and `0x09`. 
Also adds new method which is responsible for checking whether the passed address is precompile address or not.

**Related issue(s)**:

Fixes #7608 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
