### PR TITLE
fix: Fix concurrency issue in message call processors

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/AbstractEvmMessageCallProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/AbstractEvmMessageCallProcessor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.evm.contracts.execution;
+
+import static org.apache.tuweni.bytes.Bytes.EMPTY;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.DefaultExceptionalHaltReason.INSUFFICIENT_GAS;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCESS;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
+
+import com.hedera.node.app.service.evm.contracts.execution.HederaEvmMessageCallProcessor;
+import com.hedera.node.app.service.evm.store.contracts.AbstractLedgerEvmWorldUpdater;
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
+import com.swirlds.base.utility.Pair;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.hyperledger.besu.evm.EVM;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
+import org.hyperledger.besu.evm.precompile.PrecompiledContract;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
+
+public abstract class AbstractEvmMessageCallProcessor extends HederaEvmMessageCallProcessor {
+
+    protected AbstractEvmMessageCallProcessor(
+            final EVM evm,
+            final PrecompileContractRegistry precompiles,
+            final Map<String, PrecompiledContract> hederaPrecompileList) {
+        super(evm, precompiles, hederaPrecompileList);
+    }
+
+    protected Pair<Long, Bytes> calculatePrecompileGasAndOutput(PrecompiledContract contract, MessageFrame frame) {
+        Bytes output = EMPTY;
+        Long gasRequirement = 0L;
+
+        if (contract instanceof EvmHTSPrecompiledContract htsPrecompile) {
+            var updater = (AbstractLedgerEvmWorldUpdater) frame.getWorldUpdater();
+            final var costedResult = htsPrecompile.computeCosted(
+                    frame.getInputData(),
+                    frame,
+                    (now, minimumTinybarCost) -> minimumTinybarCost,
+                    updater.tokenAccessor());
+            output = costedResult.getValue();
+            gasRequirement = costedResult.getKey();
+        }
+
+        if (!"HTS".equals(contract.getName()) && !"EvmHTS".equals(contract.getName())) {
+            output = contract.computePrecompile(frame.getInputData(), frame).getOutput();
+            gasRequirement = contract.gasRequirement(frame.getInputData());
+        }
+
+        return Pair.of(gasRequirement, output);
+    }
+
+    protected void traceAndHandleExecutionResult(
+            MessageFrame frame, OperationTracer operationTracer, Long gasRequirement, Bytes output) {
+        operationTracer.tracePrecompileCall(frame, gasRequirement, output);
+        if (frame.getState() == REVERT) {
+            return;
+        }
+
+        if (frame.getRemainingGas() < gasRequirement) {
+            frame.decrementRemainingGas(frame.getRemainingGas());
+            frame.setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
+            frame.setState(EXCEPTIONAL_HALT);
+        } else if (output != null) {
+            frame.decrementRemainingGas(gasRequirement);
+            frame.setOutputData(output);
+            frame.setState(COMPLETED_SUCCESS);
+        } else {
+            frame.setState(EXCEPTIONAL_HALT);
+        }
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessor.java
@@ -32,16 +32,13 @@ import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
-import com.swirlds.base.utility.Pair;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
-import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 public class MirrorEvmMessageCallProcessor extends AbstractEvmMessageCallProcessor {
@@ -60,17 +57,6 @@ public class MirrorEvmMessageCallProcessor extends AbstractEvmMessageCallProcess
         this.entityAddressSequencer = entityAddressSequencer;
 
         MainnetPrecompiledContracts.populateForIstanbul(precompiles, gasCalculator);
-    }
-
-    @Override
-    protected void executeHederaPrecompile(
-            PrecompiledContract contract, MessageFrame frame, OperationTracer operationTracer) {
-        Pair<Long, Bytes> costAndResult = calculatePrecompileGasAndOutput(contract, frame);
-
-        Long gasRequirement = costAndResult.left();
-        Bytes output = costAndResult.right();
-
-        traceAndHandleExecutionResult(frame, operationTracer, gasRequirement, output);
     }
 
     /**

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessor.java
@@ -18,13 +18,18 @@ package com.hedera.mirror.web3.evm.contracts.execution;
 
 import static com.hedera.node.app.service.evm.contracts.operations.HederaExceptionalHaltReason.FAILURE_DURING_LAZY_ACCOUNT_CREATE;
 import static com.hedera.services.store.contracts.precompile.codec.DecodingFacade.wrapUnsafely;
+import static org.apache.tuweni.bytes.Bytes.EMPTY;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCESS;
 import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
+import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
 
 import com.hedera.mirror.web3.evm.config.PrecompiledContractProvider;
 import com.hedera.mirror.web3.evm.store.contract.EntityAddressSequencer;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmMessageCallProcessor;
+import com.hedera.node.app.service.evm.store.contracts.AbstractLedgerEvmWorldUpdater;
+import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
 import com.hedera.services.contracts.gascalculator.GasCalculatorHederaV22;
 import com.hedera.services.ledger.BalanceChange;
 import com.hedera.services.txns.crypto.AbstractAutoCreationLogic;
@@ -35,11 +40,13 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
+import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 public class MirrorEvmMessageCallProcessor extends HederaEvmMessageCallProcessor {
@@ -58,6 +65,43 @@ public class MirrorEvmMessageCallProcessor extends HederaEvmMessageCallProcessor
         this.entityAddressSequencer = entityAddressSequencer;
 
         MainnetPrecompiledContracts.populateForIstanbul(precompiles, gasCalculator);
+    }
+
+    @Override
+    protected void executeHederaPrecompile(
+            PrecompiledContract contract, MessageFrame frame, OperationTracer operationTracer) {
+        Bytes output = EMPTY;
+        Long gasRequirement = 0L;
+        if (contract instanceof EvmHTSPrecompiledContract htsPrecompile) {
+            var updater = (AbstractLedgerEvmWorldUpdater) frame.getWorldUpdater();
+            final var costedResult = htsPrecompile.computeCosted(
+                    frame.getInputData(),
+                    frame,
+                    (now, minimumTinybarCost) -> minimumTinybarCost,
+                    updater.tokenAccessor());
+            output = costedResult.getValue();
+            gasRequirement = costedResult.getKey();
+        }
+        if (!"HTS".equals(contract.getName()) && !"EvmHTS".equals(contract.getName())) {
+            output = contract.computePrecompile(frame.getInputData(), frame).getOutput();
+            gasRequirement = contract.gasRequirement(frame.getInputData());
+        }
+
+        operationTracer.tracePrecompileCall(frame, gasRequirement, output);
+        if (frame.getState() == REVERT) {
+            return;
+        }
+        if (frame.getRemainingGas() < gasRequirement) {
+            frame.decrementRemainingGas(frame.getRemainingGas());
+            frame.setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
+            frame.setState(EXCEPTIONAL_HALT);
+        } else if (output != null) {
+            frame.decrementRemainingGas(gasRequirement);
+            frame.setOutputData(output);
+            frame.setState(COMPLETED_SUCCESS);
+        } else {
+            frame.setState(EXCEPTIONAL_HALT);
+        }
     }
 
     /**

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorV30.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorV30.java
@@ -18,15 +18,10 @@ package com.hedera.mirror.web3.evm.contracts.execution;
 
 import com.hedera.mirror.web3.evm.config.PrecompiledContractProvider;
 import com.hedera.services.contracts.gascalculator.GasCalculatorHederaV22;
-import com.swirlds.base.utility.Pair;
 import jakarta.inject.Named;
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
-import org.hyperledger.besu.evm.precompile.PrecompiledContract;
-import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 @Named
 public class MirrorEvmMessageCallProcessorV30 extends AbstractEvmMessageCallProcessor {
@@ -38,16 +33,5 @@ public class MirrorEvmMessageCallProcessorV30 extends AbstractEvmMessageCallProc
             final GasCalculatorHederaV22 gasCalculator) {
         super(v30, precompiles, precompilesHolder.getHederaPrecompiles());
         MainnetPrecompiledContracts.populateForIstanbul(precompiles, gasCalculator);
-    }
-
-    @Override
-    protected void executeHederaPrecompile(
-            PrecompiledContract contract, MessageFrame frame, OperationTracer operationTracer) {
-        Pair<Long, Bytes> costAndResult = calculatePrecompileGasAndOutput(contract, frame);
-
-        Long gasRequirement = costAndResult.left();
-        Bytes output = costAndResult.right();
-
-        traceAndHandleExecutionResult(frame, operationTracer, gasRequirement, output);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorV30.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorV30.java
@@ -16,19 +16,10 @@
 
 package com.hedera.mirror.web3.evm.contracts.execution;
 
-import static org.apache.tuweni.bytes.Bytes.EMPTY;
-import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INSUFFICIENT_GAS;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCESS;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
-import static org.hyperledger.besu.evm.frame.MessageFrame.State.REVERT;
-
 import com.hedera.mirror.web3.evm.config.PrecompiledContractProvider;
-import com.hedera.node.app.service.evm.contracts.execution.HederaEvmMessageCallProcessor;
-import com.hedera.node.app.service.evm.store.contracts.AbstractLedgerEvmWorldUpdater;
-import com.hedera.node.app.service.evm.store.contracts.precompile.EvmHTSPrecompiledContract;
 import com.hedera.services.contracts.gascalculator.GasCalculatorHederaV22;
+import com.swirlds.base.utility.Pair;
 import jakarta.inject.Named;
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -38,7 +29,7 @@ import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 @Named
-public class MirrorEvmMessageCallProcessorV30 extends HederaEvmMessageCallProcessor {
+public class MirrorEvmMessageCallProcessorV30 extends AbstractEvmMessageCallProcessor {
 
     public MirrorEvmMessageCallProcessorV30(
             @Named("evm030") EVM v30,
@@ -52,37 +43,11 @@ public class MirrorEvmMessageCallProcessorV30 extends HederaEvmMessageCallProces
     @Override
     protected void executeHederaPrecompile(
             PrecompiledContract contract, MessageFrame frame, OperationTracer operationTracer) {
-        Bytes output = EMPTY;
-        Long gasRequirement = 0L;
-        if (contract instanceof EvmHTSPrecompiledContract htsPrecompile) {
-            var updater = (AbstractLedgerEvmWorldUpdater) frame.getWorldUpdater();
-            final var costedResult = htsPrecompile.computeCosted(
-                    frame.getInputData(),
-                    frame,
-                    (now, minimumTinybarCost) -> minimumTinybarCost,
-                    updater.tokenAccessor());
-            output = costedResult.getValue();
-            gasRequirement = costedResult.getKey();
-        }
-        if (!"HTS".equals(contract.getName()) && !"EvmHTS".equals(contract.getName())) {
-            output = contract.computePrecompile(frame.getInputData(), frame).getOutput();
-            gasRequirement = contract.gasRequirement(frame.getInputData());
-        }
+        Pair<Long, Bytes> costAndResult = calculatePrecompileGasAndOutput(contract, frame);
 
-        operationTracer.tracePrecompileCall(frame, gasRequirement, output);
-        if (frame.getState() == REVERT) {
-            return;
-        }
-        if (frame.getRemainingGas() < gasRequirement) {
-            frame.decrementRemainingGas(frame.getRemainingGas());
-            frame.setExceptionalHaltReason(Optional.of(INSUFFICIENT_GAS));
-            frame.setState(EXCEPTIONAL_HALT);
-        } else if (output != null) {
-            frame.decrementRemainingGas(gasRequirement);
-            frame.setOutputData(output);
-            frame.setState(COMPLETED_SUCCESS);
-        } else {
-            frame.setState(EXCEPTIONAL_HALT);
-        }
+        Long gasRequirement = costAndResult.left();
+        Bytes output = costAndResult.right();
+
+        traceAndHandleExecutionResult(frame, operationTracer, gasRequirement, output);
     }
 }


### PR DESCRIPTION
**Description**:
Currently making simultaneous calls of decimals function with multiple threads against erc tokens with different decimals will result in mixed up results. If one token has 10 decimals the other has 8 decimals, when we expect the result to be 10 it might turn out to be 8 and vice versa. This is because our MessageCallProcessors - `MirrorEvmMessageCallProcessor` and `MirrorEvmMessageCallProcessorV30` are singleton beans that extend hedera-evm `HederaEvmMessageCallProcessor` which maintains state with 
```
protected long gasRequirement;
protected Bytes output;
```
Multiple threads calling `executeHederaPrecompile()` will modify simultaneously shared  `gasRequirement` and `output` fields and mix up the results.


This Pr modifies :
`MirrorEvmMessageCallProcessor` override `executeHederaPrecompile()` define `gasRequirement` and `output` as local variables within the executeHederaPrecompile to ensure thread safety.
 
`MirrorEvmMessageCallProcessorV30` override `executeHederaPrecompile()` define `gasRequirement` and `output` as local variables within the executeHederaPrecompile to ensure thread safety.


**Related issue(s)**:

Fixes #7572 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
