### PR TITLE
Added the absolute path to test.jar

### DIFF
--- a/hedera-mirror-test/Dockerfile
+++ b/hedera-mirror-test/Dockerfile
@@ -8,4 +8,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 USER 1000:1000
 
-ENTRYPOINT ["java", "-jar", "test.jar"]
+ENTRYPOINT ["java", "-jar", "/app/test.jar"]


### PR DESCRIPTION
**Description**: 
I've added the absolute path to test.jar in order to allow the default image entrypoint to run from within 3rd party frameworks that may use a different working-directory, such as Jenkins, without the need to override the entrypoint.

- Modified ENTRYPOINT in the Dockerfile to include the absolute path for `test.jar`

**Related issue(s)**: https://github.com/swirlds/infrastructure/pull/5430

**Notes for reviewer**:
Adding the absolute path should change nothing whenever the container starts in a plain/vanilla k8s or docker environments, it will however remove the need I have to manually override the entrypoint in order to add a `cd /app` command when I attempt to start the container from within a Jenkins pipeline using a jenkins agent pod.
Apparently, once included as a container in the agent pod, Jenkins mounts its agent home directory and changes the working-dir in that container to `/home/jenkins/agent`

