### PR TITLE
Support batch stream file ingestion

### DIFF
--- a/docs/checklist/release.md
+++ b/docs/checklist/release.md
@@ -4,6 +4,7 @@ This checklist verifies a release is rolled out successfully.
 
 ## Preparation
 
+- [ ] Milestone created
 - [ ] Milestone field populated on
       relevant [issues](https://github.com/hashgraph/hedera-mirror-node/issues?q=is%3Aclosed+no%3Amilestone+sort%3Aupdated-desc)
 - [ ] Nothing open
@@ -20,13 +21,14 @@ This checklist verifies a release is rolled out successfully.
 - [ ] Deployed
 - [ ] gRPC API performance tests
 - [ ] Importer performance tests
-- [ ] REST API performance tests
-
-## Previewnet
-
-- [ ] Deployed
 
 ## Staging
+
+- [ ] Deployed
+- [ ] REST API performance tests
+- [ ] Web3 API performance tests
+
+## Previewnet
 
 - [ ] Deployed
 

--- a/docs/design/parser.md
+++ b/docs/design/parser.md
@@ -10,12 +10,13 @@ SQL Database client is tightly coupled with transaction & record's processor whi
 ## Goal
 
 1. Decouple parsing of stream from ingestion into a database
-1. Abstractions should support measuring (a) parser's performance and (b) database ingestion performance, in isolation
+2. Abstractions should support measuring (a) parser's performance and (b) database ingestion performance, in isolation
 
 ## Non-goals
 
 - Change importer from filesystem based to in-memory streaming
-- Parsing multiple rcd/balance/etc files in parallel. Parser is far from being bottleneck, there is no need to optimize it
+- Parsing multiple rcd/balance/etc files in parallel. Parser is far from being bottleneck, there is no need to optimize
+  it
 - Accommodate possibility of publishing transactions/topic messages/etc to GRPC server directly
 - Support writing to multiple databases from single importer
 - Update balance file parser code immediately
@@ -100,10 +101,15 @@ package com.hedera.mirror.importer.parser.record;
 
 public interface EntityListener {
     void onTransaction(c.h.m.i.d.Transaction transaction) throws ImporterException;
+
     void onCryptoTransfer(c.h.m.i.d.CryptoTransfer cryptoTransfer) throws ImporterException;
+
     void onTopicMessage(c.h.m.i.d.TopicMessage topicMessage) throws ImporterException;
+
     void onContractResult(c.h.m.i.d.ContractResult contractResult) throws ImporterException;
+
     void onFileData(c.h.m.i.d.FileData fileData) throws ImporterException;
+
     void onLiveHash(c.h.m.i.d.LiveHash liveHash) throws ImporterException;
 }
 ```
@@ -112,14 +118,6 @@ public interface EntityListener {
    1. `SqlEntityListener`:
       - For writing entities to SQL database
       - Useful for testing database insert performance in isolation from parser
-   1. `NullEntityListener`: No-op implementation
-      - For micro-benchmarking parser performance
-
-Note that there is no `onEntity` function. Updating the `entity` table in batches is not possible right now since
-`transaction` table uses foreign keys. For the `entity` table, first, schema changes are needed to remove entity ids,
-then `onEntity` and `onEntityUpdate` functions will be added to insert/update entities in bulk. For the purpose of
-immediate refactor, we can leave entities in `EntityRecordItemListener` (until perf optimizations via schema change in
-milestone 2).
 
 ### RecordFileParser
 
@@ -150,79 +148,16 @@ public class RecordFileParser {
 
 1. On each call to `onFile(streamFileData)`:
    1. Validate prev hash
-   1. Call `recordStreamFileListener.onStart(streamFileData)`
-   1. For each set of `Transaction` and `TransactionRecord` in record file, call `recordItemListener.onItem(recordItem)`.
-   1. Finally call `recordStreamFileListener.onEnd(recordFile)`
-   1. On exceptions, call `recordStreamFileListener.onError(error)`
-
-### RecordFileReader
-
-```java
-package com.hedera.mirror.importer.parser.record;
-
-public class RecordFileReader extends FileWatcher {
-
-    private final RecordFileParser recordFileParser; // injected dependency
-
-    @Override
-    public void onCreate() {
-        // List files
-        // Open the file on disk, create InputStream on it. Keep RecordFileParser filesystem agnostic.
-        StreamFileData streamFileData = new StreamFileData(filename, inputStream);
-        recordFileParser.onFile(streamFileData);
-    }
-}
-```
+   2. For each set of `Transaction` and `TransactionRecord` in record file,
+      call `recordItemListener.onItem(recordItem)`.
+   3. Finally call `recordStreamFileListener.onEnd(recordFile)`
 
 ## Outstanding questions:
 
 1. Does Spring Data repository has support for Postgres COPY command? Couldn't find sources that suggest it does. If
    that indeed turns out to be the case, then I see at least two possibilities:
    - Use manual connection(s) to COPY to transaction, crypto_transfer, topic_message, other write heavy tables.
-     And use Spring Repositories for other tables. However, that raises the question of consistency of data across multiple
+     And use Spring Repositories for other tables. However, that raises the question of consistency of data across
+     multiple
      transactions (since there are multiple connections).
    - Use COPY and PreparedStatement over single connection
-
-## Tasks (in suggested order):
-
-#### Milestone 1 (done)
-
-1. Finalize design
-1. Refactoring
-   1. Add the interfaces and domains ([#564](https://github.com/hashgraph/hedera-mirror-node/issues/564))
-   1. Split `RecordFileLogger` class into two
-      1. Create `SqlEntityListener`. Move existing sql writer code from `RecordFileLogger`
-         to new class as-is. ([#566](https://github.com/hashgraph/hedera-mirror-node/issues/566))
-      1. Change `RecordFileLogger` to `class EntityRecordItemListener implements RecordItemListener {...}`
-         ([#567](https://github.com/hashgraph/hedera-mirror-node/issues/567))
-
-#### Milestone 2
-
-All top level tasks can be done in parallel.
-
-1. Implement `PubSubRecordItemListner` for `blockchain-etl` project (done)
-1. Split `RecordFileParser` class into two ([#568](https://github.com/hashgraph/hedera-mirror-node/issues/568))
-   - Move FileSystem related code into `RecordFileReader`
-   - Keep `RecordFileParser` agnostic of source of stream files
-1. Perf
-   1. Hook up `SqlEntityListener` with `data-generator` to test db insert performance and
-      establish baseline ([#569](https://github.com/hashgraph/hedera-mirror-node/issues/569))
-   1. Optimize `SqlEntityListener` ([#570](https://github.com/hashgraph/hedera-mirror-node/issues/570))
-      - Schema changes to remove entity ids (while at it, remove `fildId` from `transaction`)
-      - Get rid of all `SELECT` queries in parser
-      - Use of `COPY`
-      - Concurrency using multiple jdbc connections
-1. Refactor `EntityRecordItemListener` class. Split parsing logic into re-usable helper functions.
-   ([#571](https://github.com/hashgraph/hedera-mirror-node/issues/571))
-   - Will make it easy for mirror node users to write custom parsers
-   - Will make it possible to have filtering logic less loosely coupled with parsing logic
-
-#### Milestone 3 (followup tasks to tie loose ends)
-
-- Remove event parser code: Doesn't have tests. Not used in last 6 months. No likelihood of needed in next couple months
-  There is no need to pay tech-rent on this debt. Can be done right once when it is really needed.
-  ([#572](https://github.com/hashgraph/hedera-mirror-node/issues/572)) (done)
-- Delete files once they are parsed ([#259](https://github.com/hashgraph/hedera-mirror-node/issues/259)) (done)
-- Update balance file parser code to new design ([#573](https://github.com/hashgraph/hedera-mirror-node/issues/573))
-  - Share as much filesystem related code as possible between `RecordFileReader` and `BalanceFileParser`
-    (to be renamed to `BalanceStreamReader`)

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.importer.domain;
 
+import com.google.common.base.Suppliers;
 import com.hedera.mirror.importer.exception.FileOperationException;
 import com.hedera.mirror.importer.exception.InvalidStreamFileException;
 import java.io.ByteArrayInputStream;
@@ -25,6 +26,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.function.Supplier;
 import lombok.CustomLog;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -45,8 +47,7 @@ public class StreamFileData {
     @EqualsAndHashCode.Include
     private final StreamFilename streamFilename;
 
-    @EqualsAndHashCode.Include
-    private final byte[] bytes;
+    private final Supplier<byte[]> bytes;
 
     @Getter(lazy = true)
     private final byte[] decompressedBytes = decompressBytes();
@@ -54,15 +55,20 @@ public class StreamFileData {
     private final Instant lastModified;
 
     private static StreamFileData readStreamFileData(File file, StreamFilename streamFilename) {
-        try {
-            byte[] bytes = FileUtils.readFileToByteArray(file);
-            var lastModified = Instant.ofEpochMilli(file.lastModified());
-            return new StreamFileData(streamFilename, bytes, lastModified);
-        } catch (InvalidStreamFileException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new FileOperationException("Unable to read file to byte array", e);
+        if (!file.exists() || !file.canRead() || !file.isFile()) {
+            throw new FileOperationException("Unable to read file " + file);
         }
+
+        var bytes = Suppliers.memoize(() -> {
+            try {
+                return FileUtils.readFileToByteArray(file);
+            } catch (IOException e) {
+                throw new FileOperationException("Unable to read file to byte array", e);
+            }
+        });
+
+        var lastModified = Instant.ofEpochMilli(file.lastModified());
+        return new StreamFileData(streamFilename, bytes, lastModified);
     }
 
     public static StreamFileData from(@NonNull File file) {
@@ -77,12 +83,16 @@ public class StreamFileData {
     // Used for testing String based files like CSVs
     public static StreamFileData from(@NonNull String filename, @NonNull String contents) {
         return new StreamFileData(
-                StreamFilename.from(filename), contents.getBytes(StandardCharsets.UTF_8), Instant.now());
+                StreamFilename.from(filename), () -> contents.getBytes(StandardCharsets.UTF_8), Instant.now());
     }
 
     // Used for testing with raw bytes
     public static StreamFileData from(@NonNull String filename, byte[] bytes) {
-        return new StreamFileData(StreamFilename.from(filename), bytes, Instant.now());
+        return new StreamFileData(StreamFilename.from(filename), () -> bytes, Instant.now());
+    }
+
+    public byte[] getBytes() {
+        return bytes.get();
     }
 
     public InputStream getInputStream() {
@@ -105,10 +115,10 @@ public class StreamFileData {
     private byte[] decompressBytes() {
         var compressor = streamFilename.getCompressor();
         if (StringUtils.isBlank(compressor)) {
-            return bytes;
+            return getBytes();
         }
 
-        try (var inputStream = new ByteArrayInputStream(bytes);
+        try (var inputStream = new ByteArrayInputStream(getBytes());
                 var compressorInputStream =
                         compressorStreamFactory.createCompressorInputStream(compressor, inputStream)) {
             return compressorInputStream.readAllBytes();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -59,7 +59,7 @@ public class StreamFileData {
             throw new FileOperationException("Unable to read file " + file);
         }
 
-        var bytes = Suppliers.memoize(() -> {
+        Supplier<byte[]> bytes = Suppliers.memoize(() -> {
             try {
                 return FileUtils.readFileToByteArray(file);
             } catch (IOException e) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/Downloader.java
@@ -36,6 +36,7 @@ import com.hedera.mirror.importer.domain.StreamFileSignature;
 import com.hedera.mirror.importer.domain.StreamFilename;
 import com.hedera.mirror.importer.downloader.provider.StreamFileProvider;
 import com.hedera.mirror.importer.downloader.provider.TransientProviderException;
+import com.hedera.mirror.importer.exception.FileOperationException;
 import com.hedera.mirror.importer.exception.HashMismatchException;
 import com.hedera.mirror.importer.exception.SignatureVerificationException;
 import com.hedera.mirror.importer.reader.StreamFileReader;
@@ -382,7 +383,7 @@ public abstract class Downloader<T extends StreamFile<I>, I extends StreamItem> 
 
                 onVerified(streamFileData, streamFile, node);
                 return true;
-            } catch (HashMismatchException | TransientProviderException e) {
+            } catch (FileOperationException | HashMismatchException | TransientProviderException e) {
                 log.warn(
                         "Failed processing signature from node {} corresponding to {}. Will retry another node: {}",
                         nodeId,

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/S3StreamFileProvider.java
@@ -66,7 +66,9 @@ public final class S3StreamFileProvider implements StreamFileProvider {
         var responseFuture = s3Client.getObject(request, AsyncResponseTransformer.toBytes());
         return Mono.fromFuture(responseFuture)
                 .map(r -> new StreamFileData(
-                        streamFilename, r.asByteArrayUnsafe(), r.response().lastModified()))
+                        streamFilename,
+                        () -> r.asByteArrayUnsafe(),
+                        r.response().lastModified()))
                 .timeout(properties.getTimeout())
                 .onErrorMap(NoSuchKeyException.class, TransientProviderException::new)
                 .doOnSuccess(s -> log.debug("Finished downloading {}", s3Key));

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ErrataMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ErrataMigration.java
@@ -113,11 +113,6 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
     }
 
     @Override
-    public void onStart() {
-        // Not applicable
-    }
-
-    @Override
     public void onEnd(AccountBalanceFile accountBalanceFile) {
         if (isMainnet()) {
             long consensusTimestamp = accountBalanceFile.getConsensusTimestamp();
@@ -130,11 +125,6 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
             }
             accountBalanceFileRepository.save(accountBalanceFile);
         }
-    }
-
-    @Override
-    public void onError() {
-        // Not applicable
     }
 
     @Override
@@ -223,7 +213,6 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
         var resourceResolver = new PathMatchingResourcePatternResolver();
         Resource[] resources = resourceResolver.getResources("classpath*:errata/mainnet/missingtransactions/*.bin");
         Arrays.sort(resources, Comparator.comparing(Resource::getFilename));
-        recordStreamFileListener.onStart();
         var dateRangeFilter = new DateRangeFilter(importerProperties.getStartDate(), importerProperties.getEndDate());
 
         for (Resource resource : resources) {
@@ -251,7 +240,6 @@ public class ErrataMigration extends RepeatableMigration implements BalanceStrea
                     log.info("Skipped previously processed errata {}", name);
                 }
             } catch (IOException e) {
-                recordStreamFileListener.onError();
                 throw new FileOperationException("Error parsing errata file " + name, e);
             }
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/AbstractStreamFileParser.java
@@ -97,11 +97,7 @@ public abstract class AbstractStreamFileParser<T extends StreamFile<?>> implemen
             }
 
             doParse(streamFile);
-
-            streamFileListener.onEnd(streamFile);
             doFlush(streamFile);
-            last.set(streamFile);
-            streamFile.clear();
 
             log.info(
                     "Successfully processed {} items from {} in {}",
@@ -156,10 +152,7 @@ public abstract class AbstractStreamFileParser<T extends StreamFile<?>> implemen
                 return;
             }
 
-            streamFileListener.onEnd(previous);
             doFlush(previous);
-            last.set(previous);
-            previous.clear();
             log.info(
                     "Successfully batch processed {} items from {} files in {}: {}", count, size, stopwatch, filenames);
 
@@ -176,7 +169,9 @@ public abstract class AbstractStreamFileParser<T extends StreamFile<?>> implemen
     }
 
     protected void doFlush(T streamFile) {
-        // Do nothing
+        streamFileListener.onEnd(streamFile);
+        last.set(streamFile);
+        streamFile.clear();
     }
 
     protected abstract void doParse(T streamFile);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamFileListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamFileListener.java
@@ -21,15 +21,5 @@ import com.hedera.mirror.importer.exception.ImporterException;
 
 public interface StreamFileListener<T extends StreamFile<?>> {
 
-    /**
-     * Called when starting to process a new stream file.
-     */
-    default void onStart() throws ImporterException {}
-
-    default void onEnd(T streamFile) throws ImporterException {}
-
-    /**
-     * Called if an error is encountered during processing of stream file.
-     */
-    default void onError() {}
+    void onEnd(T streamFile) throws ImporterException;
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/StreamFileParser.java
@@ -17,10 +17,13 @@
 package com.hedera.mirror.importer.parser;
 
 import com.hedera.mirror.common.domain.StreamFile;
+import java.util.List;
 
 public interface StreamFileParser<T extends StreamFile<?>> {
 
     void parse(T streamFile);
+
+    void parse(List<T> streamFiles);
 
     ParserProperties getProperties();
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParser.java
@@ -46,7 +46,6 @@ public class AccountBalanceFileParser extends AbstractStreamFileParser<AccountBa
 
     private final BatchPersister batchPersister;
     private final DateRangeCalculator dateRangeCalculator;
-    private final BalanceStreamFileListener streamFileListener;
 
     public AccountBalanceFileParser(
             BatchPersister batchPersister,
@@ -55,10 +54,9 @@ public class AccountBalanceFileParser extends AbstractStreamFileParser<AccountBa
             StreamFileRepository<AccountBalanceFile, Long> accountBalanceFileRepository,
             DateRangeCalculator dateRangeCalculator,
             BalanceStreamFileListener streamFileListener) {
-        super(meterRegistry, parserProperties, accountBalanceFileRepository);
+        super(meterRegistry, parserProperties, streamFileListener, accountBalanceFileRepository);
         this.batchPersister = batchPersister;
         this.dateRangeCalculator = dateRangeCalculator;
-        this.streamFileListener = streamFileListener;
     }
 
     /**
@@ -119,6 +117,5 @@ public class AccountBalanceFileParser extends AbstractStreamFileParser<AccountBa
         Instant loadEnd = Instant.now();
         accountBalanceFile.setCount(count);
         accountBalanceFile.setLoadEnd(loadEnd.getEpochSecond());
-        streamFileListener.onEnd(accountBalanceFile);
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/CompositeBalanceStreamFileListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/CompositeBalanceStreamFileListener.java
@@ -18,11 +18,9 @@ package com.hedera.mirror.importer.parser.balance;
 
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
 import com.hedera.mirror.importer.exception.ImporterException;
-import com.hedera.mirror.importer.parser.StreamFileListener;
 import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
 import jakarta.inject.Named;
 import java.util.List;
-import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 
@@ -35,26 +33,10 @@ public class CompositeBalanceStreamFileListener implements BalanceStreamFileList
     private final AccountBalanceFileRepository accountBalanceFileRepository;
 
     @Override
-    public void onStart() throws ImporterException {
-        onEach(StreamFileListener::onStart);
-    }
-
-    @Override
     public void onEnd(AccountBalanceFile streamFile) throws ImporterException {
         accountBalanceFileRepository.save(streamFile);
         for (int i = 0; i < listeners.size(); i++) {
             listeners.get(i).onEnd(streamFile);
-        }
-    }
-
-    @Override
-    public void onError() {
-        onEach(StreamFileListener::onError);
-    }
-
-    private void onEach(Consumer<BalanceStreamFileListener> consumer) {
-        for (int i = 0; i < listeners.size(); i++) {
-            consumer.accept(listeners.get(i));
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -40,8 +40,8 @@ import io.micrometer.core.instrument.Timer;
 import jakarta.inject.Named;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.retry.annotation.Backoff;
@@ -53,9 +53,7 @@ import reactor.core.publisher.Flux;
 public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
 
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final AtomicReference<RecordFile> last;
     private final RecordItemListener recordItemListener;
-    private final RecordStreamFileListener recordStreamFileListener;
     private final DateRangeCalculator dateRangeCalculator;
     private final ParserContext parserContext;
 
@@ -75,11 +73,9 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
             RecordStreamFileListener recordStreamFileListener,
             DateRangeCalculator dateRangeCalculator,
             ParserContext parserContext) {
-        super(meterRegistry, parserProperties, streamFileRepository);
+        super(meterRegistry, parserProperties, recordStreamFileListener, streamFileRepository);
         this.applicationEventPublisher = applicationEventPublisher;
-        this.last = new AtomicReference<>();
         this.recordItemListener = recordItemListener;
-        this.recordStreamFileListener = recordStreamFileListener;
         this.dateRangeCalculator = dateRangeCalculator;
         this.parserContext = parserContext;
 
@@ -127,43 +123,59 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
             maxAttemptsExpression = "#{@recordParserProperties.getRetry().getMaxAttempts()}")
     @Transactional(timeoutString = "#{@recordParserProperties.getTransactionTimeout().toSeconds()}")
     public synchronized void parse(RecordFile recordFile) {
-        super.parse(recordFile);
+        try {
+            super.parse(recordFile);
+        } finally {
+            parserContext.clear();
+        }
+    }
+
+    @Leader
+    @Override
+    @Retryable(
+            backoff =
+                    @Backoff(
+                            delayExpression = "#{@recordParserProperties.getRetry().getMinBackoff().toMillis()}",
+                            maxDelayExpression = "#{@recordParserProperties.getRetry().getMaxBackoff().toMillis()}",
+                            multiplierExpression = "#{@recordParserProperties.getRetry().getMultiplier()}"),
+            retryFor = Throwable.class,
+            noRetryFor = OutOfMemoryError.class,
+            maxAttemptsExpression = "#{@recordParserProperties.getRetry().getMaxAttempts()}")
+    @Transactional(timeoutString = "#{@recordParserProperties.getTransactionTimeout().toSeconds()}")
+    public synchronized void parse(List<RecordFile> recordFiles) {
+        try {
+            super.parse(recordFiles);
+        } finally {
+            parserContext.clear();
+        }
     }
 
     @Override
     protected void doParse(RecordFile recordFile) {
         DateRangeFilter dateRangeFilter = dateRangeCalculator.getFilter(parserProperties.getStreamType());
+        Flux<RecordItem> recordItems = recordFile.getItems();
 
-        try {
-            Flux<RecordItem> recordItems = recordFile.getItems();
-
-            if (log.isDebugEnabled() || log.isTraceEnabled()) {
-                recordItems = recordItems.doOnNext(this::logItem);
-            }
-
-            recordStreamFileListener.onStart();
-            var aggregator = new RecordItemAggregator();
-
-            long count = recordItems
-                    .doOnNext(aggregator::accept)
-                    .filter(r -> dateRangeFilter.filter(r.getConsensusTimestamp()))
-                    .doOnNext(recordItemListener::onItem)
-                    .doOnNext(this::recordMetrics)
-                    .count()
-                    .block();
-
-            recordFile.setCount(count);
-            aggregator.update(recordFile);
-            updateIndex(recordFile);
-            recordStreamFileListener.onEnd(recordFile);
-            applicationEventPublisher.publishEvent(new RecordFileParsedEvent(this, recordFile.getConsensusEnd()));
-            last.set(recordFile);
-        } catch (Exception ex) {
-            recordStreamFileListener.onError();
-            throw ex;
-        } finally {
-            parserContext.clear();
+        if (log.isDebugEnabled() || log.isTraceEnabled()) {
+            recordItems = recordItems.doOnNext(this::logItem);
         }
+
+        var aggregator = new RecordItemAggregator();
+
+        long count = recordItems
+                .doOnNext(aggregator::accept)
+                .filter(r -> dateRangeFilter.filter(r.getConsensusTimestamp()))
+                .doOnNext(recordItemListener::onItem)
+                .doOnNext(this::recordMetrics)
+                .count()
+                .block();
+
+        recordFile.setCount(count);
+        aggregator.update(recordFile);
+        updateIndex(recordFile);
+
+        parserContext.add(recordFile);
+        parserContext.addAll(recordFile.getSidecars());
+        applicationEventPublisher.publishEvent(new RecordFileParsedEvent(this, recordFile.getConsensusEnd()));
     }
 
     private void logItem(RecordItem recordItem) {
@@ -190,19 +202,14 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
 
     // Correct v5 block numbers once we receive a v6 block with a canonical number
     private void updateIndex(RecordFile recordFile) {
-        var lastRecordFile = last.get();
-        var recordFileRepository = (RecordFileRepository) streamFileRepository;
-
-        if (lastRecordFile == null) {
-            lastRecordFile = recordFileRepository.findLatest().orElse(null);
-        }
+        var lastRecordFile = getLast();
 
         if (lastRecordFile != null && lastRecordFile.getVersion() < VERSION && recordFile.getVersion() >= VERSION) {
             long offset = recordFile.getIndex() - lastRecordFile.getIndex() - 1;
 
-            if (offset != 0) {
+            if (offset != 0 && streamFileRepository instanceof RecordFileRepository repository) {
                 var stopwatch = Stopwatch.createStarted();
-                int count = recordFileRepository.updateIndex(offset);
+                int count = repository.updateIndex(offset);
                 log.info("Updated {} blocks with offset {} in {}", count, offset, stopwatch);
             }
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -151,6 +151,11 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
     }
 
     @Override
+    protected void doFlush(RecordFile streamFile) {
+        applicationEventPublisher.publishEvent(new RecordFileParsedEvent(this, streamFile.getConsensusEnd()));
+    }
+
+    @Override
     protected void doParse(RecordFile recordFile) {
         DateRangeFilter dateRangeFilter = dateRangeCalculator.getFilter(parserProperties.getStreamType());
         Flux<RecordItem> recordItems = recordFile.getItems();
@@ -175,7 +180,6 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
 
         parserContext.add(recordFile);
         parserContext.addAll(recordFile.getSidecars());
-        applicationEventPublisher.publishEvent(new RecordFileParsedEvent(this, recordFile.getConsensusEnd()));
     }
 
     private void logItem(RecordItem recordItem) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/RecordFileParser.java
@@ -152,6 +152,7 @@ public class RecordFileParser extends AbstractStreamFileParser<RecordFile> {
 
     @Override
     protected void doFlush(RecordFile streamFile) {
+        super.doFlush(streamFile);
         applicationEventPublisher.publishEvent(new RecordFileParsedEvent(this, streamFile.getConsensusEnd()));
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeRecordStreamFileListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/CompositeRecordStreamFileListener.java
@@ -18,11 +18,9 @@ package com.hedera.mirror.importer.parser.record.entity;
 
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.importer.exception.ImporterException;
-import com.hedera.mirror.importer.parser.StreamFileListener;
 import com.hedera.mirror.importer.parser.record.RecordStreamFileListener;
 import jakarta.inject.Named;
 import java.util.List;
-import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 
@@ -34,25 +32,9 @@ public class CompositeRecordStreamFileListener implements RecordStreamFileListen
     private final List<RecordStreamFileListener> listeners;
 
     @Override
-    public void onStart() throws ImporterException {
-        onEach(StreamFileListener::onStart);
-    }
-
-    @Override
     public void onEnd(RecordFile streamFile) throws ImporterException {
         for (int i = 0; i < listeners.size(); i++) {
             listeners.get(i).onEnd(streamFile);
-        }
-    }
-
-    @Override
-    public void onError() {
-        onEach(StreamFileListener::onError);
-    }
-
-    private void onEach(Consumer<RecordStreamFileListener> consumer) {
-        for (int i = 0; i < listeners.size(); i++) {
-            consumer.accept(listeners.get(i));
         }
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -96,10 +96,6 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
 
     @Override
     public void onEnd(RecordFile recordFile) {
-        if (recordFile != null) {
-            context.add(recordFile);
-            context.addAll(recordFile.getSidecars());
-        }
         flush();
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplIntegrationTest.java
@@ -827,7 +827,6 @@ class ContractResultServiceImplIntegrationTest extends ImporterIntegrationTest {
                             .name(filename))
                     .get();
 
-            recordStreamFileListener.onStart();
             contractResultService.process(recordItem, transaction);
             // commit, close connection
             recordStreamFileListener.onEnd(recordFile);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/provider/AbstractStreamFileProviderTest.java
@@ -184,7 +184,8 @@ abstract class AbstractStreamFileProviderTest {
         fileCopier.copy();
         dataPath.toFile().setExecutable(false);
         var data = streamFileData(node, "2022-07-13T08_46_08.041986003Z.rcd_sig");
-        StepVerifier.withVirtualTime(() -> streamFileProvider.get(node, data.getStreamFilename()))
+        StepVerifier.withVirtualTime(() ->
+                        streamFileProvider.get(node, data.getStreamFilename()).map(StreamFileData::getBytes))
                 .thenAwait(Duration.ofSeconds(10L))
                 .expectError(RuntimeException.class)
                 .verify(Duration.ofSeconds(10L));
@@ -268,7 +269,7 @@ abstract class AbstractStreamFileProviderTest {
                     .resolve(streamFilename.getFileType() == SIDECAR ? SIDECAR_FOLDER : "")
                     .resolve(filename);
             var bytes = FileUtils.readFileToByteArray(repoDataPath.toFile());
-            return new StreamFileData(streamFilename, bytes, Instant.now());
+            return new StreamFileData(streamFilename, () -> bytes, Instant.now());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ErrataMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ErrataMigrationTest.java
@@ -233,15 +233,11 @@ public class ErrataMigrationTest extends ImporterIntegrationTest {
         AccountBalanceFile accountBalanceFile =
                 domainBuilder.accountBalanceFile().get();
         accountBalanceFile.setConsensusTimestamp(BAD_TIMESTAMP1);
-        errataMigration.onStart(); // Call to increase test coverage of no-op methods
-        errataMigration.onError();
         errataMigration.onEnd(accountBalanceFile);
         assertThat(accountBalanceFile.getTimeOffset()).isEqualTo(-1);
 
         accountBalanceFile = domainBuilder.accountBalanceFile().get();
         accountBalanceFile.setConsensusTimestamp(BAD_TIMESTAMP_FIXED_OFFSET);
-        errataMigration.onStart(); // Call to increase test coverage of no-op methods
-        errataMigration.onError();
         errataMigration.onEnd(accountBalanceFile);
         assertThat(accountBalanceFile.getTimeOffset()).isEqualTo(53);
     }
@@ -251,8 +247,6 @@ public class ErrataMigrationTest extends ImporterIntegrationTest {
         importerProperties.setNetwork(ImporterProperties.HederaNetwork.TESTNET);
         AccountBalanceFile accountBalanceFile = new AccountBalanceFile();
         accountBalanceFile.setConsensusTimestamp(BAD_TIMESTAMP1);
-        errataMigration.onStart(); // Call to increase test coverage of no-op methods
-        errataMigration.onError();
         errataMigration.onEnd(accountBalanceFile);
         assertThat(accountBalanceFile.getTimeOffset()).isZero();
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
@@ -24,7 +24,6 @@ import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
 import com.hedera.mirror.importer.ImporterProperties;
-import com.hedera.mirror.importer.parser.StreamFileParser;
 import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
 import com.hedera.mirror.importer.repository.AccountBalanceRepository;
 import com.hedera.mirror.importer.repository.TokenBalanceRepository;
@@ -41,7 +40,7 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
 
     private final AccountBalanceBuilder accountBalanceBuilder;
     private final AccountBalanceFileBuilder accountBalanceFileBuilder;
-    private final StreamFileParser<AccountBalanceFile> accountBalanceFileParser;
+    private final AccountBalanceFileParser accountBalanceFileParser;
     private final AccountBalanceFileRepository accountBalanceFileRepository;
     private final AccountBalanceRepository accountBalanceRepository;
     private final TokenBalanceRepository tokenBalanceRepository;
@@ -50,6 +49,7 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
 
     @BeforeEach
     void setup() {
+        accountBalanceFileParser.clear();
         parserProperties.setEnabled(true);
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -99,7 +99,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
         if (parsed) {
             verify(recordItemListener).onItem(recordItem);
             verify(recordStreamFileListener).onEnd(recordFile);
-            verify(recordStreamFileListener, never()).onError();
             // Can't verify the event object since ApplicationEvent has a timestamp field for when the event happened
             verify(applicationEventPublisher)
                     .publishEvent(argThat(e -> e instanceof RecordFileParsedEvent recordFileParsedEvent
@@ -107,9 +106,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
         } else {
             if (dbError) {
                 verify(recordStreamFileListener, never()).onEnd(recordFile);
-                verify(recordStreamFileListener).onError();
-            } else {
-                verify(recordStreamFileListener, never()).onStart();
             }
 
             verify(applicationEventPublisher, never()).publishEvent(any());
@@ -171,7 +167,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
         parser.parse(recordFile);
 
         // then
-        verify(recordStreamFileListener).onStart();
         if (offset >= 0) {
             verify(recordItemListener).onItem(firstItem);
         }
@@ -217,7 +212,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
         assertAll(
                 () -> assertEquals(10000000000L + 100000000000L + 1000000000000L, recordFile.getGasUsed()),
                 () -> assertArrayEquals(expectedLogBloom, recordFile.getLogsBloom()),
-                () -> verify(recordStreamFileListener, times(1)).onStart(),
                 () -> verify(recordStreamFileListener, times(1)).onEnd(recordFile),
                 () -> verify(recordItemListener, times(1)).onItem(recordItem1),
                 () -> verify(recordItemListener, times(1)).onItem(recordItem2),
@@ -238,7 +232,6 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
         parser.parse(recordFile);
 
         // then
-        verify(recordStreamFileListener).onStart();
         if (offset < 0) {
             verify(recordItemListener).onItem(firstItem);
         }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -59,6 +59,7 @@ import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -286,6 +287,19 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
 
         // then
         assertParsed(streamFile, true, false);
+    }
+
+    @Test
+    void emptyList() {
+        // given
+        when(recordFileRepository.findLatest()).thenReturn(Optional.empty());
+
+        // when
+        parser.parse(List.of());
+
+        // then
+        verify(recordStreamFileListener, never()).onEnd(any());
+        verify(applicationEventPublisher, never()).publishEvent(any());
     }
 
     @Test

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/AbstractEntityRecordItemListenerTest.java
@@ -215,7 +215,6 @@ public abstract class AbstractEntityRecordItemListenerTest extends ImporterInteg
             long consensusStart = recordItem.getConsensusTimestamp();
             RecordFile recordFile = recordFile(consensusStart, consensusStart + 1, filename);
 
-            recordStreamFileListener.onStart();
             entityRecordItemListener.onItem(recordItem);
             // commit, close connection
             recordStreamFileListener.onEnd(recordFile);
@@ -230,8 +229,6 @@ public abstract class AbstractEntityRecordItemListenerTest extends ImporterInteg
             long consensusStart = recordItems.get(0).getConsensusTimestamp();
             long consensusEnd = recordItems.get(recordItems.size() - 1).getConsensusTimestamp();
             RecordFile recordFile = recordFile(consensusStart, consensusEnd, filename);
-
-            recordStreamFileListener.onStart();
 
             // process each record item
             for (RecordItem recordItem : recordItems) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -167,7 +167,6 @@ class SqlEntityListenerTest extends ImporterIntegrationTest {
         entityProperties.getPersist().setEntityHistory(true);
         entityProperties.getPersist().setTransactionHash(false);
         entityProperties.getPersist().setTrackBalance(true);
-        sqlEntityListener.onStart();
     }
 
     @AfterEach
@@ -723,21 +722,6 @@ class SqlEntityListenerTest extends ImporterIntegrationTest {
         nonEmptyCustomFee.setTimestampUpper(emptyCustomFee.getTimestampLower());
         assertThat(customFeeRepository.findAll()).containsExactly(emptyCustomFee);
         assertThat(findHistory(CustomFee.class)).containsExactly(nonEmptyCustomFee);
-    }
-
-    @Test
-    void onEnd() {
-        var recordFile = domainBuilder.recordFile().get();
-        sqlEntityListener.onEnd(recordFile);
-        assertThat(recordFileRepository.findAll()).containsExactly(recordFile);
-        assertThat(sidecarFileRepository.findAll()).containsExactlyInAnyOrderElementsOf(recordFile.getSidecars());
-    }
-
-    @Test
-    void onEndNull() {
-        sqlEntityListener.onEnd(null);
-        assertThat(recordFileRepository.count()).isZero();
-        assertThat(sidecarFileRepository.count()).isZero();
     }
 
     @ParameterizedTest
@@ -3018,8 +3002,6 @@ class SqlEntityListenerTest extends ImporterIntegrationTest {
                 domainBuilder.recordFile().customize(r -> r.sidecars(List.of())).get();
         transactionTemplate.executeWithoutResult(status -> sqlEntityListener.onEnd(recordFile));
         parserContext.clear();
-
-        assertThat(recordFileRepository.findAll()).contains(recordFile);
     }
 
     private ContractState getContractState(ContractStateChange contractStateChange, long createdTimestamp) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorIntegrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorIntegrationTest.java
@@ -390,7 +390,6 @@ class EntityStakeCalculatorIntegrationTest extends ImporterIntegrationTest {
                     .customize(rf ->
                             rf.consensusStart(timestamp).consensusEnd(timestamp).name(filename))
                     .get();
-            recordStreamFileListener.onStart();
             entityRecordItemListener.onItem(recordItem);
             recordStreamFileListener.onEnd(recordFile);
         });

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/topic/TopicMessageLookupEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/topic/TopicMessageLookupEntityListenerTest.java
@@ -225,12 +225,10 @@ class TopicMessageLookupEntityListenerTest extends AbstractTopicMessageLookupInt
 
     private void completeFile(List<TopicMessage> topicMessages, RecordFile recordFile, boolean success) {
         transactionTemplate.executeWithoutResult(s -> {
-            recordStreamFileListener.onStart();
             topicMessages.forEach(entityListener::onTopicMessage);
-            recordStreamFileListener.onEnd(recordFile);
-
-            if (!success) {
-                recordStreamFileListener.onError();
+            if (success) {
+                recordStreamFileListener.onEnd(recordFile);
+            } else {
                 s.setRollbackOnly();
             }
         });


### PR DESCRIPTION
**Description**:

* Add a `StreamFileParser.parse(List<StreamFile>)`
* Change parser last stream file lookup from a query to a cached value
* Change `StreamFileData` to lazy load bytes from files
* Change `TopicMessageLookupListener` to use `ParserContext` instead of internal state
* Move `RecordFile` persistence from `SqlEntityListener` to `RecordFileParser`
* Remove unused `onStart()` and `onError()` methods from `StreamFileListener`
* Update release checklist

**Related issue(s)**:

Fixes #7316

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
