### PR TITLE
Improve entity stake calculation in v2

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorImpl.java
@@ -54,8 +54,7 @@ public class EntityStakeCalculatorImpl implements EntityStakeCalculator {
                 }
 
                 var stopwatch = Stopwatch.createStarted();
-                var lastEndStakePeriod =
-                        entityStakeRepository.getEndStakePeriod().orElse(0L);
+                var lastEndStakePeriod = entityStakeRepository.getEndStakePeriod().orElse(0L);
                 transactionOperations.executeWithoutResult(s -> {
                     entityStakeRepository.lockFromConcurrentUpdates();
                     entityStakeRepository.createEntityStateStart();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/staking/EntityStakeCalculatorImpl.java
@@ -54,7 +54,8 @@ public class EntityStakeCalculatorImpl implements EntityStakeCalculator {
                 }
 
                 var stopwatch = Stopwatch.createStarted();
-                var lastEndStakePeriod = entityStakeRepository.getEndStakePeriod().orElse(0L);
+                var lastEndStakePeriod =
+                        entityStakeRepository.getEndStakePeriod().orElse(0L);
                 transactionOperations.executeWithoutResult(s -> {
                     entityStakeRepository.lockFromConcurrentUpdates();
                     entityStakeRepository.createEntityStateStart();

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryCustom.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryCustom.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.mirror.importer.repository;
 
 interface EntityStakeRepositoryCustom {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryCustom.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryCustom.java
@@ -1,0 +1,6 @@
+package com.hedera.mirror.importer.repository;
+
+interface EntityStakeRepositoryCustom {
+
+    void createEntityStateStart();
+}

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryCustomImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryCustomImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.mirror.importer.repository;
 
 import jakarta.inject.Named;
@@ -15,92 +31,96 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 class EntityStakeRepositoryCustomImpl implements EntityStakeRepositoryCustom {
 
-    private static final String CLEANUP_TABLE_SQL = """
+    private static final String CLEANUP_TABLE_SQL =
+            """
             drop index if exists entity_state_start__id;
             drop index if exists entity_state_start__staked_account_id;
             truncate entity_state_start;
             """;
-    private static final String CREATE_ENTITY_STATE_START_SQL = """
-           with entity_state as (
-             select
-               id,
-               staked_account_id,
-               staked_node_id,
-               stake_period_start
-             from entity
-             where id = 800 or (
-               deleted is not true and
-               type in ('ACCOUNT', 'CONTRACT') and
-               timestamp_range @> :endPeriodTimestamp and
-               (staked_account_id <> 0 or (decline_reward is false and staked_node_id <> -1))
-             )
-             union all
-             select *
-             from (
-               select
-                 distinct on (id)
-                 id,
-                 staked_account_id,
-                 staked_node_id,
-                 stake_period_start
-               from entity_history
-               where id <> 800 and (
-                 deleted is not true and
-                 type in ('ACCOUNT', 'CONTRACT') and
-                 timestamp_range @> :endPeriodTimestamp and
-                 (staked_account_id <> 0 or (decline_reward is false and staked_node_id <> -1))
-               )
-               order by id, timestamp_range desc
-             ) as latest_history
-           ), balance_snapshot as (
-             select distinct on (account_id) account_id, balance
-             from account_balance
-             where consensus_timestamp > :lowerBalanceTimestamp and consensus_timestamp <= :balanceSnapshotTimestamp
-             order by account_id, consensus_timestamp desc
-           )
-           insert into entity_state_start (balance, id, staked_account_id, staked_node_id, stake_period_start)
-           select
-             coalesce(balance, 0) + coalesce(change, 0),
-             id,
-             coalesce(staked_account_id, 0),
-             coalesce(staked_node_id, -1),
-             coalesce(stake_period_start, -1)
-           from entity_state
-           left join balance_snapshot on account_id = id
-           left join (
-             select entity_id, sum(amount) as change
-             from crypto_transfer
-             where consensus_timestamp <= :endPeriodTimestamp and consensus_timestamp > :balanceSnapshotTimestamp
-             group by entity_id
-           ) as balance_change on entity_id = id;
-           """;
-    private static final String CREATE_TABLE_INDEX_DDL = """
-           create index if not exists entity_state_start__id on entity_state_start (id);
-           create index if not exists entity_state_start__staked_account_id
-             on entity_state_start (staked_account_id) where staked_account_id <> 0;
-           """;
-    private static final String GET_END_PERIOD_TIMESTAMP_SQL = """
-          select consensus_timestamp
-          from node_stake
-          where epoch_day >= coalesce(
-            (select end_stake_period + 1 from entity_stake where id = 800),
-            (
-              select epoch_day
-              from node_stake
-              where consensus_timestamp > (
-                select lower(timestamp_range) as timestamp from entity where id = 800
-                union all
-                select lower(timestamp_range) as timestamp from entity_history where id = 800
-                order by timestamp
+    private static final String CREATE_ENTITY_STATE_START_SQL =
+            """
+            with entity_state as (
+              select
+                id,
+                staked_account_id,
+                staked_node_id,
+                stake_period_start
+              from entity
+              where id = 800 or (
+                deleted is not true and
+                type in ('ACCOUNT', 'CONTRACT') and
+                timestamp_range @> :endPeriodTimestamp and
+                (staked_account_id <> 0 or (decline_reward is false and staked_node_id <> -1))
+              )
+              union all
+              select *
+              from (
+                select
+                  distinct on (id)
+                  id,
+                  staked_account_id,
+                  staked_node_id,
+                  stake_period_start
+                from entity_history
+                where id <> 800 and (
+                  deleted is not true and
+                  type in ('ACCOUNT', 'CONTRACT') and
+                  timestamp_range @> :endPeriodTimestamp and
+                  (staked_account_id <> 0 or (decline_reward is false and staked_node_id <> -1))
+                )
+                order by id, timestamp_range desc
+              ) as latest_history
+            ), balance_snapshot as (
+              select distinct on (account_id) account_id, balance
+              from account_balance
+              where consensus_timestamp > :lowerBalanceTimestamp and consensus_timestamp <= :balanceSnapshotTimestamp
+              order by account_id, consensus_timestamp desc
+            )
+            insert into entity_state_start (balance, id, staked_account_id, staked_node_id, stake_period_start)
+            select
+              coalesce(balance, 0) + coalesce(change, 0),
+              id,
+              coalesce(staked_account_id, 0),
+              coalesce(staked_node_id, -1),
+              coalesce(stake_period_start, -1)
+            from entity_state
+            left join balance_snapshot on account_id = id
+            left join (
+              select entity_id, sum(amount) as change
+              from crypto_transfer
+              where consensus_timestamp <= :endPeriodTimestamp and consensus_timestamp > :balanceSnapshotTimestamp
+              group by entity_id
+            ) as balance_change on entity_id = id;
+            """;
+    private static final String CREATE_TABLE_INDEX_DDL =
+            """
+            create index if not exists entity_state_start__id on entity_state_start (id);
+            create index if not exists entity_state_start__staked_account_id
+              on entity_state_start (staked_account_id) where staked_account_id <> 0;
+            """;
+    private static final String GET_END_PERIOD_TIMESTAMP_SQL =
+            """
+            select consensus_timestamp
+            from node_stake
+            where epoch_day >= coalesce(
+              (select end_stake_period + 1 from entity_stake where id = 800),
+              (
+                select epoch_day
+                from node_stake
+                where consensus_timestamp > (
+                  select lower(timestamp_range) as timestamp from entity where id = 800
+                  union all
+                  select lower(timestamp_range) as timestamp from entity_history where id = 800
+                  order by timestamp
+                  limit 1
+                )
+                order by consensus_timestamp
                 limit 1
               )
-              order by consensus_timestamp
-              limit 1
             )
-          )
-          order by epoch_day
-          limit 1
-          """;
+            order by epoch_day
+            limit 1
+            """;
     private static final long ONE_MONTH_IN_NS = Duration.ofDays(31).toNanos();
 
     private final AccountBalanceRepository accountBalanceRepository;
@@ -120,7 +140,8 @@ class EntityStakeRepositoryCustomImpl implements EntityStakeRepositoryCustom {
         // Add 1 for upper because the upper in getMaxConsensusTimestampInRange is exclusive
         long upperTimestamp = endPeriodTimestamp.get() + 1;
         long lowerTimestamp = upperTimestamp - ONE_MONTH_IN_NS;
-        var balanceSnapshotTimestamp = accountBalanceRepository.getMaxConsensusTimestampInRange(lowerTimestamp, upperTimestamp);
+        var balanceSnapshotTimestamp =
+                accountBalanceRepository.getMaxConsensusTimestampInRange(lowerTimestamp, upperTimestamp);
         if (balanceSnapshotTimestamp.isEmpty()) {
             return;
         }
@@ -142,5 +163,4 @@ class EntityStakeRepositoryCustomImpl implements EntityStakeRepositoryCustom {
             return Optional.empty();
         }
     }
-
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryCustomImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryCustomImpl.java
@@ -1,0 +1,146 @@
+package com.hedera.mirror.importer.repository;
+
+import jakarta.inject.Named;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@Named
+@RequiredArgsConstructor
+class EntityStakeRepositoryCustomImpl implements EntityStakeRepositoryCustom {
+
+    private static final String CLEANUP_TABLE_SQL = """
+            drop index if exists entity_state_start__id;
+            drop index if exists entity_state_start__staked_account_id;
+            truncate entity_state_start;
+            """;
+    private static final String CREATE_ENTITY_STATE_START_SQL = """
+           with entity_state as (
+             select
+               id,
+               staked_account_id,
+               staked_node_id,
+               stake_period_start
+             from entity
+             where id = 800 or (
+               deleted is not true and
+               type in ('ACCOUNT', 'CONTRACT') and
+               timestamp_range @> :endPeriodTimestamp and
+               (staked_account_id <> 0 or (decline_reward is false and staked_node_id <> -1))
+             )
+             union all
+             select *
+             from (
+               select
+                 distinct on (id)
+                 id,
+                 staked_account_id,
+                 staked_node_id,
+                 stake_period_start
+               from entity_history
+               where id <> 800 and (
+                 deleted is not true and
+                 type in ('ACCOUNT', 'CONTRACT') and
+                 timestamp_range @> :endPeriodTimestamp and
+                 (staked_account_id <> 0 or (decline_reward is false and staked_node_id <> -1))
+               )
+               order by id, timestamp_range desc
+             ) as latest_history
+           ), balance_snapshot as (
+             select distinct on (account_id) account_id, balance
+             from account_balance
+             where consensus_timestamp > :lowerBalanceTimestamp and consensus_timestamp <= :balanceSnapshotTimestamp
+             order by account_id, consensus_timestamp desc
+           )
+           insert into entity_state_start (balance, id, staked_account_id, staked_node_id, stake_period_start)
+           select
+             coalesce(balance, 0) + coalesce(change, 0),
+             id,
+             coalesce(staked_account_id, 0),
+             coalesce(staked_node_id, -1),
+             coalesce(stake_period_start, -1)
+           from entity_state
+           left join balance_snapshot on account_id = id
+           left join (
+             select entity_id, sum(amount) as change
+             from crypto_transfer
+             where consensus_timestamp <= :endPeriodTimestamp and consensus_timestamp > :balanceSnapshotTimestamp
+             group by entity_id
+           ) as balance_change on entity_id = id;
+           """;
+    private static final String CREATE_TABLE_INDEX_DDL = """
+           create index if not exists entity_state_start__id on entity_state_start (id);
+           create index if not exists entity_state_start__staked_account_id
+             on entity_state_start (staked_account_id) where staked_account_id <> 0;
+           """;
+    private static final String GET_END_PERIOD_TIMESTAMP_SQL = """
+          select consensus_timestamp
+          from node_stake
+          where epoch_day >= coalesce(
+            (select end_stake_period + 1 from entity_stake where id = 800),
+            (
+              select epoch_day
+              from node_stake
+              where consensus_timestamp > (
+                select lower(timestamp_range) as timestamp from entity where id = 800
+                union all
+                select lower(timestamp_range) as timestamp from entity_history where id = 800
+                order by timestamp
+                limit 1
+              )
+              order by consensus_timestamp
+              limit 1
+            )
+          )
+          order by epoch_day
+          limit 1
+          """;
+    private static final long ONE_MONTH_IN_NS = Duration.ofDays(31).toNanos();
+
+    private final AccountBalanceRepository accountBalanceRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    @Modifying
+    @Override
+    @Transactional
+    public void createEntityStateStart() {
+        jdbcTemplate.execute(CLEANUP_TABLE_SQL);
+
+        var endPeriodTimestamp = getEndPeriodTimestamp();
+        if (endPeriodTimestamp.isEmpty()) {
+            return;
+        }
+
+        // Add 1 for upper because the upper in getMaxConsensusTimestampInRange is exclusive
+        long upperTimestamp = endPeriodTimestamp.get() + 1;
+        long lowerTimestamp = upperTimestamp - ONE_MONTH_IN_NS;
+        var balanceSnapshotTimestamp = accountBalanceRepository.getMaxConsensusTimestampInRange(lowerTimestamp, upperTimestamp);
+        if (balanceSnapshotTimestamp.isEmpty()) {
+            return;
+        }
+
+        long lowerBalanceTimestamp = balanceSnapshotTimestamp.get() - ONE_MONTH_IN_NS;
+        var params = new MapSqlParameterSource()
+                .addValue("balanceSnapshotTimestamp", balanceSnapshotTimestamp.get())
+                .addValue("endPeriodTimestamp", endPeriodTimestamp.get())
+                .addValue("lowerBalanceTimestamp", lowerBalanceTimestamp);
+        var namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
+        namedParameterJdbcTemplate.update(CREATE_ENTITY_STATE_START_SQL, params);
+        jdbcTemplate.execute(CREATE_TABLE_INDEX_DDL);
+    }
+
+    private Optional<Long> getEndPeriodTimestamp() {
+        try {
+            return Optional.ofNullable(jdbcTemplate.queryForObject(GET_END_PERIOD_TIMESTAMP_SQL, Long.class));
+        } catch (EmptyResultDataAccessException ex) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/hedera-mirror-importer/src/main/resources/db/migration/common/R__01_temp_tables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/common/R__01_temp_tables.sql
@@ -4,6 +4,8 @@ drop table if exists ${tempSchema}.contract_state_temp;
 drop table if exists ${tempSchema}.crypto_allowance_temp;
 drop table if exists ${tempSchema}.custom_fee_temp;
 drop table if exists ${tempSchema}.dissociate_token_transfer;
+drop table if exists ${tempSchema}.entity_stake_temp;
+drop table if exists ${tempSchema}.entity_state_start;
 drop table if exists ${tempSchema}.entity_temp;
 drop table if exists ${tempSchema}.nft_allowance_temp;
 drop table if exists ${tempSchema}.nft_temp;
@@ -17,6 +19,7 @@ create unlogged table if not exists ${tempSchema}.contract_state_temp as table c
 create unlogged table if not exists ${tempSchema}.crypto_allowance_temp as table crypto_allowance limit 0;
 create unlogged table if not exists ${tempSchema}.custom_fee_temp as table custom_fee limit 0;
 create unlogged table if not exists ${tempSchema}.dissociate_token_transfer as table token_transfer limit 0;
+create unlogged table if not exists ${tempSchema}.entity_stake_temp as table entity_stake limit 0;
 create unlogged table if not exists ${tempSchema}.entity_temp as table entity limit 0;
 create unlogged table if not exists ${tempSchema}.nft_allowance_temp as table nft_allowance limit 0;
 create unlogged table if not exists ${tempSchema}.nft_temp as table nft limit 0;
@@ -26,10 +29,20 @@ create unlogged table if not exists ${tempSchema}.token_allowance_temp as table 
 create unlogged table if not exists ${tempSchema}.token_temp as table token limit 0;
 create unlogged table if not exists ${tempSchema}.topic_message_lookup_temp as table topic_message_lookup limit 0;
 
+create unlogged table if not exists ${tempSchema}.entity_state_start (
+  balance            bigint not null,
+  id                 bigint not null,
+  staked_account_id  bigint not null,
+  staked_node_id     bigint not null,
+  stake_period_start bigint not null
+);
+
 alter table if exists ${tempSchema}.contract_state_temp owner to temporary_admin;
 alter table if exists ${tempSchema}.crypto_allowance_temp owner to temporary_admin;
 alter table if exists ${tempSchema}.custom_fee_temp owner to temporary_admin;
 alter table if exists ${tempSchema}.dissociate_token_transfer owner to temporary_admin;
+alter table if exists ${tempSchema}.entity_stake_temp owner to temporary_admin;
+alter table if exists ${tempSchema}.entity_state_start owner to temporary_admin;
 alter table if exists ${tempSchema}.entity_temp owner to temporary_admin;
 alter table if exists ${tempSchema}.nft_allowance_temp owner to temporary_admin;
 alter table if exists ${tempSchema}.nft_temp owner to temporary_admin;
@@ -65,6 +78,14 @@ alter table if exists ${tempSchema}.custom_fee_temp set (
     );
 
 alter table if exists ${tempSchema}.dissociate_token_transfer set (
+    autovacuum_enabled = false
+    );
+
+alter table if exists ${tempSchema}.entity_stake_temp set (
+    autovacuum_enabled = false
+    );
+
+alter table if exists ${tempSchema}.entity_state_start set (
     autovacuum_enabled = false
     );
 

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/R__02_temp_table_distribution.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/R__02_temp_table_distribution.sql
@@ -3,7 +3,9 @@
 select create_distributed_table('${tempSchema}.contract_state_temp', 'contract_id', colocate_with => 'contract_state');
 select create_distributed_table('${tempSchema}.crypto_allowance_temp', 'owner', colocate_with => 'crypto_allowance');
 select create_distributed_table('${tempSchema}.custom_fee_temp', 'token_id', colocate_with => 'custom_fee');
-select create_distributed_table('${tempSchema}.entity_temp', 'id', colocate_with := 'entity');
+select create_distributed_table('${tempSchema}.entity_stake_temp', 'id', colocate_with => 'entity_stake');
+select create_distributed_table('${tempSchema}.entity_state_start', 'id', colocate_with => 'entity');
+select create_distributed_table('${tempSchema}.entity_temp', 'id', colocate_with => 'entity');
 select create_distributed_table('${tempSchema}.nft_allowance_temp', 'owner', colocate_with => 'nft_allowance');
 select create_distributed_table('${tempSchema}.nft_temp', 'token_id', colocate_with => 'nft');
 select create_distributed_table('${tempSchema}.schedule_temp', 'schedule_id', colocate_with => 'schedule');

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryTest.java
@@ -276,8 +276,7 @@ class EntityStakeRepositoryTest extends AbstractRepositoryTest {
                 .customize(ns -> ns.consensusTimestamp(timestamp).epochDay(epochDay))
                 .persist();
         domainBuilder
-                .entity()
-                .customize(e -> e.timestampRange(Range.atLeast(timestamp - 5000L)))
+                .entity(STAKING_REWARD_ACCOUNT, timestamp - 5000L)
                 .persist();
 
         transactionOperations.executeWithoutResult(s -> {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/repository/EntityStakeRepositoryTest.java
@@ -275,9 +275,7 @@ class EntityStakeRepositoryTest extends AbstractRepositoryTest {
                 .nodeStake()
                 .customize(ns -> ns.consensusTimestamp(timestamp).epochDay(epochDay))
                 .persist();
-        domainBuilder
-                .entity(STAKING_REWARD_ACCOUNT, timestamp - 5000L)
-                .persist();
+        domainBuilder.entity(STAKING_REWARD_ACCOUNT, timestamp - 5000L).persist();
 
         transactionOperations.executeWithoutResult(s -> {
             // when


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR improves entity stake calculation in v2

- Change `entity_stake_temp` to be a permanent table in temp schema, distribute the the table and colocate it with `entity_stake` in v2
- Change`entity_state_start` to be a permanent table in temp schema, distribute the table and colocate it with `entity` in v2
- Break down the SQL for creating `entity_state_start` to minimize the number of timestamp partitions scanned
- Optimize the SQL query for `EntityStakeRepository.updated()`

**Related issue(s)**:

Fixes #7663

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Tested with citus db with the range of crypto transfers to scan limited to 600s

- `createEntityStateStart` takes about 30s when cold (all data read from disk), 2s when hot (the second run, most data it needs is in memory0
- `updateEntityStake` takes about 20s for ~54000 entities

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
