### PR TITLE
Expose the entrypoint command using an env var named ENTRYPOINT_COMMAND

### DIFF
--- a/hedera-mirror-test/Dockerfile
+++ b/hedera-mirror-test/Dockerfile
@@ -8,4 +8,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 USER 1000:1000
 
+ENV ENTRYPOINT_COMMAND="java -jar /app/test.jar"
 ENTRYPOINT ["java", "-jar", "/app/test.jar"]


### PR DESCRIPTION
**Description**:
This PR is a follow-up and addition for the change made in #7665 
Jenkins appears to be implicitly overriding the entrypoint/cmd of any container(s) used by its execution agent.
In order to get around that, I've exposed an environment variable in the acceptance container named ENTRYPOINT_COMMAND, which would allow me to grab its value (that should match the entrypoint command itself) inside the jenkins pipeline and simply run it there, without making any customizations or overrides to the command.

- Added ENTRYPOINT_COMMAND environment variable to the acceptance-tests Dockerfile

**Related issue(s)**: https://github.com/swirlds/infrastructure/pull/5430

**Notes for reviewer**:
