### PR TITLE
Add wait strategy for testcontainer docker db readiness 

### DIFF
--- a/hedera-mirror-rest/__tests__/globalSetup.js
+++ b/hedera-mirror-rest/__tests__/globalSetup.js
@@ -42,7 +42,12 @@ const createDbContainers = async (maxWorkers) => {
       .withDatabase(dbName)
       .withPassword('mirror_node_pass')
       .withUsername('mirror_node')
-      .withWaitStrategy(Wait.forHealthCheck())
+      .withLogConsumer((stream) => {
+        stream.on('data', (line) => console.log(line));
+        stream.on('err', (line) => console.error(line));
+        stream.on('end', () => console.log('Stream closed'));
+      })
+      .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections'))
       .start();
     console.info(`Started PostgreSQL container for Jest worker ${i} with image ${image}`);
     setJestEnvironment(dockerDb, i);

--- a/hedera-mirror-rest/__tests__/globalSetup.js
+++ b/hedera-mirror-rest/__tests__/globalSetup.js
@@ -42,7 +42,6 @@ const createDbContainers = async (maxWorkers) => {
       .withDatabase(dbName)
       .withPassword('mirror_node_pass')
       .withUsername('mirror_node')
-      .withStartupTimeout(100)
       .withWaitStrategy(Wait.forHealthCheck())
       .start();
     console.info(`Started PostgreSQL container for Jest worker ${i} with image ${image}`);

--- a/hedera-mirror-rest/__tests__/globalSetup.js
+++ b/hedera-mirror-rest/__tests__/globalSetup.js
@@ -47,7 +47,7 @@ const createDbContainers = async (maxWorkers) => {
         stream.on('err', (line) => console.error(line));
         stream.on('end', () => console.log('Stream closed'));
       })
-      .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections'))
+      .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
       .start();
     console.info(`Started PostgreSQL container for Jest worker ${i} with image ${image}`);
     setJestEnvironment(dockerDb, i);

--- a/hedera-mirror-rest/__tests__/globalSetup.js
+++ b/hedera-mirror-rest/__tests__/globalSetup.js
@@ -18,6 +18,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {PostgreSqlContainer} from '@testcontainers/postgresql';
+import {Wait} from 'testcontainers';
 
 const dbName = 'mirror_node';
 const dockerNamePrefix = 'INTEGRATION_DATABASE_URL';
@@ -41,6 +42,8 @@ const createDbContainers = async (maxWorkers) => {
       .withDatabase(dbName)
       .withPassword('mirror_node_pass')
       .withUsername('mirror_node')
+      .withStartupTimeout(100)
+      .withWaitStrategy(Wait.forHealthCheck())
       .start();
     console.info(`Started PostgreSQL container for Jest worker ${i} with image ${image}`);
     setJestEnvironment(dockerDb, i);

--- a/hedera-mirror-rest/__tests__/globalSetup.js
+++ b/hedera-mirror-rest/__tests__/globalSetup.js
@@ -42,11 +42,6 @@ const createDbContainers = async (maxWorkers) => {
       .withDatabase(dbName)
       .withPassword('mirror_node_pass')
       .withUsername('mirror_node')
-      .withLogConsumer((stream) => {
-        stream.on('data', (line) => console.log(line));
-        stream.on('err', (line) => console.error(line));
-        stream.on('end', () => console.log('Stream closed'));
-      })
       .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
       .start();
     console.info(`Started PostgreSQL container for Jest worker ${i} with image ${image}`);


### PR DESCRIPTION
**Description**:
Adds a wait strategy for the rest test docker db test containers. This seems to resolve the intermittent CI problem. 
**Related issue(s)**:

Fixes #7698 

**Notes for reviewer**:
Tested in CI with 7 runs each of Rest v1 and Rest v2.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
