### PR TITLE
Refactor `StreamFile.items` from `Flux` to `Collection`

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/StreamFile.java
@@ -16,14 +16,15 @@
 
 package com.hedera.mirror.common.domain;
 
+import java.util.Collection;
+import java.util.List;
 import lombok.NonNull;
-import reactor.core.publisher.Flux;
 
 public interface StreamFile<T extends StreamItem> {
 
     default void clear() {
         setBytes(null);
-        setItems(null);
+        setItems(List.of());
     }
 
     StreamFile<T> copy();
@@ -57,9 +58,9 @@ public interface StreamFile<T extends StreamItem> {
 
     default void setIndex(Long index) {}
 
-    Flux<T> getItems();
+    Collection<T> getItems();
 
-    void setItems(Flux<T> items);
+    void setItems(Collection<T> items);
 
     Long getLoadEnd();
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/balance/AccountBalanceFile.java
@@ -21,6 +21,8 @@ import com.hedera.mirror.common.domain.StreamType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Transient;
+import java.util.Collection;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,7 +30,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import reactor.core.publisher.Flux;
 
 @Builder(toBuilder = true)
 @Data
@@ -54,7 +55,7 @@ public class AccountBalanceFile implements StreamFile<AccountBalance> {
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     @Transient
-    private Flux<AccountBalance> items = Flux.empty();
+    private Collection<AccountBalance> items = List.of();
 
     private Long loadEnd;
 
@@ -79,13 +80,13 @@ public class AccountBalanceFile implements StreamFile<AccountBalance> {
     }
 
     @Override
-    public Long getConsensusEnd() {
-        return getConsensusStart();
+    public void setConsensusStart(Long timestamp) {
+        consensusTimestamp = timestamp;
     }
 
     @Override
-    public void setConsensusStart(Long timestamp) {
-        consensusTimestamp = timestamp;
+    public Long getConsensusEnd() {
+        return getConsensusStart();
     }
 
     @Override

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
@@ -26,7 +26,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Transient;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,7 +36,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.data.util.Version;
-import reactor.core.publisher.Flux;
 
 @Builder(toBuilder = true)
 @Data
@@ -88,7 +87,7 @@ public class RecordFile implements StreamFile<RecordItem> {
     @JsonIgnore
     @ToString.Exclude
     @Transient
-    private Flux<RecordItem> items = Flux.empty();
+    private Collection<RecordItem> items = List.of();
 
     private Long loadEnd;
 
@@ -118,7 +117,7 @@ public class RecordFile implements StreamFile<RecordItem> {
     @JsonIgnore
     @ToString.Exclude
     @Transient
-    private List<SidecarFile> sidecars = Collections.emptyList();
+    private Collection<SidecarFile> sidecars = List.of();
 
     private Integer size;
 
@@ -128,7 +127,7 @@ public class RecordFile implements StreamFile<RecordItem> {
     public void clear() {
         StreamFile.super.clear();
         setLogsBloom(null);
-        setSidecars(Collections.emptyList());
+        setSidecars(List.of());
     }
 
     @Override

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/record/RecordFileDownloader.java
@@ -129,15 +129,12 @@ public class RecordFileDownloader extends Downloader<RecordFile, RecordItem> {
                         ArrayListMultimap::create))
                 .block();
 
-        recordFile
-                .getItems()
-                .doOnNext(recordItem -> {
-                    var timestamp = recordItem.getTransactionRecord().getConsensusTimestamp();
-                    if (records.containsKey(timestamp)) {
-                        recordItem.setSidecarRecords(records.get(timestamp));
-                    }
-                })
-                .blockLast();
+        recordFile.getItems().forEach(recordItem -> {
+            var timestamp = recordItem.getTransactionRecord().getConsensusTimestamp();
+            if (records.containsKey(timestamp)) {
+                recordItem.setSidecarRecords(records.get(timestamp));
+            }
+        });
     }
 
     private Mono<SidecarFile> getSidecar(ConsensusNode node, StreamFilename recordFilename, SidecarFile sidecar) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParser.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParser.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,45 +78,56 @@ public class AccountBalanceFileParser extends AbstractStreamFileParser<AccountBa
     }
 
     @Override
+    @Leader
+    @Retryable(
+            backoff =
+                    @Backoff(
+                            delayExpression = "#{@balanceParserProperties.getRetry().getMinBackoff().toMillis()}",
+                            maxDelayExpression = "#{@balanceParserProperties.getRetry().getMaxBackoff().toMillis()}",
+                            multiplierExpression = "#{@balanceParserProperties.getRetry().getMultiplier()}"),
+            maxAttemptsExpression = "#{@balanceParserProperties.getRetry().getMaxAttempts()}")
+    @Transactional(timeoutString = "#{@balanceParserProperties.getTransactionTimeout().toSeconds()}")
+    public synchronized void parse(List<AccountBalanceFile> accountBalanceFile) {
+        super.parse(accountBalanceFile);
+    }
+
+    @Override
     protected void doParse(AccountBalanceFile accountBalanceFile) {
         log.info("Starting processing account balances file {}", accountBalanceFile.getName());
         DateRangeFilter filter = dateRangeCalculator.getFilter(StreamType.BALANCE);
         int batchSize = ((BalanceParserProperties) parserProperties).getBatchSize();
-        long count = 0L;
+        var count = new AtomicLong(0L);
 
         if (filter.filter(accountBalanceFile.getConsensusTimestamp())) {
             List<AccountBalance> accountBalances = new ArrayList<>(batchSize);
             Map<TokenBalance.Id, TokenBalance> tokenBalances = new HashMap<>(batchSize);
 
-            count = accountBalanceFile
-                    .getItems()
-                    .doOnNext(accountBalance -> {
-                        accountBalances.add(accountBalance);
-                        for (var tokenBalance : accountBalance.getTokenBalances()) {
-                            if (tokenBalances.putIfAbsent(tokenBalance.getId(), tokenBalance) != null) {
-                                log.warn("Skipping duplicate token balance: {}", tokenBalance);
-                            }
-                        }
+            accountBalanceFile.getItems().forEach(accountBalance -> {
+                accountBalances.add(accountBalance);
+                for (var tokenBalance : accountBalance.getTokenBalances()) {
+                    if (tokenBalances.putIfAbsent(tokenBalance.getId(), tokenBalance) != null) {
+                        log.warn("Skipping duplicate token balance: {}", tokenBalance);
+                    }
+                }
 
-                        if (accountBalances.size() >= batchSize) {
-                            batchPersister.persist(accountBalances);
-                            accountBalances.clear();
-                        }
+                if (accountBalances.size() >= batchSize) {
+                    batchPersister.persist(accountBalances);
+                    accountBalances.clear();
+                }
 
-                        if (tokenBalances.size() >= batchSize) {
-                            batchPersister.persist(tokenBalances.values());
-                            tokenBalances.clear();
-                        }
-                    })
-                    .count()
-                    .block();
+                if (tokenBalances.size() >= batchSize) {
+                    batchPersister.persist(tokenBalances.values());
+                    tokenBalances.clear();
+                }
+                count.getAndIncrement();
+            });
 
             batchPersister.persist(accountBalances);
             batchPersister.persist(tokenBalances.values());
         }
 
         Instant loadEnd = Instant.now();
-        accountBalanceFile.setCount(count);
+        accountBalanceFile.setCount(count.get());
         accountBalanceFile.setLoadEnd(loadEnd.getEpochSecond());
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReader.java
@@ -40,7 +40,6 @@ import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
-import reactor.core.publisher.Flux;
 
 @CustomLog
 @RequiredArgsConstructor
@@ -112,7 +111,7 @@ public abstract class CsvBalanceFileReader implements BalanceFileReader {
 
             accountBalanceFile.setCount(count.get());
             accountBalanceFile.setFileHash(DomainUtils.bytesToHex(messageDigest.digest()));
-            accountBalanceFile.setItems(Flux.fromIterable(items));
+            accountBalanceFile.setItems(items);
             return accountBalanceFile;
         } catch (IOException ex) {
             throw new InvalidDatasetException("Error reading account balance file", ex);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
@@ -16,9 +16,6 @@
 
 package com.hedera.mirror.importer.reader.balance;
 
-import com.google.protobuf.CodedInputStream;
-import com.google.protobuf.ExtensionRegistryLite;
-import com.google.protobuf.UnknownFieldSet;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.AccountBalanceFile;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
@@ -27,28 +24,21 @@ import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.exception.InvalidStreamFileException;
 import com.hedera.mirror.importer.exception.StreamFileReaderException;
+import com.hedera.services.stream.proto.AllAccountBalances;
 import com.hedera.services.stream.proto.SingleAccountBalances;
-import com.hederahashgraph.api.proto.java.Timestamp;
 import jakarta.inject.Named;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.io.IOUtils;
-import org.springframework.util.Assert;
-import reactor.core.publisher.Flux;
 
 @CustomLog
 @Named
 public class ProtoBalanceFileReader implements BalanceFileReader {
 
     private static final String FILE_EXTENSION = "pb";
-    private static final int TAG_EOF = 0;
-    private static final int TAG_TIMESTAMP = 10;
-    private static final int TAG_BALANCE = 18;
 
     @Override
     public boolean supports(StreamFileData streamFileData) {
@@ -59,16 +49,24 @@ public class ProtoBalanceFileReader implements BalanceFileReader {
     @Override
     public AccountBalanceFile read(StreamFileData streamFileData) {
         Instant loadStart = Instant.now();
-        Flux<AccountBalance> items = toFlux(streamFileData);
-        long consensusTimestamp = items.map(AccountBalance::getId)
-                .map(AccountBalance.Id::getConsensusTimestamp)
-                .blockFirst();
 
-        try (InputStream inputStream = streamFileData.getInputStream()) {
+        try {
+            var bytes = streamFileData.getDecompressedBytes();
+            var allAccountBalances = AllAccountBalances.parseFrom(bytes);
+
+            if (!allAccountBalances.hasConsensusTimestamp()) {
+                throw new InvalidStreamFileException("Missing required consensusTimestamp field");
+            }
+
+            long consensusTimestamp = DomainUtils.timestampInNanosMax(allAccountBalances.getConsensusTimestamp());
+            var items = allAccountBalances.getAllAccountsList().stream()
+                    .map(ab -> toAccountBalance(consensusTimestamp, ab))
+                    .collect(Collectors.toList());
+
             AccountBalanceFile accountBalanceFile = new AccountBalanceFile();
             accountBalanceFile.setBytes(streamFileData.getBytes());
             accountBalanceFile.setConsensusTimestamp(consensusTimestamp);
-            accountBalanceFile.setFileHash(DigestUtils.sha384Hex(inputStream));
+            accountBalanceFile.setFileHash(DigestUtils.sha384Hex(bytes));
             accountBalanceFile.setItems(items);
             accountBalanceFile.setLoadStart(loadStart.getEpochSecond());
             accountBalanceFile.setName(streamFileData.getFilename());
@@ -76,50 +74,6 @@ public class ProtoBalanceFileReader implements BalanceFileReader {
         } catch (IOException e) {
             throw new StreamFileReaderException(e);
         }
-    }
-
-    private Flux<AccountBalance> toFlux(StreamFileData streamFileData) {
-        return Flux.defer(() -> {
-            InputStream inputStream = streamFileData.getInputStream();
-            ExtensionRegistryLite extensionRegistry = ExtensionRegistryLite.getEmptyRegistry();
-            CodedInputStream input = CodedInputStream.newInstance(inputStream);
-            AtomicLong consensusTimestamp = new AtomicLong(0L);
-            UnknownFieldSet.Builder unknownFieldSet = UnknownFieldSet.newBuilder();
-
-            return Flux.<AccountBalance>generate(sink -> {
-                        try {
-                            boolean done = false;
-                            while (!done) {
-                                int tag = input.readTag();
-                                switch (tag) {
-                                    case TAG_EOF:
-                                        done = true;
-                                        break;
-                                    case TAG_TIMESTAMP:
-                                        Timestamp timestamp = input.readMessage(Timestamp.parser(), extensionRegistry);
-                                        consensusTimestamp.set(DomainUtils.timestampInNanosMax(timestamp));
-                                        break;
-                                    case TAG_BALANCE:
-                                        Assert.state(consensusTimestamp.get() > 0, "Missing consensus timestamp)");
-                                        var ab = input.readMessage(SingleAccountBalances.parser(), extensionRegistry);
-                                        sink.next(toAccountBalance(consensusTimestamp.get(), ab));
-                                        return;
-                                    default:
-                                        log.warn("Unsupported tag: {}", tag);
-                                        done = !unknownFieldSet.mergeFieldFrom(tag, input);
-                                }
-                            }
-
-                            Assert.state(consensusTimestamp.get() > 0, "Missing consensus timestamp)");
-                            sink.complete();
-                        } catch (IOException e) {
-                            sink.error(new StreamFileReaderException(e));
-                        } catch (IllegalStateException e) {
-                            sink.error(new InvalidStreamFileException(e));
-                        }
-                    })
-                    .doFinally(s -> IOUtils.closeQuietly(inputStream));
-        });
     }
 
     private AccountBalance toAccountBalance(long consensusTimestamp, SingleAccountBalances balances) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/balance/ProtoBalanceFileReader.java
@@ -30,7 +30,6 @@ import jakarta.inject.Named;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.apache.commons.codec.digest.DigestUtils;
 
@@ -61,7 +60,7 @@ public class ProtoBalanceFileReader implements BalanceFileReader {
             long consensusTimestamp = DomainUtils.timestampInNanosMax(allAccountBalances.getConsensusTimestamp());
             var items = allAccountBalances.getAllAccountsList().stream()
                     .map(ab -> toAccountBalance(consensusTimestamp, ab))
-                    .collect(Collectors.toList());
+                    .toList();
 
             AccountBalanceFile accountBalanceFile = new AccountBalanceFile();
             accountBalanceFile.setBytes(streamFileData.getBytes());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/AbstractPreV5RecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/AbstractPreV5RecordFileReader.java
@@ -37,7 +37,6 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.codec.binary.Hex;
-import reactor.core.publisher.Flux;
 
 @RequiredArgsConstructor
 public abstract class AbstractPreV5RecordFileReader implements RecordFileReader {
@@ -146,7 +145,7 @@ public abstract class AbstractPreV5RecordFileReader implements RecordFileReader 
         recordFile.setCount((long) count);
         recordFile.setFileHash(fileHash);
         recordFile.setHash(fileHash);
-        recordFile.setItems(Flux.fromIterable(items));
+        recordFile.setItems(items);
     }
 
     protected static class RecordFileDigest implements AutoCloseable {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/ProtoRecordFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/ProtoRecordFileReader.java
@@ -45,7 +45,6 @@ import java.util.stream.Stream;
 import lombok.CustomLog;
 import org.apache.commons.io.output.NullOutputStream;
 import org.springframework.data.util.Version;
-import reactor.core.publisher.Flux;
 
 @CustomLog
 @Named
@@ -93,7 +92,7 @@ public class ProtoRecordFileReader implements RecordFileReader {
                     .hapiVersionPatch(hapiProtoVersion.getPatch())
                     .hash(DomainUtils.bytesToHex(DomainUtils.getHashBytes(endObjectRunningHash)))
                     .index(recordStreamFile.getBlockNumber())
-                    .items(Flux.fromIterable(items))
+                    .items(items)
                     .loadStart(loadStart)
                     .metadataHash(getMetadataHash(digestAlgorithm, recordStreamFile))
                     .name(filename)

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV5.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV5.java
@@ -41,7 +41,6 @@ import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.commons.codec.binary.Hex;
-import reactor.core.publisher.Flux;
 
 @Named
 public class RecordFileReaderImplV5 implements RecordFileReader {
@@ -146,7 +145,7 @@ public class RecordFileReaderImplV5 implements RecordFileReader {
         recordFile.setConsensusEnd(consensusEnd);
         recordFile.setConsensusStart(consensusStart);
         recordFile.setHash(Hex.encodeHexString(endHashObject.getHash()));
-        recordFile.setItems(Flux.fromIterable(items));
+        recordFile.setItems(items);
         recordFile.setPreviousHash(Hex.encodeHexString(startHashObject.getHash()));
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/downloader/AbstractDownloaderTest.java
@@ -756,7 +756,7 @@ public abstract class AbstractDownloaderTest<T extends StreamFile<?>> {
                     .isNotEmpty()
                     .get()
                     .returns(null, StreamFile::getBytes)
-                    .returns(null, StreamFile::getItems)
+                    .returns(List.of(), StreamFile::getItems)
                     .returns(lastFilename, StreamFile::getName);
         } else {
             // Can't reset mockito ArgumentCaptor. So when files is empty, just verify streamFileNotifier.verified is

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixCryptoAllowanceAmountMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixCryptoAllowanceAmountMigrationTest.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.jdbc.core.JdbcTemplate;
-import reactor.core.publisher.Flux;
 
 @EnabledIfV1
 @RequiredArgsConstructor
@@ -65,6 +64,17 @@ class FixCryptoAllowanceAmountMigrationTest extends AbstractAsyncJavaMigrationTe
     private final RecordItemBuilder recordItemBuilder;
 
     private @Getter FixCryptoAllowanceAmountMigration migration;
+
+    private static CryptoAllowance convert(CryptoAllowanceHistory history) {
+        return CryptoAllowance.builder()
+                .amount(history.getAmount())
+                .amountGranted(history.getAmountGranted())
+                .owner(history.getOwner())
+                .payerAccountId(history.getPayerAccountId())
+                .spender(history.getSpender())
+                .timestampRange(history.getTimestampRange())
+                .build();
+    }
 
     @BeforeEach
     void setup() {
@@ -251,7 +261,7 @@ class FixCryptoAllowanceAmountMigrationTest extends AbstractAsyncJavaMigrationTe
                         .setTransactionID(transactionId3))
                 .build();
 
-        recordFile.setItems(Flux.fromIterable(List.of(recordItem1, recordItem2, recordItem3)));
+        recordFile.setItems(List.of(recordItem1, recordItem2, recordItem3));
 
         // when, run the async migration and ingesting the record file concurrently
         runMigration();
@@ -289,16 +299,5 @@ class FixCryptoAllowanceAmountMigrationTest extends AbstractAsyncJavaMigrationTe
     @SneakyThrows
     private void runMigration() {
         migration.doMigrate();
-    }
-
-    private static CryptoAllowance convert(CryptoAllowanceHistory history) {
-        return CryptoAllowance.builder()
-                .amount(history.getAmount())
-                .amountGranted(history.getAmountGranted())
-                .owner(history.getOwner())
-                .payerAccountId(history.getPayerAccountId())
-                .spender(history.getSpender())
-                .timestampRange(history.getTimestampRange())
-                .build();
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/AbstractStreamFileParserTest.java
@@ -119,10 +119,10 @@ public abstract class AbstractStreamFileParserTest<F extends StreamFile<?>, T ex
     protected void assertParsed(F streamFile, boolean parsed, boolean dbError) {
         if (!dbError) {
             assertThat(streamFile.getBytes()).isNull();
-            assertThat(streamFile.getItems()).isNull();
+            assertThat(streamFile.getItems()).isEmpty();
         } else {
             assertThat(streamFile.getBytes()).isNotNull();
-            assertThat(streamFile.getItems()).isNotNull();
+            assertThat(streamFile.getItems()).isNotEmpty();
         }
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileBuilder.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.Assert;
-import reactor.core.publisher.Flux;
 
 @Named
 @RequiredArgsConstructor
@@ -74,7 +73,7 @@ public class AccountBalanceFileBuilder {
                     .count((long) accountBalanceList.size())
                     .consensusTimestamp(consensusTimestamp)
                     .fileHash(Hex.encodeHexString(domainBuilder.bytes(48)))
-                    .items(Flux.fromIterable(accountBalanceList))
+                    .items(accountBalanceList)
                     .loadStart(domainBuilder.timestamp())
                     .name(filename)
                     .nodeId(0L)

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/balance/AccountBalanceFileParserTest.java
@@ -28,7 +28,6 @@ import com.hedera.mirror.importer.repository.AccountBalanceFileRepository;
 import com.hedera.mirror.importer.repository.AccountBalanceRepository;
 import com.hedera.mirror.importer.repository.TokenBalanceRepository;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -70,7 +69,7 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
     void success() {
         // given
         var accountBalanceFile = accountBalanceFile(1);
-        var items = accountBalanceFile.getItems().collectList().block();
+        var items = accountBalanceFile.getItems();
 
         // when
         accountBalanceFileParser.parse(accountBalanceFile);
@@ -86,7 +85,7 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
         int batchSize = parserProperties.getBatchSize();
         parserProperties.setBatchSize(2);
         var accountBalanceFile = accountBalanceFile(1);
-        var items = accountBalanceFile.getItems().collectList().block();
+        var items = accountBalanceFile.getItems();
 
         // when
         accountBalanceFileParser.parse(accountBalanceFile);
@@ -101,7 +100,7 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
         // given
         var accountBalanceFile = accountBalanceFile(1);
         var duplicate = accountBalanceFile(1);
-        var items = accountBalanceFile.getItems().collectList().block();
+        var items = accountBalanceFile.getItems();
 
         // when
         accountBalanceFileParser.parse(accountBalanceFile);
@@ -130,7 +129,7 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
         var network = importerProperties.getNetwork();
         importerProperties.setNetwork(ImporterProperties.HederaNetwork.MAINNET);
         AccountBalanceFile accountBalanceFile = accountBalanceFile(BAD_TIMESTAMP1);
-        List<AccountBalance> items = accountBalanceFile.getItems().collectList().block();
+        var items = accountBalanceFile.getItems();
 
         // when
         accountBalanceFileParser.parse(accountBalanceFile);
@@ -141,14 +140,14 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
         importerProperties.setNetwork(network);
     }
 
-    void assertAccountBalanceFile(AccountBalanceFile accountBalanceFile, List<AccountBalance> accountBalances) {
+    void assertAccountBalanceFile(AccountBalanceFile accountBalanceFile, Collection<AccountBalance> accountBalances) {
         Map<TokenBalance.Id, TokenBalance> tokenBalances = accountBalances.stream()
                 .map(AccountBalance::getTokenBalances)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toMap(TokenBalance::getId, t -> t, (previous, current) -> previous));
 
         assertThat(accountBalanceFile.getBytes()).isNull();
-        assertThat(accountBalanceFile.getItems()).isNull();
+        assertThat(accountBalanceFile.getItems()).isEmpty();
         assertThat(accountBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(accountBalances);
         assertThat(tokenBalanceRepository.findAll()).containsExactlyInAnyOrderElementsOf(tokenBalances.values());
 
@@ -165,7 +164,7 @@ class AccountBalanceFileParserTest extends ImporterIntegrationTest {
 
     void assertAccountBalanceFileWhenSkipped(AccountBalanceFile accountBalanceFile) {
         assertThat(accountBalanceFile.getBytes()).isNull();
-        assertThat(accountBalanceFile.getItems()).isNull();
+        assertThat(accountBalanceFile.getItems()).isEmpty();
         assertThat(accountBalanceRepository.count()).isZero();
         assertThat(tokenBalanceRepository.count()).isZero();
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordFileBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordFileBuilder.java
@@ -37,7 +37,6 @@ import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.Assert;
-import reactor.core.publisher.Flux;
 
 /**
  * Generates record files using pre-defined templates for bulk creation of record items.
@@ -68,7 +67,7 @@ public class RecordFileBuilder {
             Assert.notEmpty(itemBuilders, "Must contain at least one record item");
             var recordFile = domainBuilder.recordFile();
             var recordItems = new ArrayList<RecordItem>();
-            recordFile.customize(r -> r.items(Flux.fromIterable(recordItems)));
+            recordFile.customize(r -> r.items(recordItems));
 
             if (previous != null) {
                 recordItemBuilder.reset(Instant.ofEpochSecond(0, previous.getConsensusStart() + CLOSE_INTERVAL));

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/RecordFileParserTest.java
@@ -60,6 +60,7 @@ import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -68,7 +69,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.context.ApplicationEventPublisher;
-import reactor.core.publisher.Flux;
 
 class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, RecordFileParser> {
 
@@ -133,7 +133,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
     protected RecordFile getStreamFile() {
         long id = ++count * 100;
         recordItem = cryptoTransferRecordItem(id);
-        return getStreamFile(Flux.just(recordItem), id);
+        return getStreamFile(List.of(recordItem), id);
     }
 
     @Override
@@ -160,7 +160,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
     void endDate(long offset) {
         // given
         RecordFile recordFile = getStreamFile();
-        RecordItem firstItem = recordFile.getItems().blockFirst();
+        RecordItem firstItem = recordFile.getItems().iterator().next();
         long end = recordFile.getConsensusStart() + offset;
         DateRangeFilter filter = new DateRangeFilter(Instant.EPOCH, Instant.ofEpochSecond(0, end));
         doReturn(filter).when(dateRangeCalculator).getFilter(parserProperties.getStreamType());
@@ -194,7 +194,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
 
         RecordItem recordItem5 = cryptoTransferRecordItem(1L);
 
-        var items = Flux.just(recordItem1, recordItem2, recordItem3, recordItem4, recordItem5);
+        var items = List.of(recordItem1, recordItem2, recordItem3, recordItem4, recordItem5);
         var recordFile = spy(getStreamFile(items, timestamp));
         doNothing().when(recordFile).clear();
 
@@ -225,7 +225,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
     void startDate(long offset) {
         // given
         RecordFile recordFile = getStreamFile();
-        RecordItem firstItem = recordFile.getItems().blockFirst();
+        RecordItem firstItem = recordFile.getItems().iterator().next();
         long start = recordFile.getConsensusStart() + offset;
         DateRangeFilter filter = new DateRangeFilter(Instant.ofEpochSecond(0, start), null);
         doReturn(filter).when(dateRangeCalculator).getFilter(parserProperties.getStreamType());
@@ -483,7 +483,7 @@ class RecordFileParserTest extends AbstractStreamFileParserTest<RecordFile, Reco
                 .build();
     }
 
-    private RecordFile getStreamFile(final Flux<RecordItem> items, final long timestamp) {
+    private RecordFile getStreamFile(final Collection<RecordItem> items, final long timestamp) {
         return domainBuilder
                 .recordFile()
                 .customize(recordFileBuilder -> recordFileBuilder

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/balance/CsvBalanceFileReaderTest.java
@@ -278,8 +278,7 @@ abstract class CsvBalanceFileReaderTest {
                 skipLines--;
             }
 
-            List<AccountBalance> accountBalances =
-                    accountBalanceFile.getItems().collectList().block();
+            var accountBalances = accountBalanceFile.getItems();
             var lineIter = reader.lines().iterator();
             var accountBalanceIter = accountBalances.iterator();
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV5Test.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderImplV5Test.java
@@ -60,7 +60,7 @@ class RecordFileReaderImplV5Test extends AbstractRecordFileReaderTest {
                     // then
                     RecordItem previousItem = null;
                     RecordItem lastParentItem = null;
-                    for (var item : actual.getItems().collectList().block()) {
+                    for (var item : actual.getItems()) {
                         // assert previous link points to previous item
                         assertThat(item.getPrevious()).isEqualTo(previousItem);
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/RecordFileReaderTest.java
@@ -83,26 +83,23 @@ abstract class RecordFileReaderTest {
                     assertThat(actual.getBytes()).isNotEmpty().isEqualTo(streamFileData.getBytes());
                     assertThat(actual.getLoadStart()).isNotNull().isPositive();
 
-                    List<Version> hapiVersions = actual.getItems()
+                    List<Version> hapiVersions = actual.getItems().stream()
                             .map(RecordItem::getHapiVersion)
-                            .collectList()
-                            .block();
+                            .collect(Collectors.toList());
                     assertThat(hapiVersions)
                             .isNotEmpty()
                             .allSatisfy(version -> assertEquals(recordFile.getHapiVersion(), version));
 
-                    List<Long> timestamps = actual.getItems()
+                    List<Long> timestamps = actual.getItems().stream()
                             .map(RecordItem::getConsensusTimestamp)
-                            .collectList()
-                            .block();
+                            .collect(Collectors.toList());
                     assertThat(timestamps).first().isEqualTo(recordFile.getConsensusStart());
                     assertThat(timestamps).last().isEqualTo(recordFile.getConsensusEnd());
                     assertThat(timestamps).doesNotHaveDuplicates().isSorted();
 
-                    List<Integer> transactionIndexes = actual.getItems()
+                    List<Integer> transactionIndexes = actual.getItems().stream()
                             .map(RecordItem::getTransactionIndex)
-                            .collectList()
-                            .block();
+                            .collect(Collectors.toList());
                     assertThat(transactionIndexes).first().isEqualTo(0);
                     assertThat(transactionIndexes)
                             .isEqualTo(IntStream.range(0, recordFile.getCount().intValue())
@@ -130,7 +127,7 @@ abstract class RecordFileReaderTest {
 
                     // then
                     RecordItem previousItem = null;
-                    for (var item : actual.getItems().collectList().block()) {
+                    for (var item : actual.getItems()) {
                         // assert previous link points to previous item
                         assertThat(item.getPrevious()).isEqualTo(previousItem);
                         previousItem = item;

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/sidecar/SidecarFileReaderImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/record/sidecar/SidecarFileReaderImplTest.java
@@ -53,8 +53,11 @@ class SidecarFileReaderImplTest {
 
     @Test
     void read() {
-        var expected =
-                TestRecordFiles.getAll().get(RECORD_FILENAME).getSidecars().get(0);
+        var expected = TestRecordFiles.getAll()
+                .get(RECORD_FILENAME)
+                .getSidecars()
+                .iterator()
+                .next();
         // clear the fields SidecarFileReader fills
         var sidecar = expected.toBuilder()
                 .actualHash(null)


### PR DESCRIPTION
**Description**:

* Change `ProtoBalanceFileReader` to no longer lazy create items
* Refactor `StreamFile.items` from `Flux` to `Collection`

**Related issue(s)**:

Fixes #7707

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
