### PR TITLE
Expose the entrypoint command using an env var named ENTRYPOINT_COMMAND (#7704)

### DIFF
--- a/hedera-mirror-test/Dockerfile
+++ b/hedera-mirror-test/Dockerfile
@@ -8,4 +8,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 USER 1000:1000
 
+ENV ENTRYPOINT_COMMAND="java -jar /app/test.jar"
 ENTRYPOINT ["java", "-jar", "/app/test.jar"]


### PR DESCRIPTION
**Description**:
- Cherry-picked commit `3f371a1f270e9621b13f81ea2cd8d6b3a6c0d3dc` into release/0.98

**Related issue(s)**: https://github.com/swirlds/infrastructure/pull/5430

**Notes for reviewer**:
A change was made and tagged into 0.99 as 0.98.0-rc1 has already been cut.
I've cherry-picked the relevant commit to be included in `release/0.98`

