### PR TITLE
Fix local stream provider regression

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/StreamFileData.java
@@ -75,6 +75,10 @@ public class StreamFileData {
         return readStreamFileData(file, StreamFilename.from(file.getPath(), File.separator));
     }
 
+    public static StreamFileData from(@NonNull File file, StreamFilename streamFilename) {
+        return readStreamFileData(file, streamFilename);
+    }
+
     public static StreamFileData from(@NonNull Path basePath, @NonNull StreamFilename streamFilename) {
         var streamFile = new File(basePath.toFile(), streamFilename.getFilePath());
         return readStreamFileData(streamFile, streamFilename);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/downloader/provider/LocalStreamFileProvider.java
@@ -52,7 +52,7 @@ public class LocalStreamFileProvider implements StreamFileProvider {
         var basePath = properties.getImporterProperties().getStreamPath().toFile();
         return Mono.fromSupplier(() -> new File(basePath, streamFilename.getFilePath()))
                 .doOnNext(this::checkSize)
-                .map(StreamFileData::from)
+                .map(file -> StreamFileData.from(file, streamFilename))
                 .timeout(properties.getTimeout())
                 .onErrorMap(FileOperationException.class, TransientProviderException::new);
     }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/PrecompileContractFeature.java
@@ -59,7 +59,6 @@ import com.hedera.hashgraph.sdk.TokenId;
 import com.hedera.hashgraph.sdk.TransactionReceipt;
 import com.hedera.mirror.rest.model.AccountInfo;
 import com.hedera.mirror.rest.model.Nft;
-import com.hedera.mirror.rest.model.TokenInfo;
 import com.hedera.mirror.rest.model.TransactionByIdResponse;
 import com.hedera.mirror.test.e2e.acceptance.client.AccountClient;
 import com.hedera.mirror.test.e2e.acceptance.client.MirrorNodeClient;
@@ -124,8 +123,6 @@ public class PrecompileContractFeature extends AbstractFeature {
             this.networkTransactionResponse = tokenAndResponse.response();
             verifyMirrorTransactionsResponse(mirrorClient, 200);
         }
-        var tokenInfo = mirrorClient.getTokenInfo(tokenAndResponse.tokenId().toString());
-        log.debug("Get token info for token {}: {}", TokenNameEnum.FUNGIBLE_KYC_NOT_APPLICABLE_UNFROZEN, tokenInfo);
     }
 
     @Given("I successfully create and verify a non fungible token for precompile contract tests")
@@ -516,17 +513,6 @@ public class PrecompileContractFeature extends AbstractFeature {
         assertThat(result).isNotEmpty();
 
         tokenKeyCheck(result);
-    }
-
-    @Retryable(
-            retryFor = {AssertionError.class},
-            backoff = @Backoff(delayExpression = "#{@restPollingProperties.minBackoff.toMillis()}"),
-            maxAttemptsExpression = "#{@restPollingProperties.maxAttempts}")
-    public void verifyToken(TokenId tokenId) {
-        TokenInfo mirrorToken = mirrorClient.getTokenInfo(tokenId.toString());
-
-        assertNotNull(mirrorToken);
-        assertThat(mirrorToken.getTokenId()).isEqualTo(tokenId.toString());
     }
 
     @Retryable(


### PR DESCRIPTION
**Description**:

* Fix regression in `LocalStreamFileProvider` that causes duplicate prefixes
* Remove unused code in acceptance tests

**Related issue(s)**:

Fixes #7740

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
