### PR TITLE
Exclude spring security from graphql module

### DIFF
--- a/hedera-mirror-graphql/build.gradle.kts
+++ b/hedera-mirror-graphql/build.gradle.kts
@@ -27,7 +27,9 @@ plugins {
 dependencies {
     annotationProcessor("org.mapstruct:mapstruct-processor")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-    compileOnly("com.graphql-java-generator:graphql-java-client-runtime")
+    compileOnly("com.graphql-java-generator:graphql-java-client-runtime") {
+        exclude(group = "org.springframework.security")
+    }
     implementation(project(":common"))
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies"))
     implementation("com.graphql-java:graphql-java-extended-scalars")


### PR DESCRIPTION
**Description**:

Fix recent Snyk Open Source workflow [failure](https://github.com/hashgraph/hedera-mirror-node/actions/runs/7918423495/job/21616797277) due to vulnerable spring security nimbus dependency. We don't use spring security so can just exclude it completely.

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
