### PR TITLE
Balance of system accounts should return zero

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -27,6 +27,7 @@ import com.hedera.mirror.web3.evm.store.contract.EntityAddressSequencer;
 import com.hedera.mirror.web3.repository.properties.CacheProperties;
 import com.hedera.node.app.service.evm.contracts.operations.CreateOperationExternalizer;
 import com.hedera.node.app.service.evm.contracts.operations.HederaBalanceOperation;
+import com.hedera.node.app.service.evm.contracts.operations.HederaBalanceOperationV038;
 import com.hedera.node.app.service.evm.contracts.operations.HederaDelegateCallOperation;
 import com.hedera.node.app.service.evm.contracts.operations.HederaEvmChainIdOperation;
 import com.hedera.node.app.service.evm.contracts.operations.HederaEvmCreate2Operation;
@@ -57,6 +58,7 @@ import org.hyperledger.besu.evm.EvmSpecVersion;
 import org.hyperledger.besu.evm.MainnetEVMs;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.hyperledger.besu.evm.operation.BalanceOperation;
 import org.hyperledger.besu.evm.operation.ExtCodeHashOperation;
 import org.hyperledger.besu.evm.operation.OperationRegistry;
 import org.hyperledger.besu.evm.operation.SelfDestructOperation;
@@ -229,7 +231,8 @@ public class EvmConfiguration {
     @Bean
     EVM evm030(
             final HederaPrngSeedOperation prngSeedOperation,
-            final HederaSelfDestructOperation hederaSelfDestructOperation) {
+            final HederaSelfDestructOperation hederaSelfDestructOperation,
+            final HederaBalanceOperation hederaBalanceOperation) {
         return evm(
                 gasCalculator,
                 mirrorNodeEvmProperties,
@@ -237,6 +240,7 @@ public class EvmConfiguration {
                 hederaBlockHashOperation,
                 hederaExtCodeHashOperation,
                 hederaSelfDestructOperation,
+                hederaBalanceOperation,
                 EvmSpecVersion.LONDON,
                 MainnetEVMs::registerLondonOperations);
     }
@@ -244,7 +248,8 @@ public class EvmConfiguration {
     @Bean
     EVM evm034(
             final HederaPrngSeedOperation prngSeedOperation,
-            final HederaSelfDestructOperation hederaSelfDestructOperation) {
+            final HederaSelfDestructOperation hederaSelfDestructOperation,
+            final HederaBalanceOperation hederaBalanceOperation) {
         return evm(
                 gasCalculator,
                 mirrorNodeEvmProperties,
@@ -252,6 +257,7 @@ public class EvmConfiguration {
                 hederaBlockHashOperation,
                 hederaExtCodeHashOperation,
                 hederaSelfDestructOperation,
+                hederaBalanceOperation,
                 EvmSpecVersion.PARIS,
                 MainnetEVMs::registerParisOperations);
     }
@@ -259,7 +265,8 @@ public class EvmConfiguration {
     @Bean
     EVM evm038(
             final HederaPrngSeedOperation prngSeedOperation,
-            final HederaSelfDestructOperationV038 hederaSelfDestructOperationV038) {
+            final HederaSelfDestructOperationV038 hederaSelfDestructOperationV038,
+            final HederaBalanceOperationV038 hederaBalanceOperationV038) {
         return evm(
                 gasCalculator,
                 mirrorNodeEvmProperties,
@@ -267,6 +274,7 @@ public class EvmConfiguration {
                 hederaBlockHashOperation,
                 hederaExtCodeHashOperationV038,
                 hederaSelfDestructOperationV038,
+                hederaBalanceOperationV038,
                 EvmSpecVersion.SHANGHAI,
                 MainnetEVMs::registerShanghaiOperations);
     }
@@ -284,6 +292,17 @@ public class EvmConfiguration {
     @Bean
     HederaSelfDestructOperationV038 hederaSelfDestructOperationV038(final GasCalculator gasCalculator) {
         return new HederaSelfDestructOperationV038(gasCalculator, addressValidator, systemAccountDetector);
+    }
+
+    @Bean
+    HederaBalanceOperation hederaBalanceOperation(final GasCalculator gasCalculator) {
+        return new HederaBalanceOperation(gasCalculator, addressValidator);
+    }
+
+    @Bean
+    HederaBalanceOperationV038 hederaBalanceOperationV038(final GasCalculator gasCalculator) {
+        return new HederaBalanceOperationV038(
+                gasCalculator, addressValidator, systemAccountDetector, mirrorNodeEvmProperties);
     }
 
     @Bean
@@ -324,6 +343,7 @@ public class EvmConfiguration {
             final HederaBlockHashOperation hederaBlockHashOperation,
             final ExtCodeHashOperation extCodeHashOperation,
             final SelfDestructOperation selfDestructOperation,
+            final BalanceOperation hederaBalanceOperation,
             EvmSpecVersion specVersion,
             OperationRegistryCallback callback) {
         final var operationRegistry = new OperationRegistry();
@@ -346,7 +366,8 @@ public class EvmConfiguration {
                         prngSeedOperation,
                         hederaBlockHashOperation,
                         extCodeHashOperation,
-                        selfDestructOperation)
+                        selfDestructOperation,
+                        hederaBalanceOperation)
                 .forEach(operationRegistry::put);
 
         return new EVM(operationRegistry, gasCalculator, provideEvmConfiguration(), specVersion);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -254,8 +254,21 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     }
 
     @Test
+    void balanceCallToNonSystemAccountReturnsBalance() {
+        // getAccountBalance(address)
+        final var balanceCall =
+                "0x93423e9c000000000000000000000000" + EVM_CODES_CONTRACT_ADDRESS.toUnprefixedHexString();
+        final var serviceParameters = serviceParametersForExecution(
+                Bytes.fromHexString(balanceCall), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
+
+        final var result = contractCallService.processCall(serviceParameters);
+        assertThat(Long.parseLong(result.substring(2), 16)).isGreaterThan(0);
+    }
+
+    @Test
     void estimateGasForBalanceCall() {
-        final var balanceCall = "0x93423e9c00000000000000000000000000000000000000000000000000000000000003e6";
+        final var balanceCall =
+                "0x93423e9c000000000000000000000000" + EVM_CODES_CONTRACT_ADDRESS.toUnprefixedHexString();
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(balanceCall), ETH_CALL_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -242,6 +242,18 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     }
 
     @Test
+    void balanceCallToSystemAccountReturnsZero() {
+        // getAccountBalance(address)
+        final var balanceCall = "0x93423e9c000000000000000000000000" + SENDER_ADDRESS.toUnprefixedHexString();
+        final var expectedBalance = "0x0000000000000000000000000000000000000000000000000000000000000000";
+        final var serviceParameters = serviceParametersForExecution(
+                Bytes.fromHexString(balanceCall), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
+
+        final var result = contractCallService.processCall(serviceParameters);
+        assertThat(result).isEqualTo(expectedBalance);
+    }
+
+    @Test
     void estimateGasForBalanceCall() {
         final var balanceCall = "0x93423e9c00000000000000000000000000000000000000000000000000000000000003e6";
         final var serviceParameters = serviceParametersForExecution(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -262,7 +262,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
                 Bytes.fromHexString(balanceCall), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
 
         final var result = contractCallService.processCall(serviceParameters);
-        assertThat(Long.parseLong(result.substring(2), 16)).isGreaterThan(0);
+        assertThat(Long.parseLong(result.substring(2), 16)).isNotZero();
     }
 
     @Test


### PR DESCRIPTION
**Description**:
This PR fixes a bug where executing balance opcode against a system account in the range 0.0.0-0.0.750 returns the actual balance instead of zero.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/7741
