### PR TITLE
Remove remaining `.js` extension from imports

### DIFF
--- a/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp-lte.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp-lte.test.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {setupIntegrationTest} from './integrationUtils.js';
-import integrationDomainOps from './integrationDomainOps.js';
-import * as utils from '../utils.js';
+import {setupIntegrationTest} from './integrationUtils';
+import integrationDomainOps from './integrationDomainOps';
+import * as utils from '../utils';
 import request from 'supertest';
-import server from '../server.js';
-import * as constants from '../constants.js';
+import server from '../server';
+import * as constants from '../constants';
 
 setupIntegrationTest();
 

--- a/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp-notfound.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp-notfound.test.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {setupIntegrationTest} from './integrationUtils.js';
-import integrationDomainOps from './integrationDomainOps.js';
-import * as utils from '../utils.js';
+import {setupIntegrationTest} from './integrationUtils';
+import integrationDomainOps from './integrationDomainOps';
+import * as utils from '../utils';
 import request from 'supertest';
-import server from '../server.js';
-import * as constants from '../constants.js';
+import server from '../server';
+import * as constants from '../constants';
 
 setupIntegrationTest();
 

--- a/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp.test.js
+++ b/hedera-mirror-rest/__tests__/accounts.deduplication.timestamp.test.js
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import {setupIntegrationTest} from './integrationUtils.js';
-import integrationDomainOps from './integrationDomainOps.js';
-import * as utils from '../utils.js';
+import {setupIntegrationTest} from './integrationUtils';
+import integrationDomainOps from './integrationDomainOps';
+import * as utils from '../utils';
 import request from 'supertest';
-import server from '../server.js';
-import * as constants from '../constants.js';
-import {nsToSecNsWithHyphen} from '../utils.js';
+import server from '../server';
+import * as constants from '../constants';
 
 setupIntegrationTest();
 

--- a/hedera-mirror-rest/__tests__/balances.deduplication.test.js
+++ b/hedera-mirror-rest/__tests__/balances.deduplication.test.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {setupIntegrationTest} from './integrationUtils.js';
-import integrationDomainOps from './integrationDomainOps.js';
-import * as utils from '../utils.js';
+import {setupIntegrationTest} from './integrationUtils';
+import integrationDomainOps from './integrationDomainOps';
+import * as utils from '../utils';
 import request from 'supertest';
-import server from '../server.js';
-import * as constants from '../constants.js';
+import server from '../server';
+import * as constants from '../constants';
 
 setupIntegrationTest();
 

--- a/hedera-mirror-rest/__tests__/config.test.js
+++ b/hedera-mirror-rest/__tests__/config.test.js
@@ -62,7 +62,7 @@ const assertCustomConfig = (actual, customConfig) => {
   expect(actual.response.compression).toBe(customConfig.hedera.mirror.rest.response.compression);
 };
 
-const loadConfig = async () => (await import('../config.js')).default;
+const loadConfig = async () => (await import('../config')).default;
 
 const loadCustomConfig = async (customConfig, filename = 'application.yml') => {
   fs.writeFileSync(path.join(tempDir, filename), yaml.dump(customConfig));

--- a/hedera-mirror-rest/__tests__/globalTeardown.js
+++ b/hedera-mirror-rest/__tests__/globalTeardown.js
@@ -15,7 +15,7 @@
  */
 
 import fs from 'fs';
-import {getDatabases} from './globalSetup.js';
+import {getDatabases} from './globalSetup';
 import log4js from 'log4js';
 
 export default async function () {

--- a/hedera-mirror-rest/__tests__/integration/transactionHashV1Matrix.js
+++ b/hedera-mirror-rest/__tests__/integration/transactionHashV1Matrix.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {isV2Schema} from '../testutils.js';
+import {isV2Schema} from '../testutils';
 
 const nullifyPayerAccountId = async () => ownerPool.queryQuietly('update transaction_hash set payer_account_id = null');
 

--- a/hedera-mirror-rest/__tests__/utils.test.js
+++ b/hedera-mirror-rest/__tests__/utils.test.js
@@ -20,7 +20,7 @@ import * as utils from '../utils';
 import config from '../config';
 import * as constants from '../constants';
 import {InvalidArgumentError, InvalidClauseError} from '../errors';
-import {Entity} from '../model/index.js';
+import {Entity} from '../model/index';
 import {Range} from 'pg-range';
 
 const ecdsaKey = '02b5ffadf88d625cd9074fa01e5280b773a60ed2de55b0d6f94460c0b5a001a258';

--- a/hedera-mirror-rest/balances.js
+++ b/hedera-mirror-rest/balances.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import AccountAlias from './accountAlias.js';
+import AccountAlias from './accountAlias';
 import {getResponseLimit} from './config';
 import * as constants from './constants';
 import EntityId from './entityId';
-import {EntityService} from './service/index.js';
+import {EntityService} from './service/index';
 import {EvmAddressType} from './constants';
-import {InvalidArgumentError} from './errors/index.js';
+import {InvalidArgumentError} from './errors/index';
 import * as utils from './utils';
 
 const {tokenBalance: tokenBalanceLimit} = getResponseLimit();

--- a/hedera-mirror-rest/errors/index.js
+++ b/hedera-mirror-rest/errors/index.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import DbError from './dbError.js';
-import FileDecodeError from './fileDecodeError.js';
-import FileDownloadError from './fileDownloadError.js';
-import InvalidArgumentError from './invalidArgumentError.js';
-import InvalidClauseError from './invalidClauseError.js';
-import InvalidConfigError from './invalidConfigError.js';
-import NotFoundError from './notFoundError.js';
+import DbError from './dbError';
+import FileDecodeError from './fileDecodeError';
+import FileDownloadError from './fileDownloadError';
+import InvalidArgumentError from './invalidArgumentError';
+import InvalidClauseError from './invalidClauseError';
+import InvalidConfigError from './invalidConfigError';
+import NotFoundError from './notFoundError';
 
 export {
   DbError,

--- a/hedera-mirror-rest/logger.js
+++ b/hedera-mirror-rest/logger.js
@@ -16,7 +16,7 @@
 
 import httpContext from 'express-http-context';
 import log4js from 'log4js';
-import * as constants from './constants.js';
+import * as constants from './constants';
 
 const configureLogger = (logLevel = 'info') => {
   log4js.configure({

--- a/hedera-mirror-rest/model/customFee.js
+++ b/hedera-mirror-rest/model/customFee.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import FixedFee from './fixedFee.js';
-import FractionalFee from './fractionalFee.js';
-import RoyaltyFee from './royaltyFee.js';
+import FixedFee from './fixedFee';
+import FractionalFee from './fractionalFee';
+import RoyaltyFee from './royaltyFee';
 
 class CustomFee {
   /**

--- a/hedera-mirror-rest/model/royaltyFee.js
+++ b/hedera-mirror-rest/model/royaltyFee.js
@@ -15,7 +15,7 @@
  */
 
 import Fee from './fee';
-import FixedFee from './fixedFee.js';
+import FixedFee from './fixedFee';
 
 class RoyaltyFee extends Fee {
   /**

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --ignore-pattern node_modules/ --fix .",
     "start": "node --experimental-specifier-resolution=node server.js",
     "pretest": "node --experimental-specifier-resolution=node __tests__/integration/generator.js",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --experimental-specifier-resolution=node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "author": "Hedera Mirror Node Team",
   "license": "Apache-2.0",

--- a/hedera-mirror-rest/service/contractService.js
+++ b/hedera-mirror-rest/service/contractService.js
@@ -34,8 +34,8 @@ import {
   RecordFile,
   EthereumTransaction,
 } from '../model';
-import ContractTransaction from '../model/contractTransaction.js';
-import {RecordFileService} from './index.js';
+import ContractTransaction from '../model/contractTransaction';
+import {RecordFileService} from './index';
 
 const {default: defaultLimit} = getResponseLimit();
 const contractLogsFields = `${ContractLog.getFullName(ContractLog.BLOOM)},

--- a/hedera-mirror-rest/service/networkNodeService.js
+++ b/hedera-mirror-rest/service/networkNodeService.js
@@ -15,7 +15,7 @@
  */
 
 import BaseService from './baseService';
-import config from '../config.js';
+import config from '../config';
 import {
   AddressBook,
   AddressBookEntry,
@@ -25,7 +25,7 @@ import {
   NodeStake,
 } from '../model';
 import {OrderSpec} from '../sql';
-import entityId from '../entityId.js';
+import entityId from '../entityId';
 
 /**
  * Network node business model

--- a/hedera-mirror-rest/service/transactionService.js
+++ b/hedera-mirror-rest/service/transactionService.js
@@ -20,8 +20,8 @@ import BaseService from './baseService';
 import {orderFilterValues} from '../constants';
 import {EthereumTransaction, Transaction} from '../model';
 import {OrderSpec} from '../sql';
-import TransactionId from '../transactionId.js';
-import config from '../config.js';
+import TransactionId from '../transactionId';
+import config from '../config';
 
 const {maxTransactionConsensusTimestampRangeNs} = config.query;
 /**

--- a/hedera-mirror-rest/viewmodel/contractActionViewModel.js
+++ b/hedera-mirror-rest/viewmodel/contractActionViewModel.js
@@ -15,8 +15,8 @@
  */
 
 import EntityId from '../entityId';
-import * as utils from '../utils.js';
-import {entityTypes} from '../constants.js';
+import * as utils from '../utils';
+import {entityTypes} from '../constants';
 import {proto} from '@hashgraph/proto';
 import _ from 'lodash';
 

--- a/hedera-mirror-rest/viewmodel/nftViewModel.js
+++ b/hedera-mirror-rest/viewmodel/nftViewModel.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import EntityId from '../entityId.js';
-import {encodeBase64, nsToSecNs} from '../utils.js';
+import EntityId from '../entityId';
+import {encodeBase64, nsToSecNs} from '../utils';
 
 /**
  * NFT view model

--- a/hedera-mirror-rest/viewmodel/stakingRewardTransferViewModel.js
+++ b/hedera-mirror-rest/viewmodel/stakingRewardTransferViewModel.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import EntityId from '../entityId.js';
-import {nsToSecNs} from '../utils.js';
+import EntityId from '../entityId';
+import {nsToSecNs} from '../utils';
 
 /**
  * Staking Reward Transfer view model

--- a/hedera-mirror-rest/viewmodel/tokenAllowanceViewModel.js
+++ b/hedera-mirror-rest/viewmodel/tokenAllowanceViewModel.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import BaseAllowanceViewModel from './baseAllowanceViewModel.js';
-import EntityId from '../entityId.js';
+import BaseAllowanceViewModel from './baseAllowanceViewModel';
+import EntityId from '../entityId';
 
 /**
  * TokenAllowance view model

--- a/hedera-mirror-rest/viewmodel/topicMessageViewModel.js
+++ b/hedera-mirror-rest/viewmodel/topicMessageViewModel.js
@@ -17,10 +17,10 @@
 import _ from 'lodash';
 import {proto} from '@hashgraph/proto';
 
-import EntityId from '../entityId.js';
-import {TransactionId} from '../model/index.js';
-import TransactionIdViewModel from './transactionIdViewModel.js';
-import {encodeBase64, encodeBinary, nsToSecNs} from '../utils.js';
+import EntityId from '../entityId';
+import {TransactionId} from '../model/index';
+import TransactionIdViewModel from './transactionIdViewModel';
+import {encodeBase64, encodeBinary, nsToSecNs} from '../utils';
 
 /**
  * Topic message view model

--- a/hedera-mirror-rest/viewmodel/transactionIdViewModel.js
+++ b/hedera-mirror-rest/viewmodel/transactionIdViewModel.js
@@ -16,8 +16,8 @@
 
 import {proto} from '@hashgraph/proto';
 
-import EntityId from '../entityId.js';
-import {nsToSecNs} from '../utils.js';
+import EntityId from '../entityId';
+import {nsToSecNs} from '../utils';
 
 /**
  * TransactionId view model


### PR DESCRIPTION
**Description**:
The `hedera-mirror-rest` module uses a mix of import statements with and without the `.js` extension.

Change all imports in the rest module to drop the unnecessary `.js` suffix.

**Related issue(s)**:

Fixes #7745

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
