### PR TITLE
Contract call without data causes NPE in web3 (0.99)

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -124,7 +124,11 @@ class ContractController {
      * data size in bytes is doubled for validation of the data length within the request object.
      */
     private void validateContractData(final ContractCallRequest request) {
-        if (!evmProperties.getDataValidatorPattern().matcher(request.getData()).find()) {
+        if (request.getData() != null
+                && !evmProperties
+                        .getDataValidatorPattern()
+                        .matcher(request.getData())
+                        .find()) {
             throw new InvalidParametersException("data field invalid hexadecimal string or contains more than %d digits"
                     .formatted(evmProperties.getMaxDataSize().toBytes() * 2L));
         }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -245,7 +245,8 @@ class ContractControllerTest {
     @Test
     void exceedingDataCallSizeOnEstimate() {
         final var request = request();
-        final var dataAsHex = ONE_BYTE_HEX.repeat((int)evmProperties.getMaxDataSize().toBytes() + 1);
+        final var dataAsHex =
+                ONE_BYTE_HEX.repeat((int) evmProperties.getMaxDataSize().toBytes() + 1);
         request.setData("0x" + dataAsHex);
         request.setEstimate(true);
 
@@ -258,14 +259,16 @@ class ContractControllerTest {
                 .expectStatus()
                 .isEqualTo(BAD_REQUEST)
                 .expectBody(GenericErrorResponse.class)
-                .isEqualTo(new GenericErrorResponse("data field invalid hexadecimal string or contains more than %d digits"
-                        .formatted(evmProperties.getMaxDataSize().toBytes() * 2L)));
+                .isEqualTo(
+                        new GenericErrorResponse("data field invalid hexadecimal string or contains more than %d digits"
+                                .formatted(evmProperties.getMaxDataSize().toBytes() * 2L)));
     }
 
     @Test
     void exceedingDataCreateSizeOnEstimate() {
         final var request = request();
-        final var dataAsHex = ONE_BYTE_HEX.repeat((int)evmProperties.getMaxDataSize().toBytes() + 1);
+        final var dataAsHex =
+                ONE_BYTE_HEX.repeat((int) evmProperties.getMaxDataSize().toBytes() + 1);
         request.setTo(null);
         request.setData("0x" + dataAsHex);
         request.setEstimate(true);
@@ -279,8 +282,9 @@ class ContractControllerTest {
                 .expectStatus()
                 .isEqualTo(BAD_REQUEST)
                 .expectBody(GenericErrorResponse.class)
-                .isEqualTo(new GenericErrorResponse("data field invalid hexadecimal string or contains more than %d digits"
-                        .formatted(evmProperties.getMaxDataSize().toBytes() *2L)));
+                .isEqualTo(
+                        new GenericErrorResponse("data field invalid hexadecimal string or contains more than %d digits"
+                                .formatted(evmProperties.getMaxDataSize().toBytes() * 2L)));
     }
 
     @Test
@@ -453,6 +457,23 @@ class ContractControllerTest {
     void callSuccess() {
         final var request = request();
         request.setData("0x1079023a0000000000000000000000000000000000000000000000000000000000000156");
+        request.setValue(0);
+
+        webClient
+                .post()
+                .uri(CALL_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(request))
+                .exchange()
+                .expectStatus()
+                .isEqualTo(OK);
+    }
+
+    @NullAndEmptySource
+    @ParameterizedTest
+    void callSuccessWithNullAndEmptyData(String data) {
+        final var request = request();
+        request.setData(data);
         request.setValue(0);
 
         webClient


### PR DESCRIPTION
Cherry pick into 0.99.

**Description**:
web3 http requests without call data will cause NPE. There is no null check on `request.getData()` and `java.util.regex.Matcher matcher(@NotNull  CharSequence input)` expect non null argument.

This PR:
* adds the null check
* adds new unit test to verify null and empty call data validate appropriately.

**Related issue(s)**:

Fixes #7789

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
