### PR TITLE
fix: Fix flaky balance call integration test

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -354,7 +354,6 @@ public class EvmConfiguration {
                 gasCalculator,
                 mirrorNodeEvmProperties.chainIdBytes32().toBigInteger());
         Set.of(
-                        new HederaBalanceOperation(gasCalculator, validator),
                         new HederaDelegateCallOperation(gasCalculator, validator),
                         new HederaEvmChainIdOperation(gasCalculator, mirrorNodeEvmProperties),
                         new HederaEvmCreate2Operation(


### PR DESCRIPTION
**Description**:
This PR fixes flaky `ContractCallServiceTest.balanceCallToSystemAccountReturnsZero()`
Evm configuration adds balance operation to it's set two times by mistake  

Modifications:
EvmConfiguration

**Related issue(s)**:

Fixes #7814

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
