### PR TITLE
Improve SyntheticCryptoTransferApprovalMigration in v2

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
@@ -29,9 +29,7 @@ import jakarta.inject.Named;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Data;
@@ -40,6 +38,8 @@ import org.flywaydb.core.api.MigrationVersion;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.util.Version;
 import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.support.TransactionOperations;
 
@@ -48,27 +48,28 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
         implements RecordStreamFileListener {
 
     static final Version HAPI_VERSION_0_38_0 = new Version(0, 38, 0);
-    private final AtomicBoolean executed = new AtomicBoolean(false);
-    // The contract id of the first synthetic transfer that could have exhibited this problem
-    private static final long GRANDFATHERED_ID = 2119900L;
     // The created timestamp of the grandfathered id contract
     static final long LOWER_BOUND_TIMESTAMP = 1680284879342064922L;
-    // This problem was fixed by services release 0.38.6,protobuf release 0.38.10, this is last timestamp before that
+    // This problem was fixed by services release 0.38.6, protobuf release 0.38.10, this is last timestamp before that
     // release
     static final long UPPER_BOUND_TIMESTAMP = 1686243920981874002L;
-    private static final long TIMESTAMP_INCREMENT =
-            Duration.ofDays(1).toNanos(); // 1 day in nanoseconds which will yield 69 async iterations
+
+    // Contracts after the grandfathered id may have exhibited the problem
+    private static final long GRANDFATHERED_ID = 2119900L;
+    // 1 day in nanoseconds which will yield 69 async iterations
+    private static final long TIMESTAMP_INCREMENT = Duration.ofDays(1).toNanos();
     private static final String TRANSFER_SQL =
             """
             with contractresults as (
               select
                 consensus_timestamp,
-                contract_id
-                from contract_result
-                where
-                  consensus_timestamp > :lower_bound and
-                  consensus_timestamp <= :upper_bound and
-                  contract_id >= :grandfathered_id
+                contract_id,
+                payer_account_id
+              from contract_result
+              where
+                consensus_timestamp > :lower_bound and
+                consensus_timestamp <= :upper_bound and
+                contract_id > :grandfathered_id
             ), cryptotransfers as (
               select
                 ct.consensus_timestamp,
@@ -78,11 +79,13 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
                 cast(null as bigint) as token_id,
                 'CRYPTO_TRANSFER' as transfer_type
               from crypto_transfer ct
-              join contractresults cr on cr.consensus_timestamp = ct.consensus_timestamp
+              join contractresults cr using (consensus_timestamp, payer_account_id)
               where
                 cr.contract_id <> ct.entity_id and
                 ct.is_approval = false and
-                ct.amount < 0
+                ct.amount < 0 and
+                ct.consensus_timestamp > :lower_bound and
+                ct.consensus_timestamp <= :upper_bound
             ), tokentransfers as (
               select
                 t.consensus_timestamp,
@@ -92,11 +95,13 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
                 token_id,
                 'TOKEN_TRANSFER' as transfer_type
               from token_transfer t
-              join contractresults cr on cr.consensus_timestamp = t.consensus_timestamp
+              join contractresults cr using (consensus_timestamp, payer_account_id)
               where
                 cr.contract_id <> account_id and
                 is_approval = false and
-                t.amount < 0
+                t.amount < 0 and
+                t.consensus_timestamp > :lower_bound and
+                t.consensus_timestamp <= :upper_bound
             ), nfttransfers as (
               select
                 t.consensus_timestamp,
@@ -106,88 +111,54 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
                 cast(null as bigint) as token_id,
                 'NFT_TRANSFER' as transfer_type
               from transaction t
-              join contractresults cr on cr.consensus_timestamp = t.consensus_timestamp,
+              join contractresults cr using (consensus_timestamp, payer_account_id),
               jsonb_array_elements(nft_transfer) with ordinality arr(item, index)
               where
                 cr.contract_id <> (arr.item->>'sender_account_id')::bigint and
-                (arr.item->>'is_approval')::boolean = false
+                (arr.item->>'is_approval')::boolean = false and
+                t.consensus_timestamp > :lower_bound and
+                t.consensus_timestamp <= :upper_bound
             ), entity as (
-                select key, id, timestamp_range from entity
-                where key is not null
-                union all
-                select key, id, timestamp_range from entity_history
-                where key is not null
-            ), cryptoentities as (
-              select ct.*, e.key
-              from cryptotransfers ct
-              join entity e on e.timestamp_range @> ct.consensus_timestamp::bigint
-              where e.id = ct.sender
-            ), tokenentities as (
-              select t.*, e.key
-              from tokentransfers t
-              join entity e on e.timestamp_range @> t.consensus_timestamp::bigint
-              where e.id = t.sender
-            ), nftentities as (
-              select nft.*, e.key
-              from nfttransfers nft
-              join entity e on e.timestamp_range @> nft.consensus_timestamp::bigint
-              where e.id = nft.sender
-            ) select * from cryptoentities
+              select key, id, timestamp_range from entity
+              where key is not null
               union all
-              select * from tokenentities
+              select key, id, timestamp_range from entity_history
+              where key is not null
+            ), transfer as (
+              select * from cryptotransfers
               union all
-              select * from nftentities
-              order by consensus_timestamp asc
+              select * from tokentransfers
+              union all
+              select * from nfttransfers
+            )
+            select t.*, e.key
+            from transfer t
+            join entity e on e.id = t.sender and e.timestamp_range @> t.consensus_timestamp
+            order by t.consensus_timestamp
             """;
-
+    private static final RowMapper<ApprovalTransfer> ROW_MAPPER = new DataClassRowMapper<>(ApprovalTransfer.class);
     private static final String UPDATE_CRYPTO_TRANSFER_SQL =
             """
-            update crypto_transfer set is_approval = true where consensus_timestamp = :consensus_timestamp and entity_id = :sender
+            update crypto_transfer
+            set is_approval = true
+            where consensus_timestamp = :consensus_timestamp and entity_id = :sender
             """;
     private static final String UPDATE_NFT_TRANSFER_SQL =
             """
-            update transaction set nft_transfer = jsonb_set(nft_transfer, array[:index::text, 'is_approval'], 'true', false) where consensus_timestamp = :consensus_timestamp
+            update transaction
+            set nft_transfer = jsonb_set(nft_transfer, array[:index::text, 'is_approval'], 'true', false)
+            where consensus_timestamp = :consensus_timestamp
             """;
     private static final String UPDATE_TOKEN_TRANSFER_SQL =
             """
-            update token_transfer set is_approval = true where consensus_timestamp = :consensus_timestamp and token_id = :token_id and account_id = :sender
+            update token_transfer
+            set is_approval = true
+            where consensus_timestamp = :consensus_timestamp and token_id = :token_id and account_id = :sender
             """;
 
-    private final RecordFileRepository recordFileRepository;
-
-    @Override
-    public void onEnd(RecordFile streamFile) throws ImporterException {
-        if (streamFile == null) {
-            return;
-        }
-
-        // The services version 0.38.0 has the fixes this migration solves.
-        try {
-            if (streamFile.getHapiVersion().isGreaterThanOrEqualTo(HAPI_VERSION_0_38_0)
-                    && executed.compareAndSet(false, true)) {
-                var latestFile = recordFileRepository.findLatestBefore(streamFile.getConsensusStart());
-                if (latestFile
-                        .filter(f -> f.getHapiVersion().isLessThan(HAPI_VERSION_0_38_0))
-                        .isPresent()) {
-                    doMigrate();
-                }
-            }
-        } catch (IOException e) {
-            log.error("Error executing the migration again after consensus_timestamp {}", streamFile.getConsensusEnd());
-        }
-    }
-
-    private enum TRANSFER_TYPE {
-        CRYPTO_TRANSFER,
-        NFT_TRANSFER,
-        TOKEN_TRANSFER
-    }
-
-    private static final DataClassRowMapper<SyntheticCryptoTransferApprovalMigration.ApprovalTransfer> resultRowMapper =
-            new DataClassRowMapper<>(ApprovalTransfer.class);
-
+    private final AtomicBoolean executed = new AtomicBoolean(false);
     private final ImporterProperties importerProperties;
-    private final NamedParameterJdbcTemplate transferJdbcTemplate;
+    private final RecordFileRepository recordFileRepository;
 
     @Getter
     private final TransactionOperations transactionOperations;
@@ -197,12 +168,11 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
             DBProperties dbProperties,
             RecordFileRepository recordFileRepository,
             ImporterProperties importerProperties,
-            NamedParameterJdbcTemplate transferJdbcTemplate,
+            NamedParameterJdbcTemplate jdbcTemplate,
             TransactionOperations transactionOperations) {
-        super(importerProperties.getMigration(), transferJdbcTemplate, dbProperties.getSchema());
+        super(importerProperties.getMigration(), jdbcTemplate, dbProperties.getSchema());
         this.recordFileRepository = recordFileRepository;
         this.importerProperties = importerProperties;
-        this.transferJdbcTemplate = transferJdbcTemplate;
         this.transactionOperations = transactionOperations;
     }
 
@@ -212,14 +182,14 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
     }
 
     @Override
-    protected MigrationVersion getMinimumVersion() {
-        // The version where the nft_transfer table was migrated to the transaction table
-        return MigrationVersion.fromVersion("1.81.0");
+    protected Long getInitial() {
+        return LOWER_BOUND_TIMESTAMP;
     }
 
     @Override
-    protected Long getInitial() {
-        return LOWER_BOUND_TIMESTAMP;
+    protected MigrationVersion getMinimumVersion() {
+        // The version where the nft_transfer table was migrated to the transaction table
+        return MigrationVersion.fromVersion("1.81.0");
     }
 
     @Override
@@ -232,29 +202,30 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
         long count = 0;
         var migrationErrors = new ArrayList<String>();
         long upperBound = Math.min(lowerBound + TIMESTAMP_INCREMENT, UPPER_BOUND_TIMESTAMP);
-        Map<String, Long> queryParamMap =
-                Map.of("lower_bound", lowerBound, "upper_bound", upperBound, "grandfathered_id", GRANDFATHERED_ID);
+        var params = new MapSqlParameterSource()
+                .addValue("lower_bound", lowerBound)
+                .addValue("upper_bound", upperBound)
+                .addValue("grandfathered_id", GRANDFATHERED_ID);
         try {
-            var transfers = transferJdbcTemplate.query(TRANSFER_SQL, queryParamMap, resultRowMapper);
-            for (ApprovalTransfer transfer : transfers) {
+            var transfers = namedParameterJdbcTemplate.query(TRANSFER_SQL, params, ROW_MAPPER);
+            for (var transfer : transfers) {
                 if (!isAuthorizedByContractKey(transfer, migrationErrors)) {
                     // set is_approval to true
                     String updateSql;
-                    var updateParamMap = new HashMap<String, Number>();
-                    updateParamMap.put("consensus_timestamp", transfer.consensusTimestamp);
+                    var updateParams =
+                            new MapSqlParameterSource().addValue("consensus_timestamp", transfer.consensusTimestamp);
                     if (transfer.transferType == TRANSFER_TYPE.CRYPTO_TRANSFER) {
                         updateSql = UPDATE_CRYPTO_TRANSFER_SQL;
-                        updateParamMap.put("sender", transfer.sender);
+                        updateParams.addValue("sender", transfer.sender);
                     } else if (transfer.transferType == TRANSFER_TYPE.NFT_TRANSFER) {
                         updateSql = UPDATE_NFT_TRANSFER_SQL;
-                        updateParamMap.put("index", transfer.index);
+                        updateParams.addValue("index", transfer.index);
                     } else {
                         updateSql = UPDATE_TOKEN_TRANSFER_SQL;
-                        updateParamMap.put("sender", transfer.sender);
-                        updateParamMap.put("token_id", transfer.tokenId);
+                        updateParams.addValue("sender", transfer.sender).addValue("token_id", transfer.tokenId);
                     }
 
-                    transferJdbcTemplate.update(updateSql, updateParamMap);
+                    namedParameterJdbcTemplate.update(updateSql, updateParams);
                     count++;
                 }
             }
@@ -268,13 +239,42 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
         return upperBound == UPPER_BOUND_TIMESTAMP ? Optional.empty() : Optional.of(upperBound);
     }
 
+    @Override
+    public void onEnd(RecordFile streamFile) throws ImporterException {
+        if (streamFile == null) {
+            return;
+        }
+
+        try {
+            // The services version 0.38.0 has the fixes this migration solves.
+            if (streamFile.getHapiVersion().isGreaterThanOrEqualTo(HAPI_VERSION_0_38_0)
+                    && executed.compareAndSet(false, true)) {
+                var previousFile = recordFileRepository.findLatestBefore(streamFile.getConsensusStart());
+                if (previousFile
+                        .filter(f -> f.getHapiVersion().isLessThan(HAPI_VERSION_0_38_0))
+                        .isPresent()) {
+                    log.info("Run migration after the first record file with HAPI {} is parsed", HAPI_VERSION_0_38_0);
+                    doMigrate();
+                }
+            }
+        } catch (IOException e) {
+            log.error("Error executing the migration again after consensus_timestamp {}", streamFile.getConsensusEnd());
+        }
+    }
+
     /**
      * A return value of false denotes that the transfer's isApproval value should be set to true
      */
     private boolean isAuthorizedByContractKey(ApprovalTransfer transfer, List<String> migrationErrors) {
-        Key parsedKey;
         try {
-            parsedKey = Key.parseFrom(transfer.key);
+            var parsedKey = Key.parseFrom(transfer.key);
+            // If the threshold is greater than one ignore it
+            if (!parsedKey.hasThresholdKey() || parsedKey.getThresholdKey().getThreshold() > 1) {
+                // Update the isApproval value to true
+                return false;
+            }
+
+            return isAuthorizedByThresholdKey(parsedKey, transfer.contractId);
         } catch (Exception e) {
             migrationErrors.add(String.format(
                     "Unable to determine if transfer should be migrated. Entity id %d at %d: %s",
@@ -282,14 +282,6 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
             // Do not update the isApproval value
             return true;
         }
-
-        // If the threshold is greater than one ignore it
-        if (!parsedKey.hasThresholdKey() || parsedKey.getThresholdKey().getThreshold() > 1) {
-            // Update the isApproval value to true
-            return false;
-        }
-
-        return isAuthorizedByThresholdKey(parsedKey, transfer.contractId);
     }
 
     private boolean isAuthorizedByThresholdKey(Key parsedKey, long contractId) {
@@ -318,5 +310,11 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
         private Long sender;
         private Long tokenId;
         private TRANSFER_TYPE transferType;
+    }
+
+    private enum TRANSFER_TYPE {
+        CRYPTO_TRANSFER,
+        NFT_TRANSFER,
+        TOKEN_TRANSFER
     }
 }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigration.java
@@ -234,7 +234,7 @@ public class SyntheticCryptoTransferApprovalMigration extends AsyncJavaMigration
             return Optional.empty();
         }
 
-        log.info("Updated {} synthetic transfer approvals", count);
+        log.info("Updated {} synthetic transfer approvals in timestamp range ({}, {}]", count, lowerBound, upperBound);
         migrationErrors.forEach(log::error);
         return upperBound == UPPER_BOUND_TIMESTAMP ? Optional.empty() : Optional.of(upperBound);
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/SyntheticCryptoTransferApprovalMigrationTest.java
@@ -191,7 +191,7 @@ class SyntheticCryptoTransferApprovalMigrationTest extends ImporterIntegrationTe
                 .persist();
 
         entitySetup();
-        Pair<List<CryptoTransfer>, List<CryptoTransfer>> cryptoTransfersPair = getCryptoTransfersPair(
+        var cryptoTransfersPair = getCryptoTransfersPair(
                 contractId,
                 contractId2,
                 priorContractId,
@@ -200,7 +200,7 @@ class SyntheticCryptoTransferApprovalMigrationTest extends ImporterIntegrationTe
                 noKeyEntity,
                 thresholdTwoKeyEntity);
 
-        Pair<List<NftTransfer>, List<NftTransfer>> nftTransfersTransactionPair = getNftTransfersTransactionPair(
+        var nftTransfersTransactionPair = getNftTransfersTransactionPair(
                 contractId,
                 contractId2,
                 priorContractId,
@@ -209,7 +209,7 @@ class SyntheticCryptoTransferApprovalMigrationTest extends ImporterIntegrationTe
                 noKeyEntity,
                 thresholdTwoKeyEntity);
 
-        Pair<List<TokenTransfer>, List<TokenTransfer>> tokenTransfersPair = getTokenTransfersPair(
+        var tokenTransfersPair = getTokenTransfersPair(
                 contractId,
                 contractId2,
                 priorContractId,
@@ -238,7 +238,7 @@ class SyntheticCryptoTransferApprovalMigrationTest extends ImporterIntegrationTe
                 .persist();
 
         entitySetup();
-        Pair<List<CryptoTransfer>, List<CryptoTransfer>> cryptoTransfersPair = getCryptoTransfersPair(
+        var cryptoTransfersPair = getCryptoTransfersPair(
                 contractId,
                 contractId2,
                 priorContractId,
@@ -247,7 +247,7 @@ class SyntheticCryptoTransferApprovalMigrationTest extends ImporterIntegrationTe
                 noKeyEntity,
                 thresholdTwoKeyEntity);
 
-        Pair<List<NftTransfer>, List<NftTransfer>> nftTransfersTransactionPair = getNftTransfersTransactionPair(
+        var nftTransfersTransactionPair = getNftTransfersTransactionPair(
                 contractId,
                 contractId2,
                 priorContractId,
@@ -256,7 +256,7 @@ class SyntheticCryptoTransferApprovalMigrationTest extends ImporterIntegrationTe
                 noKeyEntity,
                 thresholdTwoKeyEntity);
 
-        Pair<List<TokenTransfer>, List<TokenTransfer>> tokenTransfersPair = getTokenTransfersPair(
+        var tokenTransfersPair = getTokenTransfersPair(
                 contractId,
                 contractId2,
                 priorContractId,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR optimized SyntheticCryptoTransferApprovalMigration in v2

- Restructure the SQL to reduce the number of joins between transfer CTEs and entity CTE
- Fix grandfathered contract id off-by-one bug 
- Add timestamp range limit to transfer tables
- Add distribution column `payer_account_id` to joins and update SQL

**Related issue(s)**:

Fixes #7664 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Tested in citus cluster, the migration took about 5.5 minutes to complete.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
