### PR TITLE
Update OpenAPI to specify Unix timestamp

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -3226,10 +3226,12 @@ components:
       items:
         $ref: "#/components/schemas/StakingRewardTransfer"
     Timestamp:
+      description: A Unix timestamp in seconds.nanoseconds format
       type: string
       example: "1586567700.453054000"
       pattern: '^\d{1,10}(\.\d{1,9})?$'
     TimestampNullable:
+      description: A Unix timestamp in seconds.nanoseconds format
       type: string
       example: "1586567700.453054000"
       pattern: '^\d{1,10}(\.\d{1,9})?$'
@@ -4424,7 +4426,7 @@ components:
         type: string
         pattern: ^((eq|gt|gte|lt|lte):)?\d{1,19}?$
     timestampQueryParam:
-      description: The consensus timestamp in seconds.nanoseconds format with an optional comparison operator
+      description: The consensus timestamp as a Unix timestamp in seconds.nanoseconds format with an optional comparison operator
       name: timestamp
       in: query
       explode: true
@@ -4482,14 +4484,14 @@ components:
     timestampPathParam:
       name: timestamp
       in: path
-      description: The timestamp at which the associated transaction reached consensus
+      description: The Unix timestamp in seconds.nanoseconds format, the timestamp at which the associated transaction reached consensus
       required: true
       example: 1234567890.000000700
       schema:
         type: string
         pattern: ^\d{1,10}(.\d{1,9})?$
     stateTimestampQueryParam:
-      description: The consensus timestamp of the contract state in seconds.nanoseconds format with an optional comparison operator
+      description: The consensus timestamp of the contract state as a Unix timestamp in seconds.nanoseconds format with an optional comparison operator
       name: timestamp
       in: query
       explode: true
@@ -4539,6 +4541,7 @@ components:
           type: string
           pattern: ^((eq|gt|gte|lt|lte):)?\d{1,10}(.\d{1,9})?$
     tokenInfoTimestampQueryParam:
+      description: The Unix timestamp in seconds.nanoseconds format
       name: timestamp
       in: query
       explode: true

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -4426,7 +4426,7 @@ components:
         type: string
         pattern: ^((eq|gt|gte|lt|lte):)?\d{1,19}?$
     timestampQueryParam:
-      description: The consensus timestamp as a Unix timestamp in seconds.nanoseconds format with an optional comparison operator
+      description: The consensus timestamp as a Unix timestamp in seconds.nanoseconds format with an optional comparison operator. See [unixtimestamp.com](https://www.unixtimestamp.com/) for a simple way to convert a date to the 'seconds' part of the Unix time.
       name: timestamp
       in: query
       explode: true
@@ -4484,14 +4484,14 @@ components:
     timestampPathParam:
       name: timestamp
       in: path
-      description: The Unix timestamp in seconds.nanoseconds format, the timestamp at which the associated transaction reached consensus
+      description: The Unix timestamp in seconds.nanoseconds format, the timestamp at which the associated transaction reached consensus. See [unixtimestamp.com](https://www.unixtimestamp.com/) for a simple way to convert a date to the 'seconds' part of the Unix time.
       required: true
       example: 1234567890.000000700
       schema:
         type: string
         pattern: ^\d{1,10}(.\d{1,9})?$
     stateTimestampQueryParam:
-      description: The consensus timestamp of the contract state as a Unix timestamp in seconds.nanoseconds format with an optional comparison operator
+      description: The consensus timestamp of the contract state as a Unix timestamp in seconds.nanoseconds format with an optional comparison operator. See [unixtimestamp.com](https://www.unixtimestamp.com/) for a simple way to convert a date to the 'seconds' part of the Unix time.
       name: timestamp
       in: query
       explode: true
@@ -4541,7 +4541,7 @@ components:
           type: string
           pattern: ^((eq|gt|gte|lt|lte):)?\d{1,10}(.\d{1,9})?$
     tokenInfoTimestampQueryParam:
-      description: The Unix timestamp in seconds.nanoseconds format
+      description: The Unix timestamp in seconds.nanoseconds format. See [unixtimestamp.com](https://www.unixtimestamp.com/) for a simple way to convert a date to the 'seconds' part of the Unix time.
       name: timestamp
       in: query
       explode: true


### PR DESCRIPTION
**Description**:

Updates the OpenAPI specification to specify that timestamps are Unix timestamps

**Related issue(s)**:

Fixes #7754 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
