### PR TITLE
Adapt gas_consumed migration query to get failed initcode from contract_result for failed contract create transactions (0.100)

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillFailedEthereumTransactionContractResultMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillFailedEthereumTransactionContractResultMigrationTest.java
@@ -80,6 +80,7 @@ class BackfillFailedEthereumTransactionContractResultMigrationTest extends Impor
                 ethTx1.getConsensusTimestamp(),
                 domainBuilder.entityId(),
                 domainBuilder.entityId().getId(),
+                null,
                 domainBuilder);
         persistMigrationContractResult(migrationContractResult, jdbcTemplate);
 
@@ -161,7 +162,7 @@ class BackfillFailedEthereumTransactionContractResultMigrationTest extends Impor
         return jdbcTemplate.query(
                 """
                         select amount, bloom, call_result, consensus_timestamp, contract_id, created_contract_ids,
-                        error_message, function_parameters, function_result, gas_limit, gas_used, payer_account_id,
+                        error_message, failed_initcode, function_parameters, function_result, gas_limit, gas_used, payer_account_id,
                         sender_id, transaction_hash, transaction_index, transaction_nonce,
                         transaction_result from contract_result
                         """,
@@ -178,6 +179,7 @@ class BackfillFailedEthereumTransactionContractResultMigrationTest extends Impor
                             .createdContractIds(
                                     createdContractIds == null ? null : List.of((Long[]) createdContractIds.getArray()))
                             .errorMessage(rs.getString("error_message"))
+                            .failedInitcode(rs.getBytes("failed_initcode"))
                             .functionParameters(rs.getBytes("function_parameters"))
                             .functionResult(rs.getBytes("function_result"))
                             .gasLimit(rs.getLong("gas_limit"))

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixTokenAllowanceAmountMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixTokenAllowanceAmountMigrationTest.java
@@ -81,7 +81,7 @@ class FixTokenAllowanceAmountMigrationTest extends ImporterIntegrationTest {
                 .persist();
 
         var migrationContractResult1 = createMigrationContractResult(
-                transferTimestamp1, spender1, domainBuilder.entityId().getId(), domainBuilder);
+                transferTimestamp1, spender1, domainBuilder.entityId().getId(), null, domainBuilder);
         persistMigrationContractResult(migrationContractResult1, jdbcTemplate);
 
         // Token1 allowances granted by owner1, note the first token allowance's amount didn't change while the
@@ -113,7 +113,7 @@ class FixTokenAllowanceAmountMigrationTest extends ImporterIntegrationTest {
                 .persist();
 
         var migrationContractResult2 = createMigrationContractResult(
-                transferTimestamp2, spender1, domainBuilder.entityId().getId(), domainBuilder);
+                transferTimestamp2, spender1, domainBuilder.entityId().getId(), null, domainBuilder);
         persistMigrationContractResult(migrationContractResult2, jdbcTemplate);
 
         // Token2 allowance granted by owner1 to spender2
@@ -135,7 +135,7 @@ class FixTokenAllowanceAmountMigrationTest extends ImporterIntegrationTest {
                 .persist();
 
         var migrationContractResult3 = createMigrationContractResult(
-                transferTimestamp3, spender2, domainBuilder.entityId().getId(), domainBuilder);
+                transferTimestamp3, spender2, domainBuilder.entityId().getId(), null, domainBuilder);
         persistMigrationContractResult(migrationContractResult3, jdbcTemplate);
         // A normal token transfer using token allowance, note due to the inaccuracy in how we mark a transfer as
         // is_approval, the aggregated spent amount is 1000 + 4100 > granted amount 5000, the migration should have a


### PR DESCRIPTION
Description:

Cherry picks https://github.com/hashgraph/hedera-mirror-node/pull/7883 to release/0.100.

**Related issue(s)**:

Fixes #7882 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
