### PR TITLE
Change web3 API to use Spring MVC & virtual threads

### DIFF
--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -53,7 +53,7 @@ tasks.compileJava {
     dependsOn("generateEffectiveLombokConfig")
     // Disable deprecation, serial, and this-escape warnings due to errors in generated code
     options.compilerArgs.addAll(
-        listOf("-Werror", "-Xlint:all", "-Xlint:-deprecation,-serial,-this-escape")
+        listOf("-Werror", "-Xlint:all", "-Xlint:-deprecation,-serial,-this-escape,-preview")
     )
     options.encoding = "UTF-8"
     sourceCompatibility = "21"
@@ -62,7 +62,7 @@ tasks.compileJava {
 
 tasks.compileTestJava {
     dependsOn("generateEffectiveLombokConfig")
-    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all", "-Xlint:-this-escape"))
+    options.compilerArgs.addAll(listOf("-Werror", "-Xlint:all", "-Xlint:-this-escape,-preview"))
     options.encoding = "UTF-8"
     sourceCompatibility = "21"
     targetCompatibility = "21"

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-web3.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-web3.json
@@ -806,7 +806,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(reactor_netty_http_server_data_received_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (uri) / sum(rate(reactor_netty_http_server_data_received_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (uri) >= 0",
+          "expr": "sum(rate(hedera_mirror_web3_request_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (uri) / sum(rate(hedera_mirror_web3_request_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (uri) >= 0",
           "interval": "1m",
           "legendFormat": "{{uri}}",
           "range": true,
@@ -1020,7 +1020,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(reactor_netty_http_server_data_sent_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (uri) / sum(rate(reactor_netty_http_server_data_sent_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (uri) >= 0",
+          "expr": "sum(rate(hedera_mirror_web3_response_bytes_sum{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (uri) / sum(rate(hedera_mirror_web3_response_bytes_count{application=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (uri) >= 0",
           "interval": "1m",
           "legendFormat": "{{uri}}",
           "range": true,
@@ -2888,13 +2888,7 @@
         "y": 155
       },
       "id": 54,
-      "links": [
-        {
-          "targetBlank": true,
-          "title": "Explore Logs",
-          "url": "/explore?panes={\"rl3\":{\"datasource\":\"${loki}\",\"queries\":[{\"refId\":\"A\",\"expr\":\"{app=\\\"web3\\\", cluster=\\\"${cluster:text}\\\", namespace=\\\"${namespace:text}\\\"} |= ``\",\"queryType\":\"range\",\"datasource\":{\"type\":\"loki\",\"uid\":\"${loki}\"},\"editorMode\":\"builder\"}],\"range\":{\"from\":\"${__from}\",\"to\":\"${__to}\"}}}&schemaVersion=1&orgId=1"
-        }
-      ],
+      "links": [],
       "options": {
         "dedupStrategy": "none",
         "enableLogDetails": false,

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -53,7 +53,7 @@ global:
 hpa:
   behavior: {}
   enabled: false
-  maxReplicas: 8
+  maxReplicas: 12
   metrics:
     - type: Resource
       resource:
@@ -256,8 +256,8 @@ resources:
     cpu: 2
     memory: 2048Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 1
+    memory: 1024Mi
 
 revisionHistoryLimit: 3
 

--- a/charts/hedera-mirror/ci/v1-values.yaml
+++ b/charts/hedera-mirror/ci/v1-values.yaml
@@ -41,3 +41,9 @@ restjava:
       cpu: 200m
 rosetta:
   enabled: true
+web3:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+

--- a/charts/hedera-mirror/ci/v2-values.yaml
+++ b/charts/hedera-mirror/ci/v2-values.yaml
@@ -51,3 +51,9 @@ rosetta:
 stackgres:
   enabled: true
   podAntiAffinity: false
+web3:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+

--- a/docs/web3/README.md
+++ b/docs/web3/README.md
@@ -2,10 +2,6 @@
 
 The Web3 API provides Java-based REST APIs for the mirror node.
 
-## Contract Call
-
-Currently, the Web3 module only provides a partial implementation of contract call.
-
 ## Technologies
 
 This module uses [Spring Boot](https://spring.io/projects/spring-boot) for its application framework. To serve the
@@ -13,35 +9,10 @@ APIs, [Spring WebFlux](https://docs.spring.io/spring-framework/docs/current/refe
 is used with annotation-based controllers. [Spring Data JPA](https://spring.io/projects/spring-data-jpa) with Hibernate
 is used for the persistence layer.
 
-## Acceptance Tests
-
-The Web3 API uses [Postman](https://www.postman.com) tests to verify proper operation. The
-[Newman](https://learning.postman.com/docs/running-collections/using-newman-cli/command-line-integration-with-newman)
-command-line collection runner is used to execute the tests against a remote server. To use newman, either the
-executable binary or Docker approach can be used. With either approach, a `baseUrl` variable can be supplied to
-customize the target server.
-
-### Executable
-
-First ensure newman is installed locally using `npm`, then execute `newman`.
-
-```shell
-npm install -g newman
-newman run charts/hedera-mirror-web3/postman.json --env-var baseUrl=https://previewnet.mirrornode.hedera.com
-```
-
-### Docker
-
-```shell
-docker run --rm -v "${PWD}/charts/hedera-mirror-web3/postman.json:/tmp/postman.json" -t postman/newman run /tmp/postman.json --env-var baseUrl=https://previewnet.mirrornode.hedera.com
-```
-
-_Note:_ To test against an instance running on the same machine as Docker use your local IP instead of 127.0.0.1.
-
-### Supported/unsupported operations
+## Supported Operations
 
 | Estimate | Static | Operation Type                                                                            | Supported | Historical | Reads | Modifications |
-| -------- | ------ | ----------------------------------------------------------------------------------------- | --------- | ---------- | ----- | ------------- |
+|----------|--------|-------------------------------------------------------------------------------------------|-----------|------------|-------|---------------|
 | Y        | Y      | non precompile functions                                                                  | Y         | Y          | Y     | Y             |
 | Y        | N      | non precompile functions with lazy account creation                                       | Y         | Y          | Y     | Y             |
 | Y        | Y      | operations for ERC precompile functions (balance, symbol, tokenURI, name, decimals, etc.) | Y         | Y          | Y     | N             |
@@ -52,3 +23,47 @@ _Note:_ To test against an instance running on the same machine as Docker use yo
 | Y        | N      | modifying operations for HTS system contract                                              | Y         | Y          | Y     | Y             |
 
 _Note:_ Gas estimation only supports the `latest` block
+
+## Acceptance Tests
+
+The [acceptance tests](/hedera-mirror-test/README.md) contain a suite of tests to validate a web3 deployment.
+The `@web3` acceptance tag can be used to specifically target the web3 module.
+
+`./gradlew :test:acceptance --info -Dcucumber.filter.tags=@web3`
+
+## Smoke Tests
+
+The Web3 API uses [Postman](https://www.postman.com) tests to verify proper operation. The
+[Newman](https://learning.postman.com/docs/running-collections/using-newman-cli/command-line-integration-with-newman)
+command-line collection runner is used to execute the tests against a remote server. To use newman, either the
+executable binary or Docker approach can be used. With either approach, a `baseUrl` variable can be supplied to
+customize the target server.
+
+To run the Postman tests, first ensure newman is installed locally using `npm`, then execute `newman`.
+
+```shell
+npm install -g newman
+newman run charts/hedera-mirror-web3/postman.json --env-var baseUrl=https://previewnet.mirrornode.hedera.com
+```
+
+Alternatively, Docker can be used execute the smoke tests:
+
+```shell
+docker run --rm -v "${PWD}/charts/hedera-mirror-web3/postman.json:/tmp/postman.json" -t postman/newman run /tmp/postman.json --env-var baseUrl=https://previewnet.mirrornode.hedera.com
+```
+
+_Note:_ To test against an instance running on the same machine as Docker use your local IP instead of 127.0.0.1.
+
+## Manual Tests
+
+```shell
+curl -X 'POST' https://testnet.mirrornode.hedera.com/api/v1/contracts/call -H 'Content-Type: application/json' -d \
+'{
+  "block": "latest",
+  "data": "0x2e3cff6a0000000000000000000000000000000000000000000000000000000000000064",
+  "estimate": false,
+  "gas": 15000000,
+  "gasPrice": 100000000,
+  "to": "0x0000000000000000000000000000000000000168"
+}'
+```

--- a/hedera-mirror-web3/Dockerfile
+++ b/hedera-mirror-web3/Dockerfile
@@ -4,7 +4,7 @@ COPY build/libs/*.jar ./
 RUN java -Djarmode=layertools -jar *.jar extract
 
 FROM eclipse-temurin:21-jre-jammy
-ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80"
+ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=80 --enable-preview"
 EXPOSE 8545
 HEALTHCHECK --interval=10s --retries=3 --start-period=50s --timeout=2s CMD curl -f http://localhost:8545/actuator/health/liveness
 WORKDIR /app

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -34,19 +34,21 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-actuator-autoconfigure")
     implementation("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
     implementation("org.springframework.cloud:spring-cloud-starter-kubernetes-fabric8-config")
-    runtimeOnly(
-        group = "io.netty",
-        name = "netty-resolver-dns-native-macos",
-        classifier = "osx-aarch_64"
-    )
     runtimeOnly("org.postgresql:postgresql")
     testImplementation(project(path = ":common", configuration = "testClasses"))
-    testImplementation("io.projectreactor:reactor-test")
     testImplementation("org.flywaydb:flyway-core")
     testImplementation("org.mockito:mockito-inline")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:postgresql")
 }
+
+tasks.bootRun { jvmArgs = listOf("--enable-preview") }
+
+tasks.compileJava { options.compilerArgs.add("--enable-preview") }
+
+tasks.compileTestJava { options.compilerArgs.add("--enable-preview") }
+
+tasks.test { jvmArgs = listOf("--enable-preview") }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/LoggingFilter.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/LoggingFilter.java
@@ -17,92 +17,48 @@
 package com.hedera.mirror.web3.config;
 
 import jakarta.inject.Named;
-import java.io.Serial;
-import java.net.InetSocketAddress;
-import java.net.URI;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpResponse;
-import org.springframework.util.CollectionUtils;
-import org.springframework.web.server.ServerWebExchange;
-import org.springframework.web.server.WebFilter;
-import org.springframework.web.server.WebFilterChain;
-import reactor.core.publisher.Mono;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @CustomLog
 @Named
-class LoggingFilter implements WebFilter {
-
-    static final String X_FORWARDED_FOR = "X-Forwarded-For";
+class LoggingFilter extends OncePerRequestFilter {
 
     @SuppressWarnings("java:S1075")
     private static final String ACTUATOR_PATH = "/actuator/";
 
-    private static final String LOCALHOST = "127.0.0.1";
     private static final String LOG_FORMAT = "{} {} {} in {} ms: {}";
 
     @Override
-    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
         long start = System.currentTimeMillis();
-        return chain.filter(exchange)
-                .transformDeferred(call -> call.doOnEach(signal -> doFilter(exchange, signal.getThrowable(), start))
-                        .doOnCancel(() -> doFilter(exchange, new CancelledException(), start)));
-    }
+        Exception cause = null;
 
-    private void doFilter(ServerWebExchange exchange, Throwable cause, long start) {
-        ServerHttpResponse response = exchange.getResponse();
-        if (response.isCommitted() || cause instanceof CancelledException) {
-            logRequest(exchange, start, cause);
-        } else {
-            response.beforeCommit(() -> {
-                logRequest(exchange, start, cause);
-                return Mono.empty();
-            });
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception t) {
+            cause = t;
+        } finally {
+            logRequest(request, response, start, cause);
         }
     }
 
-    private void logRequest(ServerWebExchange exchange, long startTime, Throwable cause) {
+    private void logRequest(HttpServletRequest request, HttpServletResponse response, long startTime, Exception cause) {
         long elapsed = System.currentTimeMillis() - startTime;
-        ServerHttpRequest request = exchange.getRequest();
-        URI uri = request.getURI();
-        var message =
-                cause != null ? cause.getMessage() : exchange.getResponse().getStatusCode();
-        var params = new Object[] {getClient(request), request.getMethod(), uri, elapsed, message};
+        String uri = request.getRequestURI();
+        var message = cause != null ? cause.getMessage() : response.getStatus();
+        var params = new Object[] {request.getRemoteAddr(), request.getMethod(), uri, elapsed, message};
 
-        if (StringUtils.startsWith(uri.getPath(), ACTUATOR_PATH)) {
+        if (StringUtils.startsWith(uri, ACTUATOR_PATH)) {
             log.debug(LOG_FORMAT, params);
         } else if (cause != null) {
             log.warn(LOG_FORMAT, params);
         } else {
             log.info(LOG_FORMAT, params);
-        }
-    }
-
-    private String getClient(ServerHttpRequest request) {
-        String xForwardedFor = CollectionUtils.firstElement(request.getHeaders().get(X_FORWARDED_FOR));
-
-        if (StringUtils.isNotBlank(xForwardedFor)) {
-            return xForwardedFor;
-        }
-
-        InetSocketAddress remoteAddress = request.getRemoteAddress();
-
-        if (remoteAddress != null && remoteAddress.getAddress() != null) {
-            return remoteAddress.getAddress().toString();
-        }
-
-        return LOCALHOST;
-    }
-
-    private static class CancelledException extends RuntimeException {
-        private static final String MESSAGE = "cancelled";
-
-        @Serial
-        private static final long serialVersionUID = 2585926663177724443L;
-
-        CancelledException() {
-            super(MESSAGE);
         }
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/MetricsConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/MetricsConfiguration.java
@@ -16,20 +16,9 @@
 
 package com.hedera.mirror.web3.config;
 
-import com.google.common.collect.Sets;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
 import io.micrometer.core.instrument.binder.MeterBinder;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.springframework.boot.actuate.web.mappings.reactive.DispatcherHandlerMappingDescription;
-import org.springframework.boot.actuate.web.mappings.reactive.DispatcherHandlerMappingDetails;
-import org.springframework.boot.actuate.web.mappings.reactive.DispatcherHandlersMappingDescriptionProvider;
-import org.springframework.boot.actuate.web.mappings.reactive.RequestMappingConditionsDescription;
-import org.springframework.boot.web.embedded.netty.NettyServerCustomizer;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -44,24 +33,5 @@ class MetricsConfiguration {
     @Bean
     MeterBinder processThreadMetrics() {
         return new ProcessThreadMetrics();
-    }
-
-    @Bean
-    NettyServerCustomizer nettyServerCustomizer(ApplicationContext applicationContext) {
-        var provider = new DispatcherHandlersMappingDescriptionProvider();
-        Set<String> patterns = provider.describeMappings(applicationContext).values().stream()
-                .flatMap(List::stream)
-                .map(DispatcherHandlerMappingDescription::getDetails)
-                .filter(Objects::nonNull)
-                .map(DispatcherHandlerMappingDetails::getRequestMappingConditions)
-                .map(RequestMappingConditionsDescription::getPatterns)
-                .flatMap(Set::stream)
-                .filter(s -> !s.contains("*"))
-                .collect(Collectors.toSet());
-
-        Set<String> routes = Sets.union(patterns, Set.of("/actuator/health/liveness", "/actuator/health/readiness"));
-        final String unknownPath = "unknown";
-
-        return n -> n.metrics(true, route -> routes.contains(route) ? route : unknownPath);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/MetricsFilter.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/MetricsFilter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.config;
+
+import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
+import static org.springframework.web.servlet.HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Meter.MeterProvider;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import jakarta.inject.Named;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.CustomLog;
+import org.apache.catalina.connector.ResponseFacade;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
+
+@CustomLog
+@Named
+class MetricsFilter extends OncePerRequestFilter {
+
+    static final String REQUEST_BYTES = "hedera.mirror.web3.request.bytes";
+    static final String RESPONSE_BYTES = "hedera.mirror.web3.response.bytes";
+
+    private static final String METHOD = "method";
+    private static final String URI = "uri";
+
+    private final MeterProvider<DistributionSummary> requestBytesProvider;
+    private final MeterProvider<DistributionSummary> responseBytesProvider;
+
+    MetricsFilter(MeterRegistry meterRegistry) {
+        this.requestBytesProvider = DistributionSummary.builder(REQUEST_BYTES)
+                .baseUnit("bytes")
+                .description("The size of the request in bytes")
+                .withRegistry(meterRegistry);
+        this.responseBytesProvider = DistributionSummary.builder(RESPONSE_BYTES)
+                .baseUnit("bytes")
+                .description("The size of the response in bytes")
+                .withRegistry(meterRegistry);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            recordMetrics(request, response);
+        }
+    }
+
+    private void recordMetrics(HttpServletRequest request, ServletResponse response) {
+        if (request.getAttribute(BEST_MATCHING_PATTERN_ATTRIBUTE) instanceof String uri) {
+            var tags = Tags.of(METHOD, request.getMethod(), URI, uri);
+
+            var contentLengthHeader = request.getHeader(CONTENT_LENGTH);
+            if (contentLengthHeader != null) {
+                long contentLength = Math.max(0L, NumberUtils.toLong(contentLengthHeader));
+                requestBytesProvider.withTags(tags).record(contentLength);
+            }
+
+            var responseFacade = WebUtils.getNativeResponse(response, ResponseFacade.class);
+            if (responseFacade != null) {
+                var responseSize = responseFacade.getContentWritten();
+                responseBytesProvider.withTags(tags).record(responseSize);
+            }
+        }
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -48,6 +48,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.springframework.dao.QueryTimeoutException;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,10 +58,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.support.WebExchangeBindException;
 import org.springframework.web.server.ServerWebInputException;
-import org.springframework.web.server.UnsupportedMediaTypeStatusException;
-import reactor.core.publisher.Mono;
 
 @CustomLog
 @RequestMapping("/api/v1/contracts")
@@ -71,7 +71,7 @@ class ContractController {
 
     @CrossOrigin(origins = "*")
     @PostMapping(value = "/call")
-    Mono<ContractCallResponse> call(@RequestBody @Valid ContractCallRequest request) {
+    ContractCallResponse call(@RequestBody @Valid ContractCallRequest request) {
 
         if (!bucket.tryConsume(1)) {
             throw new RateLimitException("Rate limit exceeded.");
@@ -84,7 +84,7 @@ class ContractController {
         final var result = contractCallService.processCall(params);
         final var callResponse = new ContractCallResponse(result);
 
-        return Mono.just(callResponse);
+        return callResponse;
     }
 
     private CallServiceParameters constructServiceParameters(ContractCallRequest request) {
@@ -154,79 +154,86 @@ class ContractController {
      **/
     @ExceptionHandler
     @ResponseStatus(NOT_IMPLEMENTED)
-    private Mono<GenericErrorResponse> unsupportedOpResponse(final UnsupportedOperationException e) {
+    private GenericErrorResponse unsupportedOpResponse(final UnsupportedOperationException e) {
         return errorResponse(e.getMessage());
     }
 
     @ExceptionHandler
     @ResponseStatus(TOO_MANY_REQUESTS)
-    private Mono<GenericErrorResponse> rateLimitError(final RateLimitException e) {
+    private GenericErrorResponse rateLimitError(final RateLimitException e) {
         return errorResponse(e.getMessage());
     }
 
     @ExceptionHandler
     @ResponseStatus(BAD_REQUEST)
-    private Mono<GenericErrorResponse> validationError(final WebExchangeBindException e) {
+    private GenericErrorResponse validationError(final BindException e) {
         final var errors = extractValidationError(e);
         log.warn("Validation error: {}", errors);
-        return Mono.just(new GenericErrorResponse(errors));
+        return new GenericErrorResponse(errors);
     }
 
     @ExceptionHandler
     @ResponseStatus(BAD_REQUEST)
-    private Mono<GenericErrorResponse> inputValidationError(final InvalidInputException e) {
+    private GenericErrorResponse inputValidationError(final InvalidInputException e) {
         log.warn("Input validation error: {}", e.getMessage());
-        return Mono.just(new GenericErrorResponse(e.getMessage()));
+        return new GenericErrorResponse(e.getMessage());
     }
 
     @ExceptionHandler
     @ResponseStatus(BAD_REQUEST)
-    private Mono<GenericErrorResponse> mirrorEvmTransactionException(final MirrorEvmTransactionException e) {
+    private GenericErrorResponse mirrorEvmTransactionException(final MirrorEvmTransactionException e) {
         log.warn("Mirror EVM transaction error: {}", e.getMessage());
         return errorResponse(e.getMessage(), e.getDetail(), e.getData());
     }
 
     @ExceptionHandler
     @ResponseStatus(BAD_REQUEST)
-    private Mono<GenericErrorResponse> invalidJson(final ServerWebInputException e) {
+    private GenericErrorResponse invalidJson(final ServerWebInputException e) {
         log.warn("Transaction body parsing error: {}", e.getMessage());
         return errorResponse(e.getReason(), "Unable to parse JSON", StringUtils.EMPTY);
     }
 
     @ExceptionHandler
+    @ResponseStatus(BAD_REQUEST)
+    private GenericErrorResponse invalidJson(final HttpMessageConversionException e) {
+        log.warn("Transaction body parsing error: {}", e.getMessage());
+        return errorResponse("Unable to parse JSON", e.getMessage(), StringUtils.EMPTY);
+    }
+
+    @ExceptionHandler
     @ResponseStatus(NOT_FOUND)
-    private Mono<GenericErrorResponse> notFound(final EntityNotFoundException e) {
+    private GenericErrorResponse notFound(final EntityNotFoundException e) {
         log.warn("Not found: {}", e.getMessage());
         return errorResponse(e.getMessage());
     }
 
     @ExceptionHandler
     @ResponseStatus(UNSUPPORTED_MEDIA_TYPE)
-    private Mono<GenericErrorResponse> unsupportedMediaTypeError(final UnsupportedMediaTypeStatusException e) {
+    private GenericErrorResponse unsupportedMediaTypeError(final HttpMediaTypeNotSupportedException e) {
         log.warn("Unsupported media type error: {}", e.getMessage());
-        return errorResponse(UNSUPPORTED_MEDIA_TYPE.getReasonPhrase(), e.getReason(), StringUtils.EMPTY);
+        return errorResponse(UNSUPPORTED_MEDIA_TYPE.getReasonPhrase(), e.getMessage(), StringUtils.EMPTY);
     }
 
     @ExceptionHandler
     @ResponseStatus(INTERNAL_SERVER_ERROR)
-    private Mono<GenericErrorResponse> genericError(final Exception e) {
+    private GenericErrorResponse genericError(final Exception e) {
         log.error("Generic error: ", e);
         return errorResponse(INTERNAL_SERVER_ERROR.getReasonPhrase());
     }
 
     @ExceptionHandler
     @ResponseStatus(SERVICE_UNAVAILABLE)
-    private Mono<GenericErrorResponse> queryTimeout(final QueryTimeoutException e) {
+    private GenericErrorResponse queryTimeout(final QueryTimeoutException e) {
         log.error("Query timed out: {}", e.getMessage());
         return errorResponse(SERVICE_UNAVAILABLE.getReasonPhrase());
     }
 
-    private Mono<GenericErrorResponse> errorResponse(final String errorMessage) {
-        return Mono.just(new GenericErrorResponse(errorMessage));
+    private GenericErrorResponse errorResponse(final String errorMessage) {
+        return new GenericErrorResponse(errorMessage);
     }
 
-    private Mono<GenericErrorResponse> errorResponse(
+    private GenericErrorResponse errorResponse(
             final String errorMessage, final String detailedErrorMessage, final String hexErrorMessage) {
-        return Mono.just(new GenericErrorResponse(errorMessage, detailedErrorMessage, hexErrorMessage));
+        return new GenericErrorResponse(errorMessage, detailedErrorMessage, hexErrorMessage);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ValidationErrorParser.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ValidationErrorParser.java
@@ -17,20 +17,15 @@
 package com.hedera.mirror.web3.controller;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
+import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
-import org.springframework.web.bind.support.WebExchangeBindException;
 
 @UtilityClass
 public class ValidationErrorParser {
 
-    public static String parseValidationError(WebExchangeBindException e) {
-        return e.getAllErrors().stream().map(ValidationErrorParser::formatError).collect(Collectors.joining(", "));
-    }
-
-    public static List<String> extractValidationError(WebExchangeBindException e) {
+    public static List<String> extractValidationError(BindException e) {
         return e.getAllErrors().stream().map(ValidationErrorParser::formatError).toList();
     }
 

--- a/hedera-mirror-web3/src/main/resources/application.yml
+++ b/hedera-mirror-web3/src/main/resources/application.yml
@@ -39,13 +39,14 @@ management:
 server:
   compression:
     enabled: true
+  forward-headers-strategy: framework # Enable spring ForwardedHeaderFilter
   http2:
     enabled: true
   max-http-request-header-size: 1KB
-  netty:
-    connection-timeout: 3s
   port: 8545
   shutdown: graceful
+  tomcat:
+    connection-timeout: 3s
 spring:
   application:
     name: hedera-mirror-web3
@@ -74,6 +75,7 @@ spring:
       validation-timeout: 3000
   jpa:
     database: PostgreSQL
+    open-in-view: false
     properties:
       hibernate.criteria.literal_handling_mode: BIND # Ensure Criteria API queries use bind parameters and not literals
       hibernate.generate_statistics: true
@@ -81,3 +83,6 @@ spring:
       hibernate.type.json_format_mapper: com.hedera.mirror.common.converter.CustomJsonFormatMapper
   lifecycle:
     timeout-per-shutdown-phase: 20s
+  threads:
+    virtual:
+      enabled: true

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/ContextExtension.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/ContextExtension.java
@@ -38,8 +38,7 @@ public class ContextExtension implements InvocationInterceptor {
     public <T> T interceptTestFactoryMethod(
             Invocation<T> invocation,
             ReflectiveInvocationContext<Method> invocationContext,
-            ExtensionContext extensionContext)
-            throws Throwable {
+            ExtensionContext extensionContext) {
         return intercept(invocation, invocationContext);
     }
 
@@ -47,8 +46,7 @@ public class ContextExtension implements InvocationInterceptor {
     public void interceptTestMethod(
             Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext,
-            ExtensionContext extensionContext)
-            throws Throwable {
+            ExtensionContext extensionContext) {
         intercept(invocation, invocationContext);
     }
 
@@ -56,22 +54,22 @@ public class ContextExtension implements InvocationInterceptor {
     public void interceptTestTemplateMethod(
             Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext,
-            ExtensionContext extensionContext)
-            throws Throwable {
+            ExtensionContext extensionContext) {
         intercept(invocation, invocationContext);
     }
 
-    private <T> T intercept(Invocation<T> invocation, ReflectiveInvocationContext<Method> invocationContext)
-            throws Throwable {
-
+    private <T> T intercept(Invocation<T> invocation, ReflectiveInvocationContext<Method> invocationContext) {
         var stackedStateFrames =
                 getStackedStateFrames(invocationContext.getTarget().get());
 
-        try (var context = ContractCallContext.init()) {
-            context.initializeStackFrames(stackedStateFrames);
-            log.debug("Creating new context {}", context);
-            return invocation.proceed();
-        }
+        return ContractCallContext.run(context -> {
+            try {
+                context.initializeStackFrames(stackedStateFrames);
+                return invocation.proceed();
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     // If there's a Store field on the test use it to initialize the context

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/config/LoggingFilterTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/config/LoggingFilterTest.java
@@ -16,114 +16,75 @@
 
 package com.hedera.mirror.web3.config;
 
+import static com.google.common.net.HttpHeaders.X_FORWARDED_FOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
-import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
-import org.springframework.mock.web.server.MockServerWebExchange;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 
 @ExtendWith(OutputCaptureExtension.class)
 class LoggingFilterTest {
-
-    private static final Duration WAIT = Duration.ofSeconds(10L);
-
     private final LoggingFilter loggingFilter = new LoggingFilter();
+    private final MockHttpServletResponse response = new MockHttpServletResponse();
+    private final MockFilterChain chain = new MockFilterChain();
 
     @Test
+    @SneakyThrows
     void filterOnSuccess(CapturedOutput output) {
-        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
-        exchange.getResponse().setRawStatusCode(200);
+        var request = new MockHttpServletRequest("GET", "/");
 
-        StepVerifier.withVirtualTime(() -> loggingFilter.filter(
-                        exchange,
-                        serverWebExchange ->
-                                Mono.defer(() -> exchange.getResponse().setComplete())))
-                .thenAwait(WAIT)
-                .expectComplete()
-                .verify(WAIT);
+        response.setStatus(HttpStatus.OK.value());
+
+        loggingFilter.doFilter(request, response, chain);
 
         assertLog(output, "INFO", "\\w+ GET / in \\d+ ms: 200");
     }
 
     @Test
+    @SneakyThrows
     void filterPath(CapturedOutput output) {
-        var exchange = MockServerWebExchange.from(
-                MockServerHttpRequest.get("/actuator/").build());
-        exchange.getResponse().setRawStatusCode(200);
+        var request = new MockHttpServletRequest("GET", "/actuator/");
 
-        StepVerifier.withVirtualTime(() -> loggingFilter.filter(
-                        exchange,
-                        serverWebExchange ->
-                                Mono.defer(() -> exchange.getResponse().setComplete())))
-                .thenAwait(WAIT)
-                .expectComplete()
-                .verify(WAIT);
+        response.setStatus(HttpStatus.OK.value());
+
+        loggingFilter.doFilter(request, response, chain);
 
         assertThat(output).asString().isEmpty();
     }
 
     @Test
+    @SneakyThrows
     void filterXForwardedFor(CapturedOutput output) {
         String clientIp = "10.0.0.100";
-        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/")
-                .header(LoggingFilter.X_FORWARDED_FOR, clientIp)
-                .build());
-        exchange.getResponse().setRawStatusCode(200);
+        var request = new MockHttpServletRequest("GET", "/");
+        request.addHeader(X_FORWARDED_FOR, clientIp);
+        response.setStatus(HttpStatus.OK.value());
 
-        StepVerifier.withVirtualTime(() -> loggingFilter.filter(
-                        exchange,
-                        serverWebExchange ->
-                                Mono.defer(() -> exchange.getResponse().setComplete())))
-                .thenAwait(WAIT)
-                .expectComplete()
-                .verify(WAIT);
+        new ForwardedHeaderFilter()
+                .doFilter(request, response, (request1, response) -> loggingFilter.doFilter(request1, response, chain));
 
         assertLog(output, "INFO", clientIp + " GET / in \\d+ ms: 200");
     }
 
     @Test
-    void filterOnCancel(CapturedOutput output) {
-        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
-
-        StepVerifier.withVirtualTime(() -> loggingFilter.filter(
-                        exchange, serverWebExchange -> exchange.getResponse().setComplete()))
-                .thenCancel()
-                .verify(WAIT);
-
-        assertLog(output, "WARN", "\\w+ GET / in \\d+ ms: cancelled");
-    }
-
-    @Test
-    void filterOnCancelActuator(CapturedOutput output) {
-        var exchange = MockServerWebExchange.from(
-                MockServerHttpRequest.get("/actuator/prometheus").build());
-
-        StepVerifier.withVirtualTime(() -> loggingFilter.filter(
-                        exchange, serverWebExchange -> exchange.getResponse().setComplete()))
-                .thenCancel()
-                .verify(WAIT);
-
-        assertThat(output).asString().isEmpty();
-    }
-
-    @Test
+    @SneakyThrows
     void filterOnError(CapturedOutput output) {
-        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
-        exchange.getResponse().setRawStatusCode(500);
-
+        var request = new MockHttpServletRequest("GET", "/");
         var exception = new IllegalArgumentException("error");
-        StepVerifier.withVirtualTime(() -> loggingFilter
-                        .filter(exchange, serverWebExchange -> Mono.error(exception))
-                        .onErrorResume((t) -> exchange.getResponse().setComplete()))
-                .thenAwait(WAIT)
-                .expectComplete()
-                .verify(WAIT);
+
+        response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+
+        loggingFilter.doFilter(request, response, (request1, response) -> {
+            throw exception;
+        });
 
         assertLog(output, "WARN", "\\w+ GET / in \\d+ ms: " + exception.getMessage());
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/config/MetricsFilterTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/config/MetricsFilterTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.config;
+
+import static com.hedera.mirror.web3.config.MetricsFilter.REQUEST_BYTES;
+import static com.hedera.mirror.web3.config.MetricsFilter.RESPONSE_BYTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
+import static org.springframework.web.servlet.HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.Search;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import lombok.SneakyThrows;
+import org.apache.catalina.connector.ResponseFacade;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+@ExtendWith(MockitoExtension.class)
+class MetricsFilterTest {
+
+    private static final String METHOD = "GET";
+    private static final String PATH = "/actuator/prometheus";
+
+    private final MockFilterChain chain = new MockFilterChain();
+    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final MetricsFilter metricsFilter = new MetricsFilter(meterRegistry);
+    private final MockHttpServletRequest request = new MockHttpServletRequest(METHOD, PATH);
+
+    @Mock
+    private ResponseFacade response;
+
+    @Test
+    @SneakyThrows
+    void filterOnSuccess() {
+        long contentLength = 100L;
+        long responseSize = 200L;
+        request.setAttribute(BEST_MATCHING_PATTERN_ATTRIBUTE, PATH);
+        request.addHeader(CONTENT_LENGTH, contentLength);
+        doReturn(responseSize).when(response).getContentWritten();
+
+        metricsFilter.doFilter(request, response, chain);
+
+        assertThat(meterRegistry.find(REQUEST_BYTES).tags("method", METHOD, "uri", PATH))
+                .isNotNull()
+                .extracting(Search::summary)
+                .isNotNull()
+                .returns(1L, DistributionSummary::count)
+                .returns((double) contentLength, DistributionSummary::totalAmount);
+        assertThat(meterRegistry.find(RESPONSE_BYTES).tags("method", METHOD, "uri", PATH))
+                .isNotNull()
+                .extracting(Search::summary)
+                .isNotNull()
+                .returns(1L, DistributionSummary::count)
+                .returns((double) responseSize, DistributionSummary::totalAmount);
+    }
+}


### PR DESCRIPTION
**Description**:

* Add request and response metrics to replace reactor netty metrics
* Enable virtual threads
* Change from reactive Spring WebFlux to synchronous Spring MVC
* Change `ThreadLocal` to `ScopedValue` preview feature
* Improve web3 test documentation

**Related issue(s)**:

Fixes #7566

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
