### PR TITLE
07895: TransferFrom token to hollow account fails

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -168,8 +168,7 @@ public class MirrorNodeClient {
 
     public CryptoAllowancesResponse getAccountCryptoAllowance(String accountId) {
         log.debug("Verify account '{}''s crypto allowance is returned by Mirror Node", accountId);
-        return callRestEndpoint(
-                "/accounts/{accountId}/allowances/crypto", CryptoAllowancesResponse.class, accountId);
+        return callRestEndpoint("/accounts/{accountId}/allowances/crypto", CryptoAllowancesResponse.class, accountId);
     }
 
     public CryptoAllowancesResponse getAccountCryptoAllowanceBySpender(String accountId, String spenderId) {
@@ -213,8 +212,7 @@ public class MirrorNodeClient {
 
     public ContractResult getContractResultByTransactionId(String transactionId) {
         log.debug("Verify contract result '{}' is returned by Mirror Node", transactionId);
-        return callRestEndpoint(
-                "/contracts/results/{transactionId}", ContractResult.class, transactionId);
+        return callRestEndpoint("/contracts/results/{transactionId}", ContractResult.class, transactionId);
     }
 
     public ContractActionsResponse getContractActions(String transactionId) {
@@ -257,8 +255,7 @@ public class MirrorNodeClient {
 
     public Nft getNftInfo(String tokenId, long serialNumber) {
         log.debug("Verify serial number '{}' for token '{}' is returned by Mirror Node", serialNumber, tokenId);
-        return callRestEndpoint(
-                "/tokens/{tokenId}/nfts/{serialNumber}", Nft.class, tokenId, serialNumber);
+        return callRestEndpoint("/tokens/{tokenId}/nfts/{serialNumber}", Nft.class, tokenId, serialNumber);
     }
 
     public NftTransactionHistory getNftTransactions(TokenId tokenId, Long serialNumber) {
@@ -309,10 +306,7 @@ public class MirrorNodeClient {
                 accountId,
                 tokenId);
         return callRestEndpoint(
-                "/accounts/{accountId}/tokens?token.id={tokenId}",
-                TokenRelationshipResponse.class,
-                accountId,
-                tokenId);
+                "/accounts/{accountId}/tokens?token.id={tokenId}", TokenRelationshipResponse.class, accountId, tokenId);
     }
 
     public AccountBalanceTransactions getAccountDetailsUsingAlias(@NonNull AccountId accountId) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -168,7 +168,8 @@ public class MirrorNodeClient {
 
     public CryptoAllowancesResponse getAccountCryptoAllowance(String accountId) {
         log.debug("Verify account '{}''s crypto allowance is returned by Mirror Node", accountId);
-        return callRestEndpoint("/accounts/{accountId}/allowances/crypto", CryptoAllowancesResponse.class, accountId);
+        return callRestEndpoint(
+                "/accounts/{accountId}/allowances/crypto", CryptoAllowancesResponse.class, accountId);
     }
 
     public CryptoAllowancesResponse getAccountCryptoAllowanceBySpender(String accountId, String spenderId) {
@@ -212,7 +213,8 @@ public class MirrorNodeClient {
 
     public ContractResult getContractResultByTransactionId(String transactionId) {
         log.debug("Verify contract result '{}' is returned by Mirror Node", transactionId);
-        return callRestEndpoint("/contracts/results/{transactionId}", ContractResult.class, transactionId);
+        return callRestEndpoint(
+                "/contracts/results/{transactionId}", ContractResult.class, transactionId);
     }
 
     public ContractActionsResponse getContractActions(String transactionId) {
@@ -255,7 +257,8 @@ public class MirrorNodeClient {
 
     public Nft getNftInfo(String tokenId, long serialNumber) {
         log.debug("Verify serial number '{}' for token '{}' is returned by Mirror Node", serialNumber, tokenId);
-        return callRestEndpoint("/tokens/{tokenId}/nfts/{serialNumber}", Nft.class, tokenId, serialNumber);
+        return callRestEndpoint(
+                "/tokens/{tokenId}/nfts/{serialNumber}", Nft.class, tokenId, serialNumber);
     }
 
     public NftTransactionHistory getNftTransactions(TokenId tokenId, Long serialNumber) {
@@ -306,7 +309,10 @@ public class MirrorNodeClient {
                 accountId,
                 tokenId);
         return callRestEndpoint(
-                "/accounts/{accountId}/tokens?token.id={tokenId}", TokenRelationshipResponse.class, accountId, tokenId);
+                "/accounts/{accountId}/tokens?token.id={tokenId}",
+                TokenRelationshipResponse.class,
+                accountId,
+                tokenId);
     }
 
     public AccountBalanceTransactions getAccountDetailsUsingAlias(@NonNull AccountId accountId) {

--- a/hedera-mirror-test/src/test/resources/features/contract/equivalence.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/equivalence.feature
@@ -133,22 +133,19 @@ Feature: in-equivalence tests
     Examples:
       | account     |
 #      contract reverts due to INVALID_ALIAS_KEY - C but should be INVALID_RECEIVING_NODE_ACCOUNT
-#      contract reverts due to INVALID_ACCOUNT_ID - M but should be INVALID_RECEIVING_NODE_ACCOUNT
-      | "0.0.0"     |
-#      contract reverts due to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT - M but should be INVALID_RECEIVING_NODE_ACCOUNT
+#      success - M but should be 400 Bad Request
+#      | "0.0.0"     |
       | "0.0.1"     |
-#      contract reverts due to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT - M but should be INVALID_RECEIVING_NODE_ACCOUNT
       | "0.0.4"     |
 #      contract reverts due to INVALID_ALIAS_KEY - C but should be INVALID_RECEIVING_NODE_ACCOUNT
-#      contract reverts due to INVALID_ACCOUNT_ID - M but should be INVALID_RECEIVING_NODE_ACCOUNT
-      | "0.0.358"   |
+#      success - M but should be 400 Bad Request
+#      | "0.0.358"   |
 #      contract reverts due to INVALID_ALIAS_KEY - C but should be INVALID_RECEIVING_NODE_ACCOUNT
-#      contract reverts due to INVALID_ACCOUNT_ID - M but should be INVALID_RECEIVING_NODE_ACCOUNT
-      | "0.0.359"   |
+#      success - M but should be 400 Bad Request
+#      | "0.0.359"   |
 #      contract reverts due to INVALID_ALIAS_KEY - C but should be INVALID_RECEIVING_NODE_ACCOUNT
-#      contract reverts due to INVALID_ACCOUNT_ID - M but should be INVALID_RECEIVING_NODE_ACCOUNT
-      | "0.0.360"   |
-#      contract reverts due to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT - M but should be INVALID_RECEIVING_NODE_ACCOUNT
+#      success - M but should be 400 Bad Request
+#      | "0.0.360"   |
       | "0.0.741"   |
       | "0.0.800"   |
 
@@ -165,13 +162,13 @@ Feature: in-equivalence tests
     Given I mint a new nft
     Then the mirror node REST API should return status 200 for the HAPI transactions
     Then I call precompile with transferFrom "FUNGIBLE" token to a "BOB" EVM address
-#    Then I call precompile with transferFrom "NFTEQUIVALENCE" token to a "BOB" EVM address // success but should fail
+    Then I call precompile with transferFrom "NFTEQUIVALENCE" token to a "BOB" EVM address
     Then I call precompile with transferFrom "NFTEQUIVALENCE" token to a "ALICE" EVM address
     Then I call precompile with transferFrom "FUNGIBLE" token to a "ALICE" EVM address
     Given I mint a new nft
     Then the mirror node REST API should return status 200 for the HAPI transactions
-#    Then I call precompile with transferFrom "NFTEQUIVALENCE" token to an EVM address // fails on mirror node since the address is not found in the state and it is not created
-#    Then I call precompile with transferFrom "FUNGIBLE" token to an EVM address // same as above
+    Then I call precompile with transferFrom "NFTEQUIVALENCE" token to an EVM address
+    Then I call precompile with transferFrom "FUNGIBLE" token to an EVM address
     Given I mint a new nft
     Then the mirror node REST API should return status 200 for the HAPI transactions
     And I update the "BOB" account and token key for contract "ESTIMATE_PRECOMPILE"

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
@@ -397,7 +397,8 @@ public class ServicesConfiguration {
             final ContextOptionValidator contextOptionValidator,
             final AutoCreationLogic autoCreationLogic,
             final SyntheticTxnFactory syntheticTxnFactory,
-            final EntityAddressSequencer entityAddressSequencer) {
+            final EntityAddressSequencer entityAddressSequencer,
+            final Predicate<Address> systemAccountDetector) {
         return new TransferPrecompile(
                 pricingUtils,
                 mirrorNodeEvmProperties,
@@ -405,7 +406,8 @@ public class ServicesConfiguration {
                 contextOptionValidator,
                 autoCreationLogic,
                 syntheticTxnFactory,
-                entityAddressSequencer);
+                entityAddressSequencer,
+                systemAccountDetector);
     }
 
     @Bean
@@ -417,7 +419,8 @@ public class ServicesConfiguration {
             final AutoCreationLogic autoCreationLogic,
             final SyntheticTxnFactory syntheticTxnFactory,
             final EncodingFacade encoder,
-            final EntityAddressSequencer entityAddressSequencer) {
+            final EntityAddressSequencer entityAddressSequencer,
+            final Predicate<Address> systemAccountDetector) {
         return new ERCTransferPrecompile(
                 pricingUtils,
                 mirrorNodeEvmProperties,
@@ -426,7 +429,8 @@ public class ServicesConfiguration {
                 autoCreationLogic,
                 syntheticTxnFactory,
                 entityAddressSequencer,
-                encoder);
+                encoder,
+                systemAccountDetector);
     }
 
     @Bean

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessor.java
@@ -33,6 +33,7 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import java.util.Optional;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
@@ -71,8 +72,12 @@ public class MirrorEvmMessageCallProcessor extends AbstractEvmMessageCallProcess
         final var timestamp = Timestamp.newBuilder()
                 .setSeconds(frame.getBlockValues().getTimestamp())
                 .build();
-        final var lazyCreateResult =
-                autoCreationLogic.create(syntheticBalanceChange, timestamp, updater.getStore(), entityAddressSequencer);
+        final var lazyCreateResult = autoCreationLogic.create(
+                syntheticBalanceChange,
+                timestamp,
+                updater.getStore(),
+                entityAddressSequencer,
+                List.of(syntheticBalanceChange));
         if (lazyCreateResult.getLeft() != ResponseCodeEnum.OK) {
             haltFrameAndTraceCreationResult(frame, operationTracer, FAILURE_DURING_LAZY_ACCOUNT_CREATE);
         } else {

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/ledger/TransferLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/ledger/TransferLogic.java
@@ -82,7 +82,8 @@ public class TransferLogic {
                                 .setSeconds(Instant.now().getEpochSecond())
                                 .build(),
                         store,
-                        ids);
+                        ids,
+                        changes);
                 validity = result.getKey();
                 if (validity == OK && (change.isForToken())) {
                     validity = hederaTokenStore.tryTokenChange(change);

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -343,7 +343,8 @@ public class HTSPrecompiledContract extends EvmHTSPrecompiledContract {
                         transactionBodyBuilder = precompile.body(
                                 input.slice(24),
                                 aliasResolver,
-                                new ERCTransferParams(nestedFunctionSelector, senderAddress, tokenAccessor, tokenId));
+                                new ERCTransferParams(
+                                        nestedFunctionSelector, senderAddress, tokenAccessor, tokenId, store::exists));
                     }
                     default -> {
                         precompile =
@@ -396,7 +397,9 @@ public class HTSPrecompiledContract extends EvmHTSPrecompiledContract {
             case AbiConstants.ABI_ID_TRANSFER_FROM, AbiConstants.ABI_ID_TRANSFER_FROM_NFT -> {
                 precompile = precompileMapper.lookup(functionId).orElseThrow();
                 transactionBodyBuilder = precompile.body(
-                        input, aliasResolver, new ERCTransferParams(functionId, senderAddress, tokenAccessor, null));
+                        input,
+                        aliasResolver,
+                        new ERCTransferParams(functionId, senderAddress, tokenAccessor, null, store::exists));
             }
             case AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN,
                     AbiConstants.ABI_ID_CREATE_FUNGIBLE_TOKEN_V2,

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactory.java
@@ -106,9 +106,14 @@ public class SyntheticTxnFactory {
         return TransactionBody.newBuilder().setTokenMint(builder);
     }
 
-    public TransactionBody.Builder createHollowAccount(final ByteString alias, final long balance) {
+    public TransactionBody.Builder createHollowAccount(
+            final ByteString alias, final long balance, final int maxAutoAssociations) {
         final var baseBuilder = createAccountBase(balance);
-        baseBuilder.setKey(asKeyUnchecked(EMPTY_KEY)).setAlias(alias).setMemo(LAZY_MEMO);
+        baseBuilder
+                .setKey(asKeyUnchecked(EMPTY_KEY))
+                .setAlias(alias)
+                .setMemo(LAZY_MEMO)
+                .setMaxAutomaticTokenAssociations(maxAutoAssociations);
         return TransactionBody.newBuilder().setCryptoCreateAccount(baseBuilder.build());
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/DecodingFacade.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/DecodingFacade.java
@@ -235,6 +235,17 @@ public class DecodingFacade {
         return accountIdFromEvmAddress(resolvedAddress);
     }
 
+    public static AccountID convertLeftPaddedAddressToAccountId(
+            final byte[] leftPaddedAddress,
+            @NonNull final UnaryOperator<byte[]> aliasResolver,
+            @NonNull final Predicate<Address> exists) {
+        var accountID = convertLeftPaddedAddressToAccountId(leftPaddedAddress, aliasResolver);
+        if (!exists.test(EntityIdUtils.asTypedEvmAddress(accountID)) && !accountID.hasAlias()) {
+            accountID = generateAccountIDWithAliasCalculatedFrom(accountID);
+        }
+        return accountID;
+    }
+
     public static String removeBrackets(final String type) {
         final var typeWithRemovedOpenBracket = type.replace("(", "");
         return typeWithRemovedOpenBracket.replace(")", "");

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ERCTransferParams.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/codec/ERCTransferParams.java
@@ -18,7 +18,9 @@ package com.hedera.services.store.contracts.precompile.codec;
 
 import com.hedera.node.app.service.evm.store.tokens.TokenAccessor;
 import com.hederahashgraph.api.proto.java.TokenID;
+import java.util.function.Predicate;
 import org.hyperledger.besu.datatypes.Address;
 
-public record ERCTransferParams(int functionId, Address senderAddress, TokenAccessor tokenAccessor, TokenID tokenID)
+public record ERCTransferParams(
+        int functionId, Address senderAddress, TokenAccessor tokenAccessor, TokenID tokenID, Predicate<Address> exists)
         implements BodyParams {}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TransferPrecompile.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/impl/TransferPrecompile.java
@@ -20,8 +20,8 @@ import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT
 import static com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases.isMirror;
 import static com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmDecodingFacade.decodeFunctionCall;
 import static com.hedera.node.app.service.evm.store.contracts.utils.EvmParsingConstants.INT;
+import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateFalseOrRevert;
 import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
-import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrueOrRevert;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_CRYPTO_TRANSFER;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_CRYPTO_TRANSFER_V2;
 import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_TRANSFER_NFT;
@@ -648,6 +648,6 @@ public class TransferPrecompile extends AbstractWritePrecompile {
                 ? EntityIdUtils.asTypedEvmAddress(change.counterPartyAccountId())
                 : change.getAccount().asEvmAddress();
 
-        validateTrueOrRevert(!systemAccountDetector.test(accountAddress), INVALID_RECEIVING_NODE_ACCOUNT);
+        validateFalseOrRevert(systemAccountDetector.test(accountAddress), INVALID_RECEIVING_NODE_ACCOUNT);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorTest.java
@@ -60,7 +60,7 @@ class MirrorEvmMessageCallProcessorTest extends MirrorEvmMessageCallProcessorBas
 
     @Test
     void executeLazyCreateFailsWithHaltReason() {
-        when(autoCreationLogic.create(any(), any(), any(), any())).thenReturn(Pair.of(NOT_SUPPORTED, 0L));
+        when(autoCreationLogic.create(any(), any(), any(), any(), any())).thenReturn(Pair.of(NOT_SUPPORTED, 0L));
 
         subject.executeLazyCreate(messageFrame, operationTracer);
 
@@ -71,8 +71,8 @@ class MirrorEvmMessageCallProcessorTest extends MirrorEvmMessageCallProcessorBas
     }
 
     @Test
-    void executeLazyCreateFailsWithInsuffiientGas() {
-        when(autoCreationLogic.create(any(), any(), any(), any())).thenReturn(Pair.of(OK, 1000L));
+    void executeLazyCreateFailsWithInsufficientGas() {
+        when(autoCreationLogic.create(any(), any(), any(), any(), any())).thenReturn(Pair.of(OK, 1000L));
         when(messageFrame.getRemainingGas()).thenReturn(0L);
         when(messageFrame.getGasPrice()).thenReturn(Wei.ONE);
         subject.executeLazyCreate(messageFrame, operationTracer);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
@@ -302,7 +302,8 @@ class ContractCallEvmCodesTest extends ContractCallTestSetup {
     @Test
     void selfDestructCallWithSystemAccount() {
         // destroyContract(address)
-        final var destroyContractInput = "0x016a3738000000000000000000000000" + OWNER_ADDRESS.toUnprefixedHexString();
+        final var destroyContractInput =
+                "0x016a3738000000000000000000000000" + SYSTEM_ACCOUNT_ADDRESS.toUnprefixedHexString();
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(destroyContractInput), EVM_CODES_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -248,7 +248,7 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     @Test
     void balanceCallToSystemAccountReturnsZero() {
         // getAccountBalance(address)
-        final var balanceCall = "0x93423e9c000000000000000000000000" + SENDER_ADDRESS.toUnprefixedHexString();
+        final var balanceCall = "0x93423e9c000000000000000000000000" + SYSTEM_ACCOUNT_ADDRESS.toUnprefixedHexString();
         final var expectedBalance = "0x0000000000000000000000000000000000000000000000000000000000000000";
         final var serviceParameters = serviceParametersForExecution(
                 Bytes.fromHexString(balanceCall), ETH_CALL_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -146,7 +146,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     // Account addresses
     protected static final Address AUTO_RENEW_ACCOUNT_ADDRESS = toAddress(EntityId.of(0, 0, 740));
     protected static final Address AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1078));
-    protected static final Address SPENDER_ADDRESS = toAddress(EntityId.of(0, 0, 741));
+    protected static final Address SPENDER_ADDRESS = toAddress(EntityId.of(0, 0, 1041));
     protected static final Address SPENDER_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1016));
     protected static final ByteString SPENDER_PUBLIC_KEY =
             ByteString.fromHex("3a2102ff806fecbd31b4c377293cba8d2b78725965a4990e0ff1b1b29a1d2c61402310");
@@ -156,7 +156,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
             Bytes.wrap(recoverAddressFromPubKey(SPENDER_PUBLIC_KEY.substring(2).toByteArray())));
     protected static final Address SPENDER_ALIAS_HISTORICAL = Address.wrap(Bytes.wrap(
             recoverAddressFromPubKey(SPENDER_PUBLIC_KEY_HISTORICAL.substring(2).toByteArray())));
-    protected static final Address SENDER_ADDRESS = toAddress(EntityId.of(0, 0, 742));
+    protected static final Address SENDER_ADDRESS = toAddress(EntityId.of(0, 0, 1043));
     protected static final Address SENDER_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1014));
     protected static final ByteString SENDER_PUBLIC_KEY =
             ByteString.copyFrom(Hex.decode("3a2103af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d"));
@@ -167,14 +167,14 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final Address SENDER_ALIAS_HISTORICAL = Address.wrap(Bytes.wrap(
             recoverAddressFromPubKey(SENDER_PUBLIC_KEY_HISTORICAL.substring(2).toByteArray())));
     protected static final Address TREASURY_ADDRESS = toAddress(EntityId.of(0, 0, 743));
-    protected static final Address NOT_ASSOCIATED_SPENDER_ADDRESS = toAddress(EntityId.of(0, 0, 744));
+    protected static final Address NOT_ASSOCIATED_SPENDER_ADDRESS = toAddress(EntityId.of(0, 0, 1066));
     protected static final ByteString NOT_ASSOCIATED_SPENDER_PUBLIC_KEY =
             ByteString.fromHex("3a21033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d");
     protected static final Address NOT_ASSOCIATED_SPENDER_ALIAS = Address.wrap(Bytes.wrap(recoverAddressFromPubKey(
             NOT_ASSOCIATED_SPENDER_PUBLIC_KEY.substring(2).toByteArray())));
-    protected static final Address OWNER_ADDRESS = toAddress(EntityId.of(0, 0, 750));
-    protected static final Address OWNER_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 751));
-
+    protected static final Address OWNER_ADDRESS = toAddress(EntityId.of(0, 0, 1044));
+    protected static final Address OWNER_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1065));
+    protected static final Address SYSTEM_ACCOUNT_ADDRESS = toAddress(EntityId.of(0, 0, 700));
     // Token addresses
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_WITH_EXPIRY = toAddress(EntityId.of(0, 0, 1042));
     protected static final Address FUNGIBLE_TOKEN_ADDRESS_WITH_EXPIRY_HISTORICAL = toAddress(EntityId.of(0, 0, 1077));
@@ -1074,6 +1074,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
         receiverPersist();
         final var senderEntityId = senderEntityPersist();
         final var ownerEntityId = ownerEntityPersist();
+        final var systemAccountEntityId = systemAccountEntityPersist();
         final var spenderEntityId = spenderEntityPersist();
         notAssociatedSpenderEntityPersist();
         final var treasuryEntityId = treasureEntityPersist();
@@ -1854,6 +1855,21 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 .persist();
 
         return ownerEntityId;
+    }
+
+    @Nullable
+    private EntityId systemAccountEntityPersist() {
+        final var systemAccountEntityId = fromEvmAddress(SYSTEM_ACCOUNT_ADDRESS.toArrayUnsafe());
+
+        domainBuilder
+                .entity()
+                .customize(e -> e.id(systemAccountEntityId.getId())
+                        .num(systemAccountEntityId.getNum())
+                        .evmAddress(null)
+                        .alias(toEvmAddress(systemAccountEntityId))
+                        .balance(20000L))
+                .persist();
+        return systemAccountEntityId;
     }
 
     @Nullable

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/ledger/TransferLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/ledger/TransferLogicTest.java
@@ -135,7 +135,7 @@ class TransferLogicTest {
         final var failingTrigger = BalanceChange.changingHbar(aliasedAa(firstAlias, firstAmount), payer);
         final var changes = List.of(failingTrigger);
 
-        given(autoCreationLogic.create(eq(failingTrigger), any(), eq(store), eq(ids)))
+        given(autoCreationLogic.create(eq(failingTrigger), any(), eq(store), eq(ids), eq(changes)))
                 .willReturn(Pair.of(INSUFFICIENT_ACCOUNT_BALANCE, 0L));
 
         assertFailsWith(() -> subject.doZeroSum(changes, store, ids, hederaTokenStore), INSUFFICIENT_ACCOUNT_BALANCE);
@@ -159,13 +159,13 @@ class TransferLogicTest {
                 .willReturn(account);
         var nft = getEmptyUniqueToken();
         given(store.getUniqueToken(any(), eq(OnMissing.THROW))).willReturn(nft);
-        given(autoCreationLogic.create(eq(nftTransfer), any(), eq(store), eq(ids)))
+        given(autoCreationLogic.create(eq(nftTransfer), any(), eq(store), eq(ids), eq(changes)))
                 .willReturn(Pair.of(OK, 100L));
         given(hederaTokenStore.tryTokenChange(any())).willReturn(OK);
 
         subject.doZeroSum(changes, store, ids, hederaTokenStore);
 
-        verify(autoCreationLogic).create(eq(nftTransfer), any(), eq(store), eq(ids));
+        verify(autoCreationLogic).create(eq(nftTransfer), any(), eq(store), eq(ids), eq(changes));
     }
 
     @Test
@@ -179,16 +179,16 @@ class TransferLogicTest {
         final var changes = List.of(fungibleTransfer, anotherFungibleTransfer);
 
         given(store.getAccount(asTypedEvmAddress(payer), OnMissing.THROW)).willReturn(account);
-        given(autoCreationLogic.create(eq(fungibleTransfer), any(), eq(store), eq(ids)))
+        given(autoCreationLogic.create(eq(fungibleTransfer), any(), eq(store), eq(ids), eq(changes)))
                 .willReturn(Pair.of(OK, 100L));
-        given(autoCreationLogic.create(eq(anotherFungibleTransfer), any(), eq(store), eq(ids)))
+        given(autoCreationLogic.create(eq(anotherFungibleTransfer), any(), eq(store), eq(ids), eq(changes)))
                 .willReturn(Pair.of(OK, 100L));
         given(hederaTokenStore.tryTokenChange(any())).willReturn(OK);
 
         subject.doZeroSum(changes, store, ids, hederaTokenStore);
 
-        verify(autoCreationLogic).create(eq(fungibleTransfer), any(), eq(store), eq(ids));
-        verify(autoCreationLogic).create(eq(anotherFungibleTransfer), any(), eq(store), eq(ids));
+        verify(autoCreationLogic).create(eq(fungibleTransfer), any(), eq(store), eq(ids), eq(changes));
+        verify(autoCreationLogic).create(eq(anotherFungibleTransfer), any(), eq(store), eq(ids), eq(changes));
     }
 
     @Test
@@ -218,8 +218,8 @@ class TransferLogicTest {
 
             subject.doZeroSum(changes, store, ids, hederaTokenStore);
 
-            verify(autoCreationLogic, never()).create(eq(fungibleTransfer), any(), eq(store), eq(ids));
-            verify(autoCreationLogic, never()).create(eq(nftTransfer), any(), eq(store), eq(ids));
+            verify(autoCreationLogic, never()).create(eq(fungibleTransfer), any(), eq(store), eq(ids), eq(changes));
+            verify(autoCreationLogic, never()).create(eq(nftTransfer), any(), eq(store), eq(ids), eq(changes));
         }
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/SyntheticTxnFactoryTest.java
@@ -154,7 +154,7 @@ class SyntheticTxnFactoryTest {
     void createsExpectedHollowAccountCreate() {
         final var balance = 10L;
         final var evmAddressAlias = ByteString.copyFrom(Hex.decode("a94f5374fce5edbc8e2a8697c15331677e6ebf0b"));
-        final var result = subject.createHollowAccount(evmAddressAlias, balance);
+        final var result = subject.createHollowAccount(evmAddressAlias, balance, 1);
         final var txnBody = result.build();
 
         assertTrue(txnBody.hasCryptoCreateAccount());
@@ -167,7 +167,7 @@ class SyntheticTxnFactoryTest {
                 THREE_MONTHS_IN_SECONDS,
                 txnBody.getCryptoCreateAccount().getAutoRenewPeriod().getSeconds());
         assertEquals(10L, txnBody.getCryptoCreateAccount().getInitialBalance());
-        assertEquals(0L, txnBody.getCryptoCreateAccount().getMaxAutomaticTokenAssociations());
+        assertEquals(1, txnBody.getCryptoCreateAccount().getMaxAutomaticTokenAssociations());
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/TransferPrecompileTest.java
@@ -98,6 +98,7 @@ import com.hederahashgraph.api.proto.java.TransferList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
@@ -206,6 +207,9 @@ class TransferPrecompileTest {
     private EntityAddressSequencer entityAddressSequencer;
 
     @Mock
+    private Predicate<Address> systemAccountDetector;
+
+    @Mock
     private HederaEvmStackedWorldStateUpdater worldUpdater;
 
     @Mock
@@ -243,7 +247,8 @@ class TransferPrecompileTest {
                 contextOptionValidator,
                 autoCreationLogic,
                 syntheticTxnFactory,
-                entityAddressSequencer);
+                entityAddressSequencer,
+                systemAccountDetector);
         PrecompileMapper precompileMapper = new PrecompileMapper(Set.of(transferPrecompile));
         subject = new HTSPrecompiledContract(
                 infrastructureFactory, mirrorNodeEvmProperties, precompileMapper, store, tokenAccessor, pricingUtils);
@@ -556,7 +561,7 @@ class TransferPrecompileTest {
         given(precompileContext.getSenderAddress()).willReturn(contractAddress);
         given(worldUpdater.getStore()).willReturn(store);
         final var lazyCreationFee = 500L;
-        when(autoCreationLogic.create(any(), any(), any(), any()))
+        when(autoCreationLogic.create(any(), any(), any(), any(), any()))
                 .thenReturn(Pair.of(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED, lazyCreationFee));
 
         // when:

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/impl/ERCTransferPrecompileTest.java
@@ -93,8 +93,8 @@ class ERCTransferPrecompileTest {
     void decodeTransferFromFungibleInputUsingApprovalIfNotOwner() {
         final var notOwner = IdUtils.asAccount("0.0.1002");
         given(tokenAccessor.typeOf(any())).willReturn(TokenType.FUNGIBLE_COMMON);
-        final var decodedInput =
-                decodeERCTransferFrom(TRANSFER_FROM_FUNGIBLE_INPUT, tokenID, tokenAccessor, notOwner, identity());
+        final var decodedInput = decodeERCTransferFrom(
+                TRANSFER_FROM_FUNGIBLE_INPUT, tokenID, tokenAccessor, notOwner, identity(), x -> true);
         final var fungibleTransfer = decodedInput.tokenTransferWrappers().get(0).fungibleTransfers();
 
         assertTrue(fungibleTransfer.get(0).receiver().getAccountNum() > 0);
@@ -107,8 +107,8 @@ class ERCTransferPrecompileTest {
     void decodeHapiTransferFromFungibleInputUsingApprovalIfNotOwner() {
         final var notOwner = IdUtils.asAccount("0.0.1002");
         given(tokenAccessor.typeOf(any())).willReturn(TokenType.FUNGIBLE_COMMON);
-        final var decodedInput =
-                decodeERCTransferFrom(HAPI_TRANSFER_FROM_FUNGIBLE_INPUT, null, tokenAccessor, notOwner, identity());
+        final var decodedInput = decodeERCTransferFrom(
+                HAPI_TRANSFER_FROM_FUNGIBLE_INPUT, null, tokenAccessor, notOwner, identity(), x -> true);
         final var fungibleTransfer = decodedInput.tokenTransferWrappers().get(0).fungibleTransfers();
         assertEquals(HTSTestsUtil.token, fungibleTransfer.get(0).getDenomination());
         assertEquals(fungibleTransfer.get(1).sender(), IdUtils.asAccount("0.0.1450"));
@@ -121,8 +121,8 @@ class ERCTransferPrecompileTest {
     void decodeTransferFromFungibleInputStillUsesApprovalIfFromIsOperator() {
         final var owner = IdUtils.asAccount("0.0.1450");
         given(tokenAccessor.typeOf(any())).willReturn(TokenType.FUNGIBLE_COMMON);
-        final var decodedInput =
-                decodeERCTransferFrom(TRANSFER_FROM_FUNGIBLE_INPUT, tokenID, tokenAccessor, owner, identity());
+        final var decodedInput = decodeERCTransferFrom(
+                TRANSFER_FROM_FUNGIBLE_INPUT, tokenID, tokenAccessor, owner, identity(), x -> true);
         final var fungibleTransfer = decodedInput.tokenTransferWrappers().get(0).fungibleTransfers();
 
         assertTrue(fungibleTransfer.get(0).receiver().getAccountNum() > 0);
@@ -135,8 +135,8 @@ class ERCTransferPrecompileTest {
     void decodeHapiTransferFromFungibleInputStillUsesApprovalIfFromIsOperator() {
         final var owner = IdUtils.asAccount("0.0.1450");
         given(tokenAccessor.typeOf(any())).willReturn(TokenType.FUNGIBLE_COMMON);
-        final var decodedInput =
-                decodeERCTransferFrom(HAPI_TRANSFER_FROM_FUNGIBLE_INPUT, null, tokenAccessor, owner, identity());
+        final var decodedInput = decodeERCTransferFrom(
+                HAPI_TRANSFER_FROM_FUNGIBLE_INPUT, null, tokenAccessor, owner, identity(), x -> true);
         final var fungibleTransfer = decodedInput.tokenTransferWrappers().get(0).fungibleTransfers();
 
         assertEquals(IdUtils.asToken("0.0.1"), fungibleTransfer.get(0).getDenomination());
@@ -150,8 +150,8 @@ class ERCTransferPrecompileTest {
     void decodeTransferFromNonFungibleInputUsingApprovalIfNotOwner() {
         final var notOwner = IdUtils.asAccount("0.0.1002");
         given(tokenAccessor.typeOf(any())).willReturn(TokenType.NON_FUNGIBLE_UNIQUE);
-        final var decodedInput =
-                decodeERCTransferFrom(TRANSFER_FROM_NON_FUNGIBLE_INPUT, tokenID, tokenAccessor, notOwner, identity());
+        final var decodedInput = decodeERCTransferFrom(
+                TRANSFER_FROM_NON_FUNGIBLE_INPUT, tokenID, tokenAccessor, notOwner, identity(), x -> true);
         final var nftTransfer = decodedInput
                 .tokenTransferWrappers()
                 .get(0)
@@ -169,8 +169,8 @@ class ERCTransferPrecompileTest {
     void decodeHapiTransferFromNFTInputUsingApprovalIfNotOwner() {
         final var notOwner = IdUtils.asAccount("0.0.1002");
         given(tokenAccessor.typeOf(any())).willReturn(TokenType.NON_FUNGIBLE_UNIQUE);
-        final var decodedInput =
-                decodeERCTransferFrom(HAPI_TRANSFER_FROM_NFT_INPUT, null, tokenAccessor, notOwner, identity());
+        final var decodedInput = decodeERCTransferFrom(
+                HAPI_TRANSFER_FROM_NFT_INPUT, null, tokenAccessor, notOwner, identity(), x -> true);
         final var nftTransfer =
                 decodedInput.tokenTransferWrappers().get(0).nftExchanges().get(0);
 
@@ -186,8 +186,8 @@ class ERCTransferPrecompileTest {
     void decodeTransferFromNonFungibleInputIfOwner() {
         final var owner = IdUtils.asAccount("0.0.1001");
         given(tokenAccessor.typeOf(any())).willReturn(TokenType.NON_FUNGIBLE_UNIQUE);
-        final var decodedInput =
-                decodeERCTransferFrom(TRANSFER_FROM_NON_FUNGIBLE_INPUT, tokenID, tokenAccessor, owner, identity());
+        final var decodedInput = decodeERCTransferFrom(
+                TRANSFER_FROM_NON_FUNGIBLE_INPUT, tokenID, tokenAccessor, owner, identity(), x -> true);
         final var nftTransfer = decodedInput
                 .tokenTransferWrappers()
                 .get(0)
@@ -206,7 +206,7 @@ class ERCTransferPrecompileTest {
         final var owner = IdUtils.asAccount("0.0.1450");
 
         final var decodedInput =
-                decodeERCTransferFrom(HAPI_TRANSFER_FROM_NFT_INPUT, null, tokenAccessor, owner, identity());
+                decodeERCTransferFrom(HAPI_TRANSFER_FROM_NFT_INPUT, null, tokenAccessor, owner, identity(), x -> true);
         final var nftTransfer =
                 decodedInput.tokenTransferWrappers().get(0).nftExchanges().get(0);
 
@@ -224,6 +224,7 @@ class ERCTransferPrecompileTest {
         final UnaryOperator<byte[]> identity = identity();
         assertThrows(
                 ArithmeticException.class,
-                () -> decodeERCTransferFrom(TRANSFER_FROM_LONG_OVERFLOWN, tokenID, tokenAccessor, owner, identity));
+                () -> decodeERCTransferFrom(
+                        TRANSFER_FROM_LONG_OVERFLOWN, tokenID, tokenAccessor, owner, identity, x -> true));
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -124,7 +124,7 @@ class AutoCreationLogicTest {
 
         final var input = wellKnownTokenChange(edKeyAlias);
 
-        final var result = subject.create(input, at, store, ids);
+        final var result = subject.create(input, at, store, ids, List.of(input));
         assertEquals(NOT_SUPPORTED, result.getLeft());
     }
 
@@ -136,7 +136,8 @@ class AutoCreationLogicTest {
                         .setAccountID(payer)
                         .build(),
                 payer);
-        final var result = assertThrows(IllegalStateException.class, () -> subject.create(input, at, store, ids));
+        final var result =
+                assertThrows(IllegalStateException.class, () -> subject.create(input, at, store, ids, List.of(input)));
         assertTrue(result.getMessage().contains("Cannot auto-create an account from unaliased change"));
     }
 
@@ -148,14 +149,14 @@ class AutoCreationLogicTest {
         TransactionBody.Builder syntheticHollowCreation =
                 TransactionBody.newBuilder().setCryptoCreateAccount(CryptoCreateTransactionBody.newBuilder());
 
-        given(syntheticTxnFactory.createHollowAccount(evmAddressAlias, 0L)).willReturn(syntheticHollowCreation);
+        given(syntheticTxnFactory.createHollowAccount(evmAddressAlias, 0L, 0)).willReturn(syntheticHollowCreation);
         given(ids.getNewAccountId()).willReturn(created);
         given(feeCalculator.computeFee(any(), any(), eq(at))).willReturn(fees);
 
         final var input = wellKnownChange(evmAddressAlias);
 
         store.wrap();
-        final var result = subject.create(input, at, store, ids);
+        final var result = subject.create(input, at, store, ids, List.of(input));
 
         assertEquals(initialTransfer, input.getAggregatedUnits());
         assertEquals(initialTransfer, input.getNewBalance());
@@ -174,17 +175,17 @@ class AutoCreationLogicTest {
         ByteString edKeyAlias = aPrimitiveKey.toByteString();
         TransactionBody.Builder syntheticEDAliasCreation = TransactionBody.newBuilder()
                 .setCryptoCreateAccount(CryptoCreateTransactionBody.newBuilder().setAlias(edKeyAlias));
+        final var input = wellKnownTokenChange(edKeyAlias);
+        final var changes = List.of(input);
 
         given(ids.getNewAccountId()).willReturn(created);
         given(feeCalculator.computeFee(any(), any(), eq(at))).willReturn(fees);
         given(evmProperties.isLazyCreationEnabled()).willReturn(true);
-        given(syntheticTxnFactory.createAccount(edKeyAlias, aPrimitiveKey, 0L, 0))
+        given(syntheticTxnFactory.createAccount(edKeyAlias, aPrimitiveKey, 0L, changes.size()))
                 .willReturn(syntheticEDAliasCreation);
 
-        final var input = wellKnownTokenChange(edKeyAlias);
-
         store.wrap();
-        final var result = subject.create(input, at, store, ids);
+        final var result = subject.create(input, at, store, ids, changes);
 
         assertEquals(initialTransfer, input.getAggregatedUnits());
         verify(aliasManager)


### PR DESCRIPTION
**Description**:
On `transferFromNFT` or `transferFrom` HTS call to a hollow account the transaction fails as the account could not be found in the store. This PR adds the missing implementation from services that creates an account in case it does not exist. This change broke some of the other in-equivalence tests for system accounts so another missing implementation was added - `TransferPrecompile#revertIfReceiverIsSystemAccount`. After these changes an error is thrown when a transfer is attempted to a system account. Some of the integration tests are adjusted as well - a new system account is defined in order to be used for the system account related tests and the old owner account is now used in the regular cases. 

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/7895
