### PR TITLE
Optimize historical NFT count performance

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/NftRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/NftRepository.java
@@ -41,15 +41,15 @@ public interface NftRepository extends CrudRepository<Nft, AbstractNft.Id> {
     Optional<Nft> findActiveById(long tokenId, long serialNumber);
 
     /**
-     * Retrieves the most recent state of an nft by its ID up to a given block timestamp.
-     * The method considers both the current state of the nft and its historical states
-     * and returns the one that was valid just before or equal to the provided block timestamp.
+     * Retrieves the most recent state of an nft by its ID up to a given block timestamp. The method considers both the
+     * current state of the nft and its historical states and returns the one that was valid just before or equal to the
+     * provided block timestamp.
      *
-     * @param tokenId the token id of the nft to be retrieved.
-     * @param serialNumber the serial number of the nft to be retrieved.
+     * @param tokenId        the token id of the nft to be retrieved.
+     * @param serialNumber   the serial number of the nft to be retrieved.
      * @param blockTimestamp the block timestamp used to filter the results.
-     * @return an Optional containing the nft's state at the specified timestamp.
-     *         If there is no record found for the given criteria, an empty Optional is returned.
+     * @return an Optional containing the nft's state at the specified timestamp. If there is no record found for the
+     * given criteria, an empty Optional is returned.
      */
     @Query(
             value =
@@ -92,51 +92,49 @@ public interface NftRepository extends CrudRepository<Nft, AbstractNft.Id> {
     long countByAccountIdNotDeleted(Long accountId);
 
     /**
-     * Retrieves the most recent state of number of associated tokens (and if their balance is positive)
-     * by accountId up to a given block timestamp.
-     * The method considers both the current state of the token account and its historical states
-     * and returns the one that was valid just before or equal to the provided block timestamp.
+     * Retrieves the most recent state of number of associated tokens (and if their balance is positive) by accountId up
+     * to a given block timestamp. The method considers both the current state of the token account and its historical
+     * states and returns the one that was valid just before or equal to the provided block timestamp.
      *
-     * @param accountId the ID of the account
-     * @param blockTimestamp  the block timestamp used to filter the results.
+     * @param accountId      the ID of the account
+     * @param blockTimestamp the block timestamp used to filter the results.
      * @return the number of nfts the accountId owns at the specified timestamp.
      */
     @Query(
             value =
                     """
-                    select count(*)
-                    from (
-                        (
-                            select token_id
-                            from nft
-                            where account_id = :accountId
-                                and timestamp_range @> :blockTimestamp
-                                and deleted is not true
-                        )
-                        union all
-                        (
-                            select token_id
-                            from nft_history
-                            where account_id = :accountId
-                                and timestamp_range @> :blockTimestamp
-                                and deleted is not true
-                        )
-                    ) as n
-                    join entity e on e.id = n.token_id
-                    where (e.deleted is not true or lower(e.timestamp_range) > :blockTimestamp)
-                    """,
+            select count(*)
+            from (
+                (
+                    select token_id
+                    from nft
+                    where account_id = :accountId
+                        and timestamp_range @> :blockTimestamp
+                        and deleted is not true
+                )
+                union all
+                (
+                    select token_id
+                    from nft_history
+                    where account_id = :accountId
+                        and :blockTimestamp >= lower(timestamp_range) and :blockTimestamp < upper(timestamp_range)
+                        and deleted is not true
+                )
+            ) as n
+            left join entity e on e.id = n.token_id
+            where (e.deleted is not true or lower(e.timestamp_range) > :blockTimestamp)
+            """,
             nativeQuery = true)
     long countByAccountIdAndTimestampNotDeleted(long accountId, long blockTimestamp);
 
     /**
-     * Retrieves the most recent state of nft balance
-     * by accountId and tokenId up to a given block timestamp.
-     * The method considers both the current state of the token account and its historical states
-     * and returns the one that was valid just before or equal to the provided block timestamp.
+     * Retrieves the most recent state of nft balance by accountId and tokenId up to a given block timestamp. The method
+     * considers both the current state of the token account and its historical states and returns the one that was
+     * valid just before or equal to the provided block timestamp.
      *
-     * @param accountId the ID of the account
-     * @param tokenId the ID of the nft
-     * @param blockTimestamp  the block timestamp used to filter the results.
+     * @param accountId      the ID of the account
+     * @param tokenId        the ID of the nft
+     * @param blockTimestamp the block timestamp used to filter the results.
      * @return the number of nft serial numbers the accountId owns at the specified timestamp for specific tokenId.
      */
     @Query(
@@ -169,38 +167,38 @@ public interface NftRepository extends CrudRepository<Nft, AbstractNft.Id> {
     Optional<Long> nftBalanceByAccountIdTokenIdAndTimestamp(long accountId, long tokenId, long blockTimestamp);
 
     /**
-     * Finds the historical token total supply for a given token ID based on a specific block timestamp.
-     * This method calculates the historical supply by getting the sum of all not deleted nft serials for
-     * this specific timestamp range
+     * Finds the historical token total supply for a given token ID based on a specific block timestamp. This method
+     * calculates the historical supply by getting the sum of all not deleted nft serials for this specific timestamp
+     * range
      *
-     * @param tokenId the ID of the token
-     * @param blockTimestamp  the block timestamp used to filter the results.
+     * @param tokenId        the ID of the token
+     * @param blockTimestamp the block timestamp used to filter the results.
      * @return the token's total supply at the specified timestamp.
      */
     @Query(
             value =
                     """
-                    select count(*)
-                    from (
-                        (
-                            select token_id
-                            from nft
-                            where token_id = :tokenId
-                                and timestamp_range @> :blockTimestamp
-                                and deleted is not true
-                        )
-                        union all
-                        (
-                            select token_id
-                            from nft_history
-                            where token_id = :tokenId
-                                and timestamp_range @> :blockTimestamp
-                                and deleted is not true
-                        )
-                    ) as n
-                    join entity e on e.id = n.token_id
-                    where (e.deleted is not true or lower(e.timestamp_range) > :blockTimestamp)
-                    """,
+            select count(*)
+            from (
+                (
+                    select token_id
+                    from nft
+                    where token_id = :tokenId
+                        and timestamp_range @> :blockTimestamp
+                        and deleted is not true
+                )
+                union all
+                (
+                    select token_id
+                    from nft_history
+                    where token_id = :tokenId
+                        and timestamp_range @> :blockTimestamp
+                        and deleted is not true
+                )
+            ) as n
+            join entity e on e.id = n.token_id
+            where (e.deleted is not true or lower(e.timestamp_range) > :blockTimestamp)
+            """,
             nativeQuery = true)
     long findNftTotalSupplyByTokenIdAndTimestamp(long tokenId, long blockTimestamp);
 }


### PR DESCRIPTION
**Description**:

* Change historical NFT count to left join entity for partial mirror node support
* Improve the historical NFT count performance from 21s to 500ms by switching from range operator to regular comparison operators for `nft_history`

**Related issue(s)**:

Fixes #7840

**Notes for reviewer**:

Before:
```
                                                                                QUERY PLAN                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=105280.57..105280.58 rows=1 width=8) (actual time=21178.561..21178.566 rows=1 loops=1)
   ->  Nested Loop  (cost=0.99..105280.32 rows=103 width=0) (actual time=3.250..21178.356 rows=167 loops=1)
         ->  Append  (cost=0.56..105006.85 rows=103 width=8) (actual time=2.508..21125.835 rows=167 loops=1)
               ->  Index Scan using nft__account_token_serialnumber on nft  (cost=0.56..255.58 rows=89 width=8) (actual time=2.506..135.271 rows=117 loops=1)
                     Index Cond: (account_id = 567851)
                     Filter: ((deleted IS NOT TRUE) AND (timestamp_range @> '1692032127966819003'::bigint))
                     Rows Removed by Filter: 80
               ->  Bitmap Heap Scan on nft_history  (cost=3438.75..104749.73 rows=14 width=8) (actual time=6175.687..20990.444 rows=50 loops=1)
                     Recheck Cond: (timestamp_range @> '1692032127966819003'::bigint)
                     Filter: ((deleted IS NOT TRUE) AND (account_id = 567851))
                     Rows Removed by Filter: 187316
                     Heap Blocks: exact=23993
                     ->  Bitmap Index Scan on nft_history__timestamp_range  (cost=0.00..3438.74 rows=177724 width=0) (actual time=5309.649..5309.649 rows=187366 loops=1)
                           Index Cond: (timestamp_range @> '1692032127966819003'::bigint)
         ->  Index Scan using entity_pkey on entity e  (cost=0.43..2.66 rows=1 width=8) (actual time=0.311..0.311 rows=1 loops=167)
               Index Cond: (id = nft.token_id)
               Filter: ((deleted IS NOT TRUE) OR (lower(timestamp_range) > '1692032127966819003'::bigint))
 Planning Time: 2.448 ms
 Execution Time: 21178.904 ms
(19 rows)
```

After:

```
                                                                                                      QUERY PLAN                                                                                                      
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=159981.24..159981.25 rows=1 width=8) (actual time=538.629..541.190 rows=1 loops=1)
   ->  Gather  (cost=159981.02..159981.23 rows=2 width=8) (actual time=538.113..541.180 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=158981.02..158981.03 rows=1 width=8) (actual time=527.873..527.877 rows=1 loops=3)
               ->  Nested Loop  (cost=0.43..158980.85 rows=67 width=0) (actual time=197.091..527.842 rows=56 loops=3)
                     ->  Parallel Append  (cost=0.00..158556.05 rows=160 width=8) (actual time=196.770..514.967 rows=56 loops=3)
                           ->  Index Scan using nft__account_token_serialnumber on nft  (cost=0.56..255.58 rows=89 width=8) (actual time=0.189..0.674 rows=117 loops=1)
                                 Index Cond: (account_id = 567851)
                                 Filter: ((deleted IS NOT TRUE) AND (timestamp_range @> '1692032127966819003'::bigint))
                                 Rows Removed by Filter: 80
                           ->  Parallel Seq Scan on nft_history  (cost=0.00..158298.34 rows=30 width=8) (actual time=279.691..514.720 rows=17 loops=3)
                                 Filter: ((deleted IS NOT TRUE) AND (account_id = 567851) AND ('1692032127966819003'::bigint >= lower(timestamp_range)) AND ('1692032127966819003'::bigint < upper(timestamp_range)))
                                 Rows Removed by Filter: 1733868
                     ->  Index Scan using entity_pkey on entity e  (cost=0.43..2.66 rows=1 width=8) (actual time=0.230..0.230 rows=1 loops=167)
                           Index Cond: (id = nft.token_id)
                           Filter: ((deleted IS NOT TRUE) OR (lower(timestamp_range) > '1692032127966819003'::bigint))
 Planning Time: 3.298 ms
 Execution Time: 541.305 ms
(19 rows)
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
