### PR TITLE
Bump google.golang.org/protobuf from 1.32 to 1.33

### DIFF
--- a/hedera-mirror-rosetta/go.mod
+++ b/hedera-mirror-rosetta/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/thanhpk/randstr v1.0.6
 	github.com/weaveworks/common v0.0.0-20210901124008-1fa3f9fa874c
 	golang.org/x/exp v0.0.0-20240110193028-0dcbfd608b1e
-	google.golang.org/protobuf v1.32.0
+	google.golang.org/protobuf v1.33.0
 	gopkg.in/yaml.v2 v2.4.0
 	gorm.io/driver/postgres v1.5.7
 	gorm.io/gorm v1.25.7


### PR DESCRIPTION
**Description**:

Bump google.golang.org/protobuf from 1.32 to 1.33

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
