### PR TITLE
Add freeze and unfreeze missing validations

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -594,7 +594,7 @@ public class TokenClient extends AbstractNetworkClient {
                 "fungible",
                 TokenType.FUNGIBLE_COMMON,
                 TokenKycStatus.KycNotApplicable,
-                TokenFreezeStatus.FreezeNotApplicable),
+                TokenFreezeStatus.Unfrozen),
         FUNGIBLEHISTORICAL(
                 "fungible_historical", TokenType.FUNGIBLE_COMMON, TokenKycStatus.Granted, TokenFreezeStatus.Unfrozen),
         FUNGIBLE_DELETABLE(
@@ -622,7 +622,7 @@ public class TokenClient extends AbstractNetworkClient {
                 "non_fungible",
                 TokenType.NON_FUNGIBLE_UNIQUE,
                 TokenKycStatus.KycNotApplicable,
-                TokenFreezeStatus.FreezeNotApplicable),
+                TokenFreezeStatus.Unfrozen),
         NFT_FOR_ETH_CALL(
                 "non_fungible",
                 TokenType.NON_FUNGIBLE_UNIQUE,

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/TokenRelationship.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/TokenRelationship.java
@@ -21,6 +21,7 @@ import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_FREEZE_KEY;
 
 import com.google.common.base.MoreObjects;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
@@ -101,6 +102,20 @@ public class TokenRelationship {
 
     public boolean isEmptyTokenRelationship() {
         return this.equals(getEmptyTokenRelationship());
+    }
+
+    /**
+     * Modifies the state of the "Frozen" property to either true (freezes the relation between the
+     * account and the token) or false (unfreezes the relation between the account and the token).
+     *
+     * <p>Before the property modification, the method performs validation, that the respective
+     * token has a freeze key.
+     *
+     * @param freeze the new state of the property
+     */
+    public TokenRelationship changeFrozenState(boolean freeze) {
+        validateTrue(token.hasFreezeKey(), TOKEN_HAS_NO_FREEZE_KEY);
+        return createNewTokenRelationshipWithFrozenFlag(this, freeze);
     }
 
     /**

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/FreezeLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/FreezeLogic.java
@@ -42,8 +42,8 @@ public class FreezeLogic {
                 new TokenRelationshipKey(targetTokenId.asEvmAddress(), targetAccountId.asEvmAddress());
         var tokenRelationship = store.getTokenRelationship(tokenRelationshipKey, Store.OnMissing.THROW);
 
-        /* --- Do the business logic --- */
-        var frozenTokenRelationship = tokenRelationship.setFrozen(true);
+               /* --- Do the business logic --- */
+        var frozenTokenRelationship = tokenRelationship.changeFrozenState(true);
 
         /* --- Persist the updated models --- */
         store.updateTokenRelationship(frozenTokenRelationship);

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/UnfreezeLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/UnfreezeLogic.java
@@ -43,7 +43,7 @@ public class UnfreezeLogic {
         var tokenRelationship = store.getTokenRelationship(tokenRelationshipKey, Store.OnMissing.THROW);
 
         /* --- Do the business logic --- */
-        var unfrozentokenRelationship = tokenRelationship.setFrozen(false);
+        var unfrozentokenRelationship = tokenRelationship.changeFrozenState(false);
 
         /* --- Persist the updated models --- */
         store.updateTokenRelationship(unfrozentokenRelationship);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
@@ -17,8 +17,7 @@
 package com.hedera.services.store.models;
 
 import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -251,10 +250,21 @@ class TokenRelationshipTest {
         token = token.setFreezeKey(freezeKey);
 
         // when:
-        subject = new TokenRelationship(token, account, balance, true, false, false, true, true, 0);
+        subject = new TokenRelationship(token, account, balance, false, false, false, true, true, 0);
+        subject = subject.changeFrozenState(true);
 
         // then:
         assertTrue(subject.isFrozen());
+    }
+
+    @Test
+    void updateFreezeFailsAsExpectedIfFreezeKeyIsNotPresent() {
+        // given:
+        subject.setFrozen(false);
+        token.setFreezeKey(null);
+
+        // verify
+        assertFailsWith(() -> subject.changeFrozenState(true), TOKEN_HAS_NO_FREEZE_KEY);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/FreezeLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/FreezeLogicTest.java
@@ -66,13 +66,13 @@ class FreezeLogicTest {
         TokenRelationship modifiedTokenRelationship = mock(TokenRelationship.class);
         given(store.getTokenRelationship(tokenRelationshipKey, Store.OnMissing.THROW))
                 .willReturn(tokenRelationship);
-        given(tokenRelationship.setFrozen(true)).willReturn(modifiedTokenRelationship);
+        given(tokenRelationship.changeFrozenState(true)).willReturn(modifiedTokenRelationship);
 
         // when:
         subject.freeze(idOfToken, idOfAccount, store);
 
         // then:
-        verify(tokenRelationship).setFrozen(true);
+        verify(tokenRelationship).changeFrozenState(true);
         verify(store).updateTokenRelationship(modifiedTokenRelationship);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/UnfreezeLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/UnfreezeLogicTest.java
@@ -22,6 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.junit.Assert.assertFalse;
+import static com.hedera.services.utils.TxnUtils.assertFailsWith;
 
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.accessor.model.TokenRelationshipKey;
@@ -98,6 +101,21 @@ class UnfreezeLogicTest {
 
         // expect:
         assertEquals(INVALID_ACCOUNT_ID, subject.validate(tokenUnfreezeTxn));
+    }
+
+    @Test
+    void rejectChangeFrozenStateWithoutTokenFreezeKey() {
+        final TokenRelationship tokenRelationship = TokenRelationship.getEmptyTokenRelationship();
+
+        // given:
+        given(store.getTokenRelationship(tokenRelationshipKey, Store.OnMissing.THROW)).willReturn(tokenRelationship);
+
+        // expect:
+        assertFalse(tokenRelationship.getToken().hasFreezeKey());
+        assertFailsWith(() -> subject.unfreeze(idOfToken, idOfAccount, store), TOKEN_HAS_NO_FREEZE_KEY);
+
+        // verify:
+        verify(store, never()).updateTokenRelationship(tokenRelationship);
     }
 
     private void givenValidTxnCtx() {

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/UnfreezeLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/UnfreezeLogicTest.java
@@ -66,13 +66,13 @@ class UnfreezeLogicTest {
         TokenRelationship modifiedTokenRelationship = mock(TokenRelationship.class);
         given(store.getTokenRelationship(tokenRelationshipKey, Store.OnMissing.THROW))
                 .willReturn(tokenRelationship);
-        given(tokenRelationship.setFrozen(false)).willReturn(modifiedTokenRelationship);
+        given(tokenRelationship.changeFrozenState(false)).willReturn(modifiedTokenRelationship);
 
         // when:
         subject.unfreeze(idOfToken, idOfAccount, store);
 
         // then:
-        verify(tokenRelationship).setFrozen(false);
+        verify(tokenRelationship).changeFrozenState(false);
         verify(store).updateTokenRelationship(modifiedTokenRelationship);
     }
 


### PR DESCRIPTION
**Description**:
After changes, we don't have missing logic that validates the freeze and unfreeze state of the token.  I add `changeFrozenState` in `TokenRelationship` which modifies the state of the `frozen` property.  Before the property modification, the method performs validation, that the respective token has a freeze key. I replace `setFrozen` with `changeFrozenState` in `FreezeLogic`, `UnfreezeLogic` because this will help to properly change the state of the token. Make needed modifications in `TokenRelationshipTest`, `FreezeLogicTest`, `UnfreezeLogicTest`. The changes are borrowed from Hedera Services. 

**Related issue(s)**:

Fixes #7894 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
