### PR TITLE
Suppress stacktrace for invalid content encoding

### DIFF
--- a/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
@@ -23,6 +23,8 @@ plugins {
     id("jacoco")
 }
 
+tasks.register("clean") { layout.buildDirectory.asFile.get().deleteRecursively() }
+
 tasks.register<NpmTask>("run") {
     dependsOn(tasks.npmInstall)
     args = listOf("start")

--- a/hedera-mirror-rest/__tests__/integration/generator.js
+++ b/hedera-mirror-rest/__tests__/integration/generator.js
@@ -25,6 +25,11 @@ const dirname = getModuleDirname(import.meta);
 const specsPath = path.join(dirname, '..', 'specs');
 const template = fs.readFileSync(path.join(dirname, 'template.js')).toString();
 
+// Remove any generated spec tests
+fs.readdirSync(dirname, {withFileTypes: true})
+  .filter((f) => f.isFile() && f.name.endsWith('.spec.test.js'))
+  .forEach((f) => fs.rmSync(path.join(f.path, f.name)));
+
 fs.readdirSync(specsPath, {withFileTypes: true})
   .filter((dirent) => dirent.isDirectory())
   .forEach((dirent) => {

--- a/hedera-mirror-rest/constants.js
+++ b/hedera-mirror-rest/constants.js
@@ -170,7 +170,7 @@ const tokenTypeFilter = {
 
 const zeroRandomPageCostQueryHint = 'set local random_page_cost = 0';
 
-class StatusCode {
+export class StatusCode {
   constructor(code, message) {
     this.code = code;
     this.message = message;


### PR DESCRIPTION
**Description**:

* Add a `clean` task to the rest module
* Change spec test generation to remove previously generated tests first
* Change error middleware to not require manual mapping for `HttpError`

**Related issue(s)**:

Fixes #7976

**Notes for reviewer**:

Tested locally. Couldn't find an easy way to write a test with our framework.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
