### PR TITLE
Suppress log alerts for statement timeout

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -41,7 +41,7 @@ loki:
       rules:
         - alert: GrpcLogErrors
           annotations:
-            description: "Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 3m period"
+            description: "Logs for {{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 3m period"
             summary: High rate of errors in logs
           expr: >
             sum(rate({component="grpc"}
@@ -64,7 +64,7 @@ loki:
               != "Not a valid topic"
               != "Must be greater than or equal to 0"
               != "Topic does not exist"
-            [1m])) by (namespace, pod) > 1
+            [1m])) by (cluster, namespace, pod) > 1
           for: 3m
           labels:
             severity: critical
@@ -72,7 +72,7 @@ loki:
       rules:
         - alert: ImporterLogErrors
           annotations:
-            description: "Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 5m period"
+            description: "Logs for {{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 5m period"
             summary: High rate of errors in logs
           expr: >
             sum(rate({component="importer"}
@@ -80,33 +80,34 @@ loki:
               | level = "ERROR"
               != "UnusedChannelExceptionHandler"
               | message =~ ".*(Exception|hash mismatch for file|Unknown record file delimiter|Unknown file delimiter|Error parsing record file|Expecting previous file hash|Unable to extract hash and signature from file|Failed to verify record files|Account balance dataset timestamp mismatch!|ERRORS processing account balances file|does not exist in the database|Unable to connect to database|Address book file).*"
-            [1m])) by (namespace, pod) > 0.5
+            [1m])) by (cluster, namespace, pod) > 0.5
           for: 5m
           labels:
             severity: critical
         - alert: ImporterRecoverableErrors
           annotations:
-            description: "Recoverable Error Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 1m period"
+            description: "Recoverable Error Logs for {{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 1m period"
             summary: Recoverable Error found in logs
           expr: >
             sum(count_over_time({component="importer"}
               | regexp `(?P<timestamp>\S+)\s+(?P<level>\S+)\s+(?P<thread>\S+)\s+(?P<class>\S+)\s+(?P<message>.+)`
               | level = "ERROR"
               | message =~ ".*Recoverable error.*"
-            [1m])) by (namespace, pod) > 0
+            [1m])) by (cluster, namespace, pod) > 0
           labels:
             severity: critical
     - name: hedera-mirror-rest
       rules:
         - alert: RestLogErrors
           annotations:
-            description: "Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 1m period"
+            description: "Logs for {{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 1m period"
             summary: "High rate of log errors"
           expr: >
             sum(rate({component="rest"}
               | regexp `(?P<timestamp>\S+)\s+(?P<level>\S+)\s+(?P<requestId>\S+)\s+(?P<message>.+)`
               | level = "ERROR" or level = "FATAL"
-            [1m])) by (namespace, pod) > 0.04
+              != "canceling statement due to statement timeout"
+            [1m])) by (cluster, namespace, pod) > 0.04
           for: 1m
           labels:
             severity: critical
@@ -114,13 +115,13 @@ loki:
       rules:
         - alert: RosettaLogErrors
           annotations:
-            description: "Logs for {{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 1m period"
+            description: "Logs for {{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.pod }} have reached {{ $value }} error messages/s in a 1m period"
             summary: "High rate of log errors"
           expr: >
             sum(rate({component="rosetta"}
               | logfmt
               | level = "error" or level = "fatal"
-            [1m])) by (namespace, pod) > 0.04
+            [1m])) by (cluster, namespace, pod) > 0.04
           for: 1m
           labels:
             severity: critical

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -161,9 +161,9 @@ prometheusRules:
   RestErrors:
     annotations:
       description: "REST API 5xx error rate for {{ $labels.namespace }} is {{ $value | humanizePercentage }}"
-      summary: "Mirror REST API error rate exceeds 5%"
+      summary: "Mirror REST API error rate exceeds 1%"
     enabled: true
-    expr: sum(rate(api_request_total{container="rest",code=~"^5.."}[1m])) by (namespace) / sum(rate(api_request_total{container="rest"}[1m])) by (namespace) > 0.05
+    expr: sum(rate(api_request_total{container="rest",code=~"^5.."}[1m])) by (namespace) / sum(rate(api_request_total{container="rest"}[1m])) by (namespace) > 0.01
     for: 1m
     labels:
       severity: critical

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -160,10 +160,10 @@ prometheusRules:
   enabled: false
   RestErrors:
     annotations:
-      description: "REST API 5xx error rate for {{ $labels.namespace }}/{{ $labels.pod }} is {{ $value | humanizePercentage }}"
+      description: "REST API 5xx error rate for {{ $labels.namespace }} is {{ $value | humanizePercentage }}"
       summary: "Mirror REST API error rate exceeds 5%"
     enabled: true
-    expr: sum(rate(api_request_total{container="rest",code=~"^5.."}[5m])) by (namespace, pod) / sum(rate(api_request_total{container="rest"}[5m])) by (namespace, pod) > 0.05
+    expr: sum(rate(api_request_total{container="rest",code=~"^5.."}[1m])) by (namespace) / sum(rate(api_request_total{container="rest"}[1m])) by (namespace) > 0.05
     for: 1m
     labels:
       severity: critical


### PR DESCRIPTION
**Description**:

* Add cluster name to log description
* Change 5xx error rate metric to trigger at 1% across all pods
* Suppress log alerts for statement timeout

**Related issue(s)**:

Fixes #7828

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
