### PR TITLE
Add pause and unpause missing validations

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Token.java
@@ -35,6 +35,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_W
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_MAX_SUPPLY_REACHED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TREASURY_MUST_OWN_BURNED_NFT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
 
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.ByteString;
@@ -1804,6 +1805,11 @@ public class Token {
     }
 
     public Token setPaused(boolean paused) {
+        return createNewTokenWithPaused(this, paused);
+    }
+
+    public Token changePauseStatus(final boolean paused) {
+        validateTrue(hasPauseKey(), TOKEN_HAS_NO_PAUSE_KEY);
         return createNewTokenWithPaused(this, paused);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/FreezeLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/FreezeLogic.java
@@ -30,7 +30,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
  * <p>
  * Differences with the original:
  * 1. Use abstraction for the state by introducing {@link Store} interface
- * 2. Used tokenRelationship.setFrozen instead of tokenRelationship.changeFrozenState (like in services)
+ * 2. Used tokenRelationship.changeFrozenState (like in services)
  * 3. Used store.updateTokenRelationship(tokenRelationship)
  *    instead of tokenStore.commitTokenRelationships(List.of(tokenRelationship)) (like in services)
  */

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/PauseLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/PauseLogic.java
@@ -30,7 +30,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
  * <p>
  * Differences with the original:
  * 1. Use abstraction for the state by introducing {@link Store} interface
- * 2. Used token.setPaused instead of token.changePauseStatus (like in services)
+ * 2. Used token.changePauseStatus (like in services)
  * 3. Used store.updateToken(token)
  *    instead of tokenStore.commitToken(token) (like in services)
  */
@@ -41,7 +41,7 @@ public class PauseLogic {
         var token = store.loadPossiblyPausedToken(targetTokenId.asEvmAddress());
 
         /* --- Do the business logic --- */
-        var pausedToken = token.setPaused(true);
+        var pausedToken = token.changePauseStatus(true);
 
         /* --- Persist the updated models --- */
         store.updateToken(pausedToken);

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/UnfreezeLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/UnfreezeLogic.java
@@ -30,7 +30,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
  * <p>
  * Differences with the original:
  * 1. Use abstraction for the state by introducing {@link Store} interface
- * 2. Used tokenRelationship.setFrozen instead of tokenRelationship.changeFrozenState (like in services)
+ * 2. Used tokenRelationship.changeFrozenState (like in services)
  * 3. Used store.updateTokenRelationship(tokenRelationship)
  *    instead of tokenStore.commitTokenRelationships(List.of(tokenRelationship)) (like in services)
  */

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/UnpauseLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/UnpauseLogic.java
@@ -30,7 +30,7 @@ import com.hederahashgraph.api.proto.java.TransactionBody;
  * <p>
  * Differences with the original:
  * 1. Use abstraction for the state by introducing {@link Store} interface
- * 2. Used token.setPaused instead of token.changePauseStatus (like in services)
+ * 2. Used token.changePauseStatus (like in services)
  * 3. Used store.updateToken(token) instead of tokenStore.commitToken(token) (like in services)
  */
 public class UnpauseLogic {
@@ -40,7 +40,7 @@ public class UnpauseLogic {
         var token = store.loadPossiblyPausedToken(targetTokenId.asEvmAddress());
 
         /* --- Do the business logic --- */
-        var unpausedToken = token.setPaused(false);
+        var unpausedToken = token.changePauseStatus(false);
 
         /* --- Persist the updated models --- */
         store.updateToken(unpausedToken);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenTest.java
@@ -665,4 +665,22 @@ class TokenTest {
 
         assertEquals(desired, subject.toString());
     }
+
+    @Test
+    void switchingPauseStatusFailsIfNoPauseKey() {
+        assertFalse(subject.hasPauseKey());
+        assertFailsWith(() -> subject.changePauseStatus(true), TOKEN_HAS_NO_PAUSE_KEY);
+    }
+
+    @Test
+    void switchingPauseStatusWorksIfTokenHasPauseKey() {
+        Token modifiedToken = subject.setPauseKey(someKey);
+        assertTrue(modifiedToken.hasPauseKey());
+
+        modifiedToken = modifiedToken.changePauseStatus(false);
+        assertFalse(modifiedToken.isPaused());
+
+        modifiedToken = modifiedToken.changePauseStatus(true);
+        assertTrue(modifiedToken.isPaused());
+    }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
@@ -775,9 +775,10 @@ class HederaTokenStoreTest {
     }
 
     @Test
-    void adjustingRejectsPausedToken() {
+    void adjustingRejectsPausedToken() throws InvalidKeyException {
         var account = new Account(0L, Id.fromGrpcAccount(treasury), 0);
-        var token = new Token(Id.fromGrpcToken(misc)).setPaused(true);
+        var token = new Token(Id.fromGrpcToken(misc)).setPauseKey(JKey.mapKey(key));
+        token = token.changePauseStatus(true);
 
         given(store.getAccount(asTypedEvmAddress(treasury), OnMissing.THROW)).willReturn(account);
         given(store.getAccount(asTypedEvmAddress(treasury), OnMissing.DONT_THROW))

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/PauseLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/PauseLogicTest.java
@@ -16,12 +16,20 @@
 
 package com.hedera.services.txn.token;
 
+import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
+import static com.hedera.services.utils.TxnUtils.assertFailsWith;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.Token;
+import com.hedera.services.utils.IdUtils;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,13 +61,28 @@ class PauseLogicTest {
         // given:
         given(token.getId()).willReturn(id);
         given(store.loadPossiblyPausedToken(id.asEvmAddress())).willReturn(token);
-        given(token.setPaused(true)).willReturn(pausedToken);
+        given(token.changePauseStatus(true)).willReturn(pausedToken);
 
         // when:
         subject.pause(token.getId(), store);
 
         // then:
-        verify(token).setPaused(true);
+        verify(token).changePauseStatus(true);
         verify(store).updateToken(pausedToken);
+    }
+
+    @Test
+    void rejectChangePauseStatusWithoutTokenPauseKey() {
+        final Token emptyToken = Token.getEmptyToken();
+
+        // given:
+        given(store.loadPossiblyPausedToken(asTypedEvmAddress(IdUtils.asToken("1.2.3")))).willReturn(emptyToken);
+
+        // expect:
+        assertFalse(emptyToken.hasPauseKey());
+        assertFailsWith(() -> subject.pause(id, store), TOKEN_HAS_NO_PAUSE_KEY);
+
+        // verify:
+        verify(store, never()).updateToken(emptyToken);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/UnpauseLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/UnpauseLogicTest.java
@@ -16,8 +16,13 @@
 
 package com.hedera.services.txn.token;
 
+import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
+import static com.hedera.services.utils.TxnUtils.assertFailsWith;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.mirror.web3.evm.store.Store;
@@ -60,13 +65,13 @@ class UnpauseLogicTest {
         // given:
         given(token.getId()).willReturn(id);
         given(store.loadPossiblyPausedToken(id.asEvmAddress())).willReturn(token);
-        given(token.setPaused(false)).willReturn(unpausedToken);
+        given(token.changePauseStatus(false)).willReturn(unpausedToken);
 
         // when:
         subject.unpause(token.getId(), store);
 
         // then:
-        verify(token).setPaused(false);
+        verify(token).changePauseStatus(false);
         verify(store).updateToken(unpausedToken);
     }
 
@@ -87,5 +92,20 @@ class UnpauseLogicTest {
                 TransactionBody.newBuilder().setTokenUnpause(builder).build();
 
         assertEquals(ResponseCodeEnum.INVALID_TOKEN_ID, subject.validateSyntax(txnBody));
+    }
+
+    @Test
+    void rejectChangePauseStatusWithoutTokenPauseKey() {
+        final Token emptyToken = Token.getEmptyToken();
+
+        // given:
+        given(store.loadPossiblyPausedToken(asTypedEvmAddress(IdUtils.asToken("1.2.3")))).willReturn(emptyToken);
+
+        // expect:
+        assertFalse(emptyToken.hasPauseKey());
+        assertFailsWith(() -> subject.unpause(id, store), TOKEN_HAS_NO_PAUSE_KEY);
+
+        // verify:
+        verify(store, never()).updateToken(emptyToken);
     }
 }


### PR DESCRIPTION
**Description**:
After changes, we don't have missing logic that validates the pause state of the token.  I add `changePauseStatus` in `Token` which modifies the state of the `pause` property.  Before the property modification, the method performs validation, that the respective token has a pause key. I replace `setPause` with `changePauseStatus` in `PauseLogic`, and `UnpauseLogic` because this will help to properly change the state of the token. Make needed modifications in tests. The changes are borrowed from Hedera Services. 

**Related issue(s)**:

Fixes #7980

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
