### PR TITLE
Verify support for Kubernetes 1.29

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -32,6 +32,9 @@ jobs:
 
       - name: Setup Kind
         uses: helm/kind-action@v1
+        with:
+          kubectl_version: v1.29.3
+          version: v0.22.0
 
       - name: Install JDK
         uses: actions/setup-java@v4
@@ -47,7 +50,7 @@ jobs:
       - name: Install Stackgres
         run: |
           helm repo add stackgres https://stackgres.io/downloads/stackgres-k8s/stackgres/helm
-          helm install stackgres stackgres/stackgres-operator --version 1.8.0 --create-namespace -n stackgres
+          helm install stackgres stackgres/stackgres-operator --version 1.9.0 --create-namespace -n stackgres
 
       - name: Install ct
         uses: helm/chart-testing-action@v2.6.1

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -124,7 +124,7 @@ jobs:
         run: curl --retry 3 -fsL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
       - name: Create k3d cluster
-        run: k3d cluster create mirror --agents 1 --wait --image rancher/k3s:v1.28.5-k3s1
+        run: k3d cluster create mirror --agents 1 --wait --image rancher/k3s:v1.29.3-k3s1
 
       - name: Get tag
         run: echo "TAG=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV

--- a/charts/README.md
+++ b/charts/README.md
@@ -14,7 +14,7 @@ Installs the Hedera Mirror Node Helm wrapper chart. This chart will install the 
 ## Requirements
 
 - [Helm 3+](https://helm.sh)
-- [Kubernetes 1.28+](https://kubernetes.io)
+- [Kubernetes 1.29+](https://kubernetes.io)
 
 Set environment variables that will be used for the remainder of the document:
 
@@ -92,8 +92,8 @@ a [Standalone NEG](https://cloud.google.com/kubernetes-engine/docs/how-to/standa
        --create-subnetwork="" \
        --network=default \
        --zone=us-central1-a \
-       --cluster-version=1.28 \
-       --machine-type=n1-standard-4
+       --cluster-version=1.29 \
+       --machine-type=n2-custom-6-15360
    ```
 
 2. Configure Traefik to use the external load balancer.
@@ -263,6 +263,9 @@ V2:
 ```shell
 kubectl exec -it "${RELEASE}-citus-coord-0" -c postgres-util -- psql -d mirror_node -U mirror_node
 ```
+
+The Stackgres Admin UI can be [exposed](https://stackgres.io/doc/latest/administration/adminui/) to monitor and
+troubleshoot problems with Citus.
 
 A thread dump can be taken by sending a `QUIT` signal to the java process inside the container. The thread dump output
 will be visible via container logs.

--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -3,17 +3,17 @@ appVersion: 0.102.0-SNAPSHOT
 dependencies:
   - name: loki
     condition: loki.enabled
-    version: 5.41.6
+    version: 5.47.2
     repository: https://grafana.github.io/helm-charts
   - condition: prometheus-adapter.enabled
     name: prometheus-adapter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 4.9.0
+    version: 4.9.1
   - alias: prometheus
     condition: prometheus.enabled
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 55.8.3
+    version: 57.2.0
   - name: promtail
     condition: promtail.enabled
     version: 6.15.5
@@ -22,11 +22,11 @@ dependencies:
     condition: stackgres.enabled
     name: stackgres-operator
     repository: https://stackgres.io/downloads/stackgres-k8s/stackgres/helm/
-    version: 1.8.0
+    version: 1.9.0
   - condition: traefik.enabled
     name: traefik
     repository: https://helm.traefik.io/traefik
-    version: 26.0.0
+    version: 26.1.0
   - alias: zfs
     condition: zfs.enabled
     name: zfs-localpv

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -378,7 +378,7 @@ testkube:
     image:
       registry: docker.io
       repository: grafana/k6
-      tag: 0.48.0
+      tag: 0.50.0
   namespace: testkube
   test:
     config:

--- a/charts/hedera-mirror-graphql/values.yaml
+++ b/charts/hedera-mirror-graphql/values.yaml
@@ -308,7 +308,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
-    tag: 6.1.0-alpine
+    tag: 6.1.1-alpine
   postman: ""  # Custom postman.json in base64 encoding
 
 tolerations: []

--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -292,7 +292,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
-    tag: 6.1.0-alpine
+    tag: 6.1.1-alpine
   postman: ""  # Custom postman.json in base64 encoding
 
 tolerations: []

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -107,7 +107,7 @@ monitor:
           "baseUrl": "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}",
           "name": "kubernetes"
         }
-      ]
+     ]
     }
   enabled: true
   image:
@@ -268,7 +268,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: bats/bats
-    tag: v1.10.0
+    tag: 1.11.0
 
 tolerations: []
 

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -239,7 +239,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
-    tag: 6.1.0-alpine
+    tag: 6.1.1-alpine
   postman: ""  # Custom postman.json in base64 encoding
 
 tolerations: []

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -291,7 +291,7 @@ test:
   image:
     pullPolicy: IfNotPresent
     repository: postman/newman
-    tag: 6.1.0-alpine
+    tag: 6.1.1-alpine
   postman: ""  # Custom postman.json in base64 encoding
 
 tolerations: []

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -29,11 +29,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: 12.6.0
+    version: 14.0.0
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 18.6.3
+    version: 19.0.2
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest

--- a/charts/hedera-mirror/values-v2.yml
+++ b/charts/hedera-mirror/values-v2.yml
@@ -10,7 +10,7 @@ importer:
               entity:
                 persist:
                   transactionHash: true
-                  entityTransactions: true
+                  entityTransactions: false
                   topicMessageLookups: true
   env:
     SPRING_PROFILES_ACTIVE: v2

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -175,7 +175,7 @@ postgresql:
     extraEnvVarsSecret: mirror-passwords
     image:
       debug: true
-      tag: 14.10.0-debian-11-r16
+      tag: 14.11.0-debian-12-r8
     initdbScriptsCM: "{{ .Release.Name }}-init"
     maxConnections: 200
     password: ""  # Randomly generated if left blank

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -20,8 +20,8 @@ fi
 
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
-bats_tag="v1.10.0"
-postgresql_tag="14.10.0-debian-11-r16"
+bats_tag="v1.11.0"
+postgresql_tag="14.11.0-debian-12-r8"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {


### PR DESCRIPTION
**Description**:

* Add support for Kubernetes 1.29
* Bump chart dependencies
* Bump Stackgres to 1.9
* Disable entity transactions table for v2

**Related issue(s)**:

Fixes #8003

**Notes for reviewer**:

Successful run of chart workflow: https://github.com/hashgraph/hedera-mirror-node/actions/runs/8529848249/job/23369806537

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
