### PR TITLE
Add KYC key validations for grant and revoke logics

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/TokenRelationship.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/TokenRelationship.java
@@ -22,6 +22,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_FREEZE_KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_KYC_KEY;
 
 import com.google.common.base.MoreObjects;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
@@ -325,6 +326,19 @@ public class TokenRelationship {
 
     public TokenRelationship setKycGranted(boolean kycGranted) {
         return createNewTokenRelationshipWithNewKycGranted(this, kycGranted);
+    }
+
+    /**
+     * Modifies the state of the KYC property to either true (granted) or false (revoked).
+     *
+     * <p>Before the property modification, the method performs validation, that the respective
+     * token has a KYC key.
+     *
+     * @param isGranted the new state of the property
+     */
+    public TokenRelationship changeKycState(boolean isGranted) {
+        validateTrue(token.hasKycKey(), TOKEN_HAS_NO_KYC_KEY);
+        return createNewTokenRelationshipWithNewKycGranted(this, isGranted);
     }
 
     public long getBalanceChange() {

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -238,7 +238,7 @@ public class HederaTokenStore {
             }
 
             final var tokenRelationship = store.getTokenRelationship(asTokenRelationshipKey(aId, tId), OnMissing.THROW);
-            final var newTokenRelationship = tokenRelationship.changeKycState(value);
+            final var newTokenRelationship = tokenRelationship.setKycGranted(value);
             store.updateTokenRelationship(newTokenRelationship);
             return OK;
         });
@@ -251,7 +251,7 @@ public class HederaTokenStore {
             }
 
             final var tokenRelationship = store.getTokenRelationship(asTokenRelationshipKey(aId, tId), OnMissing.THROW);
-            final var newTokenRelationship = tokenRelationship.changeKycState(value);
+            final var newTokenRelationship = tokenRelationship.setFrozen(value);
             store.updateTokenRelationship(newTokenRelationship);
             return OK;
         });

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/tokens/HederaTokenStore.java
@@ -238,7 +238,7 @@ public class HederaTokenStore {
             }
 
             final var tokenRelationship = store.getTokenRelationship(asTokenRelationshipKey(aId, tId), OnMissing.THROW);
-            final var newTokenRelationship = tokenRelationship.setKycGranted(value);
+            final var newTokenRelationship = tokenRelationship.changeKycState(value);
             store.updateTokenRelationship(newTokenRelationship);
             return OK;
         });
@@ -251,7 +251,7 @@ public class HederaTokenStore {
             }
 
             final var tokenRelationship = store.getTokenRelationship(asTokenRelationshipKey(aId, tId), OnMissing.THROW);
-            final var newTokenRelationship = tokenRelationship.setKycGranted(value);
+            final var newTokenRelationship = tokenRelationship.changeKycState(value);
             store.updateTokenRelationship(newTokenRelationship);
             return OK;
         });

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/GrantKycLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/GrantKycLogic.java
@@ -46,7 +46,7 @@ public class GrantKycLogic {
         final var tokenRelationship = store.getTokenRelationship(tokenRelationshipKey, OnMissing.THROW);
 
         /* --- Do the business logic --- */
-        final var tokenRelationshipResult = tokenRelationship.setKycGranted(true);
+        final var tokenRelationshipResult = tokenRelationship.changeKycState(true);
 
         /* --- Persist the updated models --- */
         store.updateTokenRelationship(tokenRelationshipResult);

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/RevokeKycLogic.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txn/token/RevokeKycLogic.java
@@ -44,7 +44,7 @@ public class RevokeKycLogic {
         final var tokenRelationship = store.getTokenRelationship(tokenRelationshipKey, Store.OnMissing.THROW);
 
         /* --- Do the business logic --- */
-        final var tokenRelationshipResult = tokenRelationship.setKycGranted(false);
+        final var tokenRelationshipResult = tokenRelationship.changeKycState(false);
 
         /* --- Persist the updated models --- */
         store.updateTokenRelationship(tokenRelationshipResult);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -974,7 +974,7 @@ class ContractCallServicePrecompileTest extends ContractCallTestSetup {
     enum NestedContractModificationFunctions {
         CREATE_CONTRACT_VIA_CREATE2_AND_TRANSFER_FROM_IT(
                 "createContractViaCreate2AndTransferFromIt",
-                new Object[] {TREASURY_TOKEN_ADDRESS, SENDER_ALIAS, RECEIVER_ADDRESS, 1L});
+                new Object[] {TREASURY_TOKEN_ADDRESS_WITH_ALL_KEYS, SENDER_ALIAS, RECEIVER_ADDRESS, 1L});
         private final String name;
         private final Object[] functionParameters;
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -184,6 +184,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final Address NFT_ADDRESS_HISTORICAL = toAddress(EntityId.of(0, 0, 1063));
     protected static final Address NOT_FROZEN_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1048));
     protected static final Address TREASURY_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1049));
+    protected static final Address TREASURY_TOKEN_ADDRESS_WITH_ALL_KEYS = toAddress(EntityId.of(0, 0, 1110));
     protected static final Address TRANSFRER_FROM_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1111));
     protected static final Address FROZEN_FUNGIBLE_TOKEN_ADDRESS = toAddress(EntityId.of(0, 0, 1050));
     protected static final Address NFT_TRANSFER_ADDRESS = toAddress(EntityId.of(0, 0, 1051));
@@ -1140,6 +1141,14 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 9999999999999L,
                 TokenPauseStatusEnum.UNPAUSED,
                 false);
+        final var tokenTreasuryWithAllKeysEntityId = fungibleTokenPersist(
+                treasuryEntityId,
+                KEY_PROTO,
+                TREASURY_TOKEN_ADDRESS_WITH_ALL_KEYS,
+                AUTO_RENEW_ACCOUNT_ADDRESS,
+                9999999999999L,
+                TokenPauseStatusEnum.UNPAUSED,
+                false);
         final var tokenGetKeyContractAddressEntityId = fungibleTokenPersist(
                 senderEntityId,
                 keyWithContractId.toByteArray(),
@@ -1251,6 +1260,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
         tokenAccountPersist(ethAccount, tokenEntityId, TokenFreezeStatusEnum.FROZEN);
         tokenAccountPersist(senderEntityId, transferFromTokenTreasuryEntityId, TokenFreezeStatusEnum.UNFROZEN);
         tokenAccountPersist(senderEntityId, tokenTreasuryEntityId, TokenFreezeStatusEnum.UNFROZEN);
+        tokenAccountPersist(senderEntityId, tokenTreasuryWithAllKeysEntityId, TokenFreezeStatusEnum.UNFROZEN);
         tokenAccountPersist(spenderEntityId, notFrozenFungibleTokenEntityId, TokenFreezeStatusEnum.UNFROZEN);
         tokenAccountPersist(spenderEntityId, tokenTreasuryEntityId, TokenFreezeStatusEnum.UNFROZEN);
         tokenAccountPersist(ethAccount, notFrozenFungibleTokenEntityId, TokenFreezeStatusEnum.UNFROZEN);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/TokenRelationshipTest.java
@@ -296,6 +296,16 @@ class TokenRelationshipTest {
         assertTrue(subject.isKycGranted());
     }
 
+    @Test
+    void updateKycFailsAsExpectedIfKycKeyIsNotPresent() {
+        // given:
+        subject.setKycGranted(false);
+        token.setKycKey(null);
+
+        // verify
+        assertFailsWith(() -> subject.changeKycState(true), TOKEN_HAS_NO_KYC_KEY);
+    }
+
     private void assertFailsWith(Runnable something, ResponseCodeEnum status) {
         var ex = assertThrows(InvalidTransactionException.class, something::run);
         assertEquals(status, ex.getResponseCode());

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/tokens/HederaTokenStoreTest.java
@@ -21,6 +21,7 @@ import static com.hedera.services.utils.BitPackUtils.setAlreadyUsedAutomaticAsso
 import static com.hedera.services.utils.BitPackUtils.setMaxAutomaticAssociationsTo;
 import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
 import static com.hedera.services.utils.IdUtils.asToken;
+import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_EXPIRED_AND_PENDING_REMOVAL;
@@ -89,6 +90,7 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenUpdateTransactionBody;
+import com.hederahashgraph.api.proto.java.KeyList;
 import java.security.InvalidKeyException;
 import java.util.EnumSet;
 import java.util.function.UnaryOperator;
@@ -107,6 +109,8 @@ class HederaTokenStoreTest {
             .setEd25519(ByteString.copyFromUtf8("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
             .build();
 
+    private final JKey kycKey = asFcKeyUnchecked(
+            Key.newBuilder().setKeyList(KeyList.getDefaultInstance()).build());
     private static final int associatedTokensCount = 2;
     private static final int numPositiveBalances = 1;
     public static final long CONSENSUS_NOW = 1_234_567L;
@@ -825,10 +829,10 @@ class HederaTokenStoreTest {
     }
 
     @Test
-    void refusesToAdjustRevokedKycRelationship() {
+    void refusesToAdjustRevokedKycRelationship() throws InvalidKeyException {
         var account = new Account(0L, Id.fromGrpcAccount(treasury), 0);
-        var token = new Token(Id.fromGrpcToken(misc));
-        var tokenRelationship = new TokenRelationship(token, account).setKycGranted(false);
+        var token = new Token(Id.fromGrpcToken(misc)).setKycKey(kycKey);
+        var tokenRelationship = new TokenRelationship(token, account).changeKycState(false);
 
         given(store.getAccount(asTypedEvmAddress(treasury), OnMissing.THROW)).willReturn(account);
         given(store.getAccount(asTypedEvmAddress(treasury), OnMissing.DONT_THROW))
@@ -981,8 +985,9 @@ class HederaTokenStoreTest {
                 .setNumAssociations(5)
                 .setNumPositiveBalances(2);
         var token = new Token(Id.fromGrpcToken(misc)).setDecimals(2);
+        token = token.setKycKey(kycKey);
         var tokenRelationship =
-                new TokenRelationship(token, account).setFrozen(false).setKycGranted(true);
+                new TokenRelationship(token, account).setFrozen(false).changeKycState(true);
 
         final var aa =
                 AccountAmount.newBuilder().setAccountID(sponsor).setAmount(100).build();
@@ -1547,7 +1552,7 @@ class HederaTokenStoreTest {
                 .setType(TokenType.NON_FUNGIBLE_UNIQUE);
         var tokenRelationshipKey = asTokenRelationshipKey(newTreasury, nonfungible);
         var tokenRelationship =
-                new TokenRelationship(token, account).setKycGranted(true).setBalance(1L);
+                new TokenRelationship(token, account).changeKycState(true).setBalance(1L);
         final var op = updateWith(ALL_KEYS, nonfungible, true, true, true).toBuilder()
                 .setExpiry(Timestamp.newBuilder().setSeconds(0))
                 .build();

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/GrantKycLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/GrantKycLogicTest.java
@@ -17,9 +17,12 @@
 package com.hedera.services.txn.token;
 
 import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
+import static com.hedera.services.utils.TxnUtils.assertFailsWith;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_KYC_KEY;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -39,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class GrantKycLogicTest {
@@ -70,13 +74,13 @@ class GrantKycLogicTest {
         TokenRelationship accRel = mock(TokenRelationship.class);
         given(store.getTokenRelationship(tokenRelationshipKey, Store.OnMissing.THROW))
                 .willReturn(accRel);
-        given(accRel.setKycGranted(true)).willReturn(modifiedRelationship);
+        given(accRel.changeKycState(true)).willReturn(modifiedRelationship);
 
         // when:
         subject.grantKyc(idOfToken, idOfAccount, store);
 
         // then:
-        verify(accRel).setKycGranted(true);
+        verify(accRel).changeKycState(true);
         verify(store).updateTokenRelationship(modifiedRelationship);
     }
 
@@ -102,6 +106,21 @@ class GrantKycLogicTest {
 
         // expect:
         assertEquals(INVALID_ACCOUNT_ID, subject.validate(tokenGrantKycTxn));
+    }
+
+    @Test
+    void rejectChangeKycStateStateWithoutTokenKYCKey() {
+        final TokenRelationship tokenRelationship = TokenRelationship.getEmptyTokenRelationship();
+
+        // given:
+        given(store.getTokenRelationship(tokenRelationshipKey, Store.OnMissing.THROW)).willReturn(tokenRelationship);
+
+        // expect:
+        assertFalse(tokenRelationship.getToken().hasKycKey());
+        assertFailsWith(() -> subject.grantKyc(idOfToken, idOfAccount, store), TOKEN_HAS_NO_KYC_KEY);
+
+        // verify:
+        verify(store, never()).updateTokenRelationship(tokenRelationship);
     }
 
     private void givenValidTxnCtx() {

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/GrantKycLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/GrantKycLogicTest.java
@@ -109,7 +109,7 @@ class GrantKycLogicTest {
     }
 
     @Test
-    void rejectChangeKycStateStateWithoutTokenKYCKey() {
+    void rejectChangeKycStateWithoutTokenKYCKey() {
         final TokenRelationship tokenRelationship = TokenRelationship.getEmptyTokenRelationship();
 
         // given:

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/RevokeKycLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txn/token/RevokeKycLogicTest.java
@@ -108,7 +108,7 @@ public class RevokeKycLogicTest {
     }
 
     @Test
-    void rejectChangeKycStateStateWithoutTokenKYCKey() {
+    void rejectChangeKycStateWithoutTokenKYCKey() {
         final TokenRelationship tokenRelationship = TokenRelationship.getEmptyTokenRelationship();
 
         // given:


### PR DESCRIPTION
**Description**:
After changes, we don't have missing logic that validates the grant and revokes kyc state of the token. I add `changeKycState` in `TokenRelationship` which modifies the state of the `kycGranted` property. Before the property modification, the method performs validation, that the respective token has a kyc key. I replace `setKycGranted` with `changeKycState` in `GrantKycLogic`, `RevokeKycLogic`, `HederaTokenStore` because this will help to properly change the state of the token. Make needed modifications in `TokenRelationshipTest`, `HederaTokenStoreTest`, `GrantKycLogicTest`, `RevokeKycLogicTest`, `ContractCallServicePrecompileTest`, `ContractCallTestSetup`. The changes are borrowed from Hedera Services.

**Related issue(s)**:

Fixes #8001

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
