### PR TITLE
Bump Go from 1.21.3 to 1.22.2

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -51,7 +51,7 @@ jobs:
           rm -fr tmp
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.19.0
+        uses: securego/gosec@master # Temporary until next release
         with:
           args: ./...
 

--- a/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
+++ b/buildSrc/src/main/kotlin/plugin/go/GoSetup.kt
@@ -46,6 +46,7 @@ open class GoSetup : DefaultTask() {
         val targetFile = go.cacheDir.toPath().resolve(filename)
 
         if (!targetFile.toFile().exists()) {
+            go.goRoot.deleteRecursively()
             url.openStream().use {
                 logger.warn("Downloading: ${url}")
                 Files.copy(it, targetFile, StandardCopyOption.REPLACE_EXISTING)

--- a/hedera-mirror-rosetta/Dockerfile
+++ b/hedera-mirror-rosetta/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.21.3-bullseye as build
+FROM --platform=$BUILDPLATFORM golang:1.22.2-bookworm as build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=development
@@ -8,7 +8,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s -X main.Version=${VERSION}" -o hedera-mirror-rosetta
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive
 EXPOSE 5700
 HEALTHCHECK --interval=10s --retries=5 --start-period=30s --timeout=2s CMD wget -q -O- http://localhost:5700/health/liveness

--- a/hedera-mirror-rosetta/build.gradle.kts
+++ b/hedera-mirror-rosetta/build.gradle.kts
@@ -23,5 +23,5 @@ plugins {
 
 go {
     pkg = "./app/..."
-    version = "1.21.3"
+    version = "1.22.2"
 }

--- a/hedera-mirror-rosetta/go.mod
+++ b/hedera-mirror-rosetta/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashgraph/hedera-mirror-node/hedera-mirror-rosetta
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Code-Hex/go-generics-cache v1.3.1


### PR DESCRIPTION
**Description**:

* Bump Go from `1.21.3` to `1.22.2`
* Change Debian version for Go image from Bullseye to Bookworm
* Fix Gradle Go plugin not replacing local binary on version change

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
