### PR TITLE
Remove exception in TxnResourceUsageEstimator - usageGiven

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimator.java
@@ -42,7 +42,6 @@ public interface TxnResourceUsageEstimator {
      * @param txn      the txn in question
      * @param sigUsage the signature usage
      * @return the estimated resource usage
-     * @throws Exception            if the txn is malformed
      * @throws NullPointerException or analogous if the estimator does not apply to the txn
      */
     @SuppressWarnings("java:S112")

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/TxnResourceUsageEstimator.java
@@ -46,5 +46,5 @@ public interface TxnResourceUsageEstimator {
      * @throws NullPointerException or analogous if the estimator does not apply to the txn
      */
     @SuppressWarnings("java:S112")
-    FeeData usageGiven(TransactionBody txn, SigValueObj sigUsage) throws Exception;
+    FeeData usageGiven(TransactionBody txn, SigValueObj sigUsage);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculator.java
@@ -141,17 +141,9 @@ public class UsageBasedFeeCalculator implements FeeCalculator {
         } else {
             var sigUsage = getSigUsage(accessor, payerKey);
             var usageEstimator = getTxnUsageEstimator(accessor);
-            try {
-                final var usage = usageEstimator.usageGiven(accessor.getTxn(), sigUsage);
-                final var applicablePrices = prices.get(usage.getSubType());
-                return getFeeObject(usage, applicablePrices, rate);
-            } catch (Exception e) {
-                log.warn(
-                        "Argument accessor={} malformed for implied estimator {}!",
-                        accessor.getSignedTxnWrapper(),
-                        usageEstimator);
-                throw new IllegalArgumentException(e);
-            }
+            final var usage = usageEstimator.usageGiven(accessor.getTxn(), sigUsage);
+            final var applicablePrices = prices.get(usage.getSubType());
+            return getFeeObject(usage, applicablePrices, rate);
         }
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenAssociateResourceUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenAssociateResourceUsage.java
@@ -49,7 +49,7 @@ public class TokenAssociateResourceUsage extends AbstractTokenResourceUsage impl
     }
 
     @Override
-    public FeeData usageGiven(TransactionBody txn, SigValueObj svo) throws Exception {
+    public FeeData usageGiven(TransactionBody txn, SigValueObj svo) {
         final var op = txn.getTokenAssociate();
         final var account = store.getAccount(EntityIdUtils.asTypedEvmAddress(op.getAccount()), OnMissing.DONT_THROW);
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenDeleteResourceUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenDeleteResourceUsage.java
@@ -45,7 +45,7 @@ public class TokenDeleteResourceUsage extends AbstractTokenResourceUsage impleme
     }
 
     @Override
-    public FeeData usageGiven(TransactionBody txn, SigValueObj svo) throws Exception {
+    public FeeData usageGiven(TransactionBody txn, SigValueObj svo) {
         final var sigUsage = new SigUsage(svo.getTotalSigCount(), svo.getSignatureSize(), svo.getPayerAcctSigCount());
         final var estimate = factory.apply(txn, estimatorFactory.get(sigUsage, txn, ESTIMATOR_UTILS));
         return estimate.get();

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenDissociateResourceUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenDissociateResourceUsage.java
@@ -47,7 +47,7 @@ public class TokenDissociateResourceUsage extends AbstractTokenResourceUsage imp
     }
 
     @Override
-    public FeeData usageGiven(final TransactionBody txn, final SigValueObj svo) throws Exception {
+    public FeeData usageGiven(final TransactionBody txn, final SigValueObj svo) {
         final var op = txn.getTokenDissociate();
         final var account = store.getAccount(EntityIdUtils.asTypedEvmAddress(op.getAccount()), OnMissing.DONT_THROW);
         if (account == null) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenUpdateResourceUsage.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/fees/calculation/token/txns/TokenUpdateResourceUsage.java
@@ -61,7 +61,7 @@ public class TokenUpdateResourceUsage extends AbstractTokenResourceUsage impleme
     }
 
     @Override
-    public FeeData usageGiven(final TransactionBody txn, final SigValueObj svo) throws Exception {
+    public FeeData usageGiven(final TransactionBody txn, final SigValueObj svo) {
         final var op = txn.getTokenUpdate();
         final var sigUsage = new SigUsage(svo.getTotalSigCount(), svo.getSignatureSize(), svo.getPayerAcctSigCount());
         final var token = store.getToken(asTypedEvmAddress(op.getToken()), OnMissing.DONT_THROW);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
@@ -212,15 +212,12 @@ class UsageBasedFeeCalculatorTest {
     }
 
     @Test
-    void failsWithIseGivenApplicableButUnusableCalculator() {
+    void failsWithNpeGivenApplicableButUnusableCalculator() {
         // setup:
-
-        given(correctOpEstimator.applicableTo(accessor.getTxn())).willReturn(true);
-        given(txnUsageEstimators.get(any())).willReturn(List.of(correctOpEstimator));
+        givenApplicableButUnusableCalculator();
 
         // when:
-
-        assertThrows(IllegalArgumentException.class, () -> subject.computeFee(accessor, payerKey, at));
+        assertThrows(NullPointerException.class, () -> subject.computeFee(accessor, payerKey, at));
     }
 
     @Test
@@ -249,8 +246,7 @@ class UsageBasedFeeCalculatorTest {
                 getFeeObject(currentPrices.get(SubType.DEFAULT), resourceUsage, currentRate, multiplier);
         suggestedMultiplier.set(multiplier);
 
-        given(correctOpEstimator.applicableTo(accessor.getTxn())).willReturn(true);
-        given(txnUsageEstimators.get(any())).willReturn(List.of(correctOpEstimator));
+        givenApplicableButUnusableCalculator();
         given(correctOpEstimator.usageGiven(any(), any())).willReturn(resourceUsage);
         given(exchange.rate(at)).willReturn(currentRate);
         given(usagePrices.activePrices(any())).willReturn(currentPrices);
@@ -292,5 +288,10 @@ class UsageBasedFeeCalculatorTest {
                         Duration.newBuilder().setSeconds(68).build())
                 .setMemo("memo");
         return txn;
+    }
+
+    private void givenApplicableButUnusableCalculator() {
+        given(correctOpEstimator.applicableTo(accessor.getTxn())).willReturn(true);
+        given(txnUsageEstimators.get(any())).willReturn(List.of(correctOpEstimator));
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/fees/calculation/UsageBasedFeeCalculatorTest.java
@@ -58,10 +58,13 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.Transaction;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionFeeSchedule;
+
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -271,6 +274,20 @@ class UsageBasedFeeCalculatorTest {
 
         // then:
         assertEquals(expectedFeeData, feeData);
+    }
+
+    @Test
+    void failsWithNseeGetTxnUsageEstimator() {
+        final Exception exception = assertThrows(NoSuchElementException.class,
+                () -> subject.computeFee(accessor, payerKey, at));
+        assertEquals("No estimator exists for the given transaction", exception.getMessage());
+    }
+
+    @Test
+    void failsWithNseeGetQueryUsageEstimator() {
+        final Exception exception = assertThrows(NoSuchElementException.class,
+                () -> subject.estimatePayment(query, currentPrices.get(SubType.DEFAULT), at, ANSWER_ONLY));
+        assertEquals("No estimator exists for the given query", exception.getMessage());
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
**Description**:
Remove throws an exception in `TxnResourceUsageEstimator` - `usageGiven` and make needed changes because this affects all classes that implement it. The changes are part of verify the mirror node and services are in sync

**Related issue(s)**: #7822

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
