### PR TITLE
Fix balance opcode for 0.0.999 acceptance test

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
@@ -27,7 +27,6 @@ import static com.hedera.mirror.test.e2e.acceptance.steps.EquivalenceFeature.Con
 import static com.hedera.mirror.test.e2e.acceptance.steps.EquivalenceFeature.ContractMethods.GET_CODE_SIZE;
 import static com.hedera.mirror.test.e2e.acceptance.util.TestUtil.asAddress;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.esaulpaugh.headlong.abi.TupleType;
 import com.hedera.hashgraph.sdk.AccountId;
@@ -117,19 +116,14 @@ public class EquivalenceFeature extends AbstractFeature {
         }
     }
 
-    @Then("I execute balance opcode to system account {string} address with id 1 to 750 would return 0")
+    @Then("I execute balance opcode to system account {string} address would return 0")
     public void balanceOfAddress(String address) {
         var nodeType = acceptanceTestProperties.getNodeType();
         final var accountId = new AccountId(extractAccountNumber(address));
         var data = encodeData(EQUIVALENCE_CALL, GET_BALANCE, asAddress(accountId));
         var functionResult =
                 callContract(nodeType, StringUtils.EMPTY, EQUIVALENCE_CALL, GET_BALANCE, data, BIG_INTEGER_TUPLE);
-
-        if (extractAccountNumber(address) > 750 && accountExists(accountId)) {
-            assertTrue(functionResult.getResultAsNumber().compareTo(BigInteger.ZERO) >= 0);
-        } else {
-            assertThat(functionResult.getResultAsNumber()).isEqualTo(BigInteger.ZERO);
-        }
+        assertThat(BigInteger.ZERO).isEqualTo(functionResult.getResultAsNumber());
     }
 
     @Then("I execute balance opcode against a contract with balance")

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
@@ -117,7 +117,7 @@ public class EquivalenceFeature extends AbstractFeature {
         }
     }
 
-    @Then("I execute balance opcode to system account {string} address would return 0")
+    @Then("I execute balance opcode to system account {string} address with id 1 to 750 would return 0")
     public void balanceOfAddress(String address) {
         var nodeType = acceptanceTestProperties.getNodeType();
         final var accountId = new AccountId(extractAccountNumber(address));
@@ -125,14 +125,10 @@ public class EquivalenceFeature extends AbstractFeature {
         var functionResult =
                 callContract(nodeType, StringUtils.EMPTY, EQUIVALENCE_CALL, GET_BALANCE, data, BIG_INTEGER_TUPLE);
 
-        if (extractAccountNumber(address) < 751) {
-            assertThat(functionResult.getResultAsNumber()).isEqualTo(BigInteger.ZERO);
+        if (extractAccountNumber(address) > 750 && accountExists(accountId)) {
+            assertTrue(functionResult.getResultAsNumber().compareTo(BigInteger.ZERO) >= 0);
         } else {
-            if (accountExists(accountId)) {
-                assertTrue(functionResult.getResultAsNumber().compareTo(BigInteger.ZERO) > 0);
-            } else {
-                assertThat(functionResult.getResultAsNumber()).isEqualTo(BigInteger.ZERO);
-            }
+            assertThat(functionResult.getResultAsNumber()).isEqualTo(BigInteger.ZERO);
         }
     }
 

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
@@ -195,13 +195,4 @@ public class EquivalenceFeature extends AbstractFeature {
 
         private final String selector;
     }
-
-    private boolean accountExists(final AccountId accountId) {
-        try {
-            mirrorClient.getAccountDetailsByAccountId(accountId);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
 }

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EquivalenceFeature.java
@@ -128,7 +128,7 @@ public class EquivalenceFeature extends AbstractFeature {
         if (extractAccountNumber(address) < 751) {
             assertThat(functionResult.getResultAsNumber()).isEqualTo(BigInteger.ZERO);
         } else {
-            if (isAccountExists(accountId)) {
+            if (accountExists(accountId)) {
                 assertTrue(functionResult.getResultAsNumber().compareTo(BigInteger.ZERO) > 0);
             } else {
                 assertThat(functionResult.getResultAsNumber()).isEqualTo(BigInteger.ZERO);
@@ -206,7 +206,7 @@ public class EquivalenceFeature extends AbstractFeature {
         private final String selector;
     }
 
-    private boolean isAccountExists(final AccountId accountId) {
+    private boolean accountExists(final AccountId accountId) {
         try {
             mirrorClient.getAccountDetailsByAccountId(accountId);
             return true;

--- a/hedera-mirror-test/src/test/resources/features/contract/equivalence.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/equivalence.feature
@@ -9,17 +9,17 @@ Feature: in-equivalence tests
     Then I verify the equivalence contract bytecode is deployed
     Then I verify the selfdestruct contract bytecode is deployed
     Then I execute selfdestruct and set beneficiary to <account> address
-    Then I execute balance opcode to system account <account> address with id 1 to 750 would return 0
+    Then I execute balance opcode to system account <strictSystemAccount> address would return 0
     Then I verify extcodesize opcode against a system account <account> address returns 0
     Then I verify extcodecopy opcode against a system account <account> address returns empty bytes
     Then I verify extcodehash opcode against a system account <account> address returns empty bytes
     Examples:
-      | account    |
-      | "0.0.1"    |
-      | "0.0.10"   |
-      | "0.0.358"  |
-      | "0.0.750"  |
-      | "0.0.999"  |
+      | account    | strictSystemAccount |
+      | "0.0.1"    | "0.0.1"             |
+      | "0.0.10"   | "0.0.10"            |
+      | "0.0.358"  | "0.0.358"           |
+      | "0.0.750"  | "0.0.749"           |
+      | "0.0.999"  | "0.0.750"           |
 
 #   Separated scenario as it needs to be executed only once
     Scenario Outline: Validate in-equivalence for selfdestruct and balance against contract

--- a/hedera-mirror-test/src/test/resources/features/contract/equivalence.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/equivalence.feature
@@ -9,7 +9,7 @@ Feature: in-equivalence tests
     Then I verify the equivalence contract bytecode is deployed
     Then I verify the selfdestruct contract bytecode is deployed
     Then I execute selfdestruct and set beneficiary to <account> address
-    Then I execute balance opcode to system account <account> address would return 0
+    Then I execute balance opcode to system account <account> address with id 1 to 750 would return 0
     Then I verify extcodesize opcode against a system account <account> address returns 0
     Then I verify extcodecopy opcode against a system account <account> address returns empty bytes
     Then I verify extcodehash opcode against a system account <account> address returns empty bytes


### PR DESCRIPTION
**Description**:
Add logic in `EquivalenceFeature` that expects `balance` to be greater than 0 when `accountId` is greater than 751 and checks account existence by `accountId`. 

**Related issue(s)**:

Fixes #8019 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
