### PR TITLE
Replace gradle enterprise plugin with develocity

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
     implementation("org.jooq:jooq-codegen-gradle:$jooqVersion")
     implementation("org.jooq:jooq-meta:$jooqVersion")
     implementation("org.openapitools:openapi-generator-gradle-plugin:7.4.0")
-    implementation("org.owasp:dependency-check-gradle:8.4.3")
-    implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.4.1.3373")
+    implementation("org.owasp:dependency-check-gradle:9.1.0")
+    implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:5.0.0.4638")
     implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.4")
     implementation("org.testcontainers:postgresql:1.19.7")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("com.gradle.enterprise") version ("3.14.1") }
+plugins { id("com.gradle.develocity") version ("3.17") }
 
 rootProject.name = "hedera-mirror-node"
 
@@ -54,10 +54,10 @@ fun shortenProjectName(project: ProjectDescriptor) {
     project.children.forEach(this::shortenProjectName)
 }
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
         tag("CI")
     }
 }


### PR DESCRIPTION
## Description

This pull request changes the following:

- Replaces the deprecated Gradle Enterprise plugin with the Gradle Develocity plugin.
- Updates the SonarQube plugin.
- Updates the Dependency Check plugin.

### Related Issues

- Closes #8031 