### PR TITLE
Add support for nvd api keys during dependency check analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/"
-    open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "npm"
     directory: "/hedera-mirror-rest"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Vulnerability check
         env:
-          NVD_API_TOKEN: ${{ secrets.NVD_API_TOKEN }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: ./gradlew dependencyCheckAggregate
 
       - name: Upload report

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,7 @@ jobs:
   dependencies:
     name: Dependency check
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -30,11 +31,13 @@ jobs:
         uses: gradle/actions/setup-gradle@e24011a3b5db78bd5ab798036042d9312002f252 # v3.2.0
 
       - name: Vulnerability check
+        env:
+          NVD_API_TOKEN: ${{ secrets.NVD_API_TOKEN }}
         run: ./gradlew dependencyCheckAggregate
 
       - name: Upload report
-        if: failure()
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        if: failure()
         with:
           name: dependency-check-report
           path: build/reports/dependency-check-report.html

--- a/buildSrc/src/main/kotlin/common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-conventions.gradle.kts
@@ -23,6 +23,10 @@ repositories { mavenCentral() }
 val resources = rootDir.resolve("buildSrc").resolve("src").resolve("main").resolve("resources")
 
 dependencyCheck {
+    if (System.getenv().containsKey("NVD_API_KEY")) {
+        nvd.apiKey = System.getenv("NVD_API_KEY")
+    }
+
     failBuildOnCVSS = 8f
     suppressionFile = resources.resolve("suppressions.xml").toString()
     analyzers(


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds support for setting an optional NVD API Key when running the dependency check plugin.
- Updates the CI pipelines to provide a NVD API key.
- Updates dependabot configuration to analyze Github Actions dependencies daily.
