### PR TITLE
Increase max header size

### DIFF
--- a/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/javascript-conventions.gradle.kts
@@ -23,6 +23,12 @@ plugins {
     id("jacoco")
 }
 
+node {
+    download = true
+    version = "18.18.0"
+    workDir = rootDir.resolve(".gradle").resolve("nodejs")
+}
+
 tasks.register("clean") { layout.buildDirectory.asFile.get().deleteRecursively() }
 
 tasks.register<NpmTask>("run") {

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -80,7 +80,6 @@ ingress:
       paths:
         # the rest of /api/v1/contracts will still be handled by the REST API logic, except for this one address
         - "/api/v1/contracts/call"
-        - "/web3"
   tls:
     enabled: false
     secretName: ""

--- a/hedera-mirror-graphql/src/main/resources/application.yml
+++ b/hedera-mirror-graphql/src/main/resources/application.yml
@@ -41,7 +41,7 @@ server:
     enabled: true
   http2:
     enabled: true
-  max-http-request-header-size: 1KB
+  max-http-request-header-size: 2KB
   netty:
     connection-timeout: 3s
   port: 8083

--- a/hedera-mirror-grpc/src/main/resources/application.yml
+++ b/hedera-mirror-grpc/src/main/resources/application.yml
@@ -52,7 +52,7 @@ server:
     enabled: true
   http2:
     enabled: true
-  max-http-request-header-size: 1KB
+  max-http-request-header-size: 2KB
   port: 8081
   shutdown: graceful
 spring:

--- a/hedera-mirror-rest-java/src/main/resources/application.yml
+++ b/hedera-mirror-rest-java/src/main/resources/application.yml
@@ -42,7 +42,7 @@ server:
   forward-headers-strategy: framework #Enable spring ForwardedHeaderFilter
   http2:
     enabled: true
-  max-http-request-header-size: 1KB
+  max-http-request-header-size: 2KB
   port: 8084
   shutdown: graceful
   tomcat:

--- a/hedera-mirror-web3/src/main/resources/application.yml
+++ b/hedera-mirror-web3/src/main/resources/application.yml
@@ -42,7 +42,7 @@ server:
   forward-headers-strategy: framework # Enable spring ForwardedHeaderFilter
   http2:
     enabled: true
-  max-http-request-header-size: 1KB
+  max-http-request-header-size: 2KB
   port: 8545
   shutdown: graceful
   tomcat:


### PR DESCRIPTION
**Description**:

* Fix rest module Gradle tasks not working when node directory was missing
* Increase max header size from `1KB` to `2KB`
* Remove legacy `/web3` routing

**Related issue(s)**:

Fixes #8068

**Notes for reviewer**:

After switching from Reactor Netty to Tomcat, suddenly our 1KB max header restriction apparently started taking effect and causing 400 errors for browser-based clients with really verbose headers added implicitly by the browser.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
