### PR TITLE
Adapt contract deploy to work for eth call

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -94,7 +94,7 @@ class ContractController {
 
         /*When performing estimateGas with an empty "to" field, we set a default value of the zero address
         to avoid any potential NullPointerExceptions throughout the process.*/
-        if ((request.getTo() == null || request.getTo().isEmpty()) && request.isEstimate()) {
+        if (request.getTo() == null || request.getTo().isEmpty()) {
             receiver = Address.ZERO;
         } else {
             receiver = Address.fromHexString(request.getTo());

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/ContractController.java
@@ -92,7 +92,7 @@ class ContractController {
 
         Address receiver;
 
-        /*When performing estimateGas with an empty "to" field, we set a default value of the zero address
+        /*In case of an empty "to" field, we set a default value of the zero address
         to avoid any potential NullPointerExceptions throughout the process.*/
         if (request.getTo() == null || request.getTo().isEmpty()) {
             receiver = Address.ZERO;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
@@ -63,6 +63,6 @@ public class ContractCallRequest {
 
     @AssertTrue(message = "must not be empty")
     private boolean hasTo() {
-        return estimate || StringUtils.isNotEmpty(to);
+        return (value > 0 && from != null) ? StringUtils.isNotEmpty(to) : true;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
@@ -63,6 +63,6 @@ public class ContractCallRequest {
 
     @AssertTrue(message = "must not be empty")
     private boolean hasTo() {
-        return (value > 0 && from != null) ? StringUtils.isNotEmpty(to) : true;
+        return value <= 0 || from == null || StringUtils.isNotEmpty(to);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -107,6 +107,7 @@ class ContractControllerTest {
     void estimateGas(String to) throws Exception {
         final var request = request();
         request.setEstimate(true);
+        request.setValue(0);
         request.setTo(to);
         contractCall(request).andExpect(status().isOk());
     }
@@ -135,7 +136,6 @@ class ContractControllerTest {
         contractCall(request()).andExpect(status().isTooManyRequests());
     }
 
-    @NullAndEmptySource
     @ValueSource(
             strings = {
                 " ",
@@ -149,7 +149,17 @@ class ContractControllerTest {
     @ParameterizedTest
     void callInvalidTo(String to) throws Exception {
         final var request = request();
+        request.setValue(0);
         request.setTo(to);
+        contractCall(request)
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(new StringContains("to field")));
+    }
+
+    @Test
+    void callInvalidToDueToTransfer() throws Exception {
+        final var request = request();
+        request.setTo(null);
         contractCall(request)
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string(new StringContains("to field")));
@@ -218,6 +228,7 @@ class ContractControllerTest {
         final var dataAsHex =
                 ONE_BYTE_HEX.repeat((int) evmProperties.getMaxDataSize().toBytes() + 1);
         request.setTo(null);
+        request.setValue(0);
         request.setData("0x" + dataAsHex);
         request.setEstimate(true);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -508,6 +508,17 @@ class ContractCallServiceTest extends ContractCallTestSetup {
     }
 
     @Test
+    void ethCallForContractDeploy() {
+        final var serviceParameters = serviceParametersForTopLevelContractCreate(
+                ADDRESS_THIS_CONTRACT_INIT_BYTES_PATH, ETH_CALL, SENDER_ADDRESS);
+
+        String result = contractCallService.processCall(serviceParameters);
+        assertThat(result)
+                .isEqualTo(Bytes.wrap(functionEncodeDecoder.getContractBytes(ADDRESS_THIS_CONTRACT_BYTES_PATH))
+                        .toHexString());
+    }
+
+    @Test
     void nestedContractStateChangesWork() {
         final var stateChangeHash =
                 "0x51fecdca000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000004ed00000000000000000000000000000000000000000000000000000000000000046976616e00000000000000000000000000000000000000000000000000000000";


### PR DESCRIPTION
**Description**:
The old validation of the "to" field on contract call made the requests to fail in the contract deploy scenario because the "to" field is empty in this case and only the estimate calls worked before. This PR makes the validation less restrictive and it is now applicable only for transfers.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/8072