### PR TITLE
Bump bouncy castle version to fix synk vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
         api("com.esaulpaugh:headlong:10.0.2")
         api("com.github.meanbeanlib:meanbean:3.0.0-M9")
         api("com.github.vertical-blank:sql-formatter:2.0.5")
-        api("org.bouncycastle:bcprov-jdk15to18:1.78")
+        api("org.bouncycastle:bcprov-jdk18on:1.78")
         api("com.bucket4j:bucket4j-core:8.10.1")
         api("com.google.cloud:spring-cloud-gcp-dependencies:5.1.2")
         api("com.google.guava:guava:33.1.0-jre")

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("jakarta.inject:jakarta.inject-api")
     implementation("javax.inject:javax.inject:1")
     implementation("net.java.dev.jna:jna")
-    implementation("org.bouncycastle:bcprov-jdk15to18")
+    implementation("org.bouncycastle:bcprov-jdk18on")
     implementation("org.springframework:spring-context-support")
     implementation("org.springframework.boot:spring-boot-actuator-autoconfigure")
     implementation("org.springframework.boot:spring-boot-configuration-processor")


### PR DESCRIPTION
**Description**:
Fix synk vulnerability by bouncing bouncy castle 

This PR modifies 
* Bump bouncyCastle version to  org.bouncycastle:bcprov-jdk18on:1.78  

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
