### PR TITLE
Unset restjava enable override in integration flux config

### DIFF
--- a/clusters/preprod/integration/helmrelease.yaml
+++ b/clusters/preprod/integration/helmrelease.yaml
@@ -57,8 +57,6 @@ spec:
           enabled: false
     postgresql:
       enabled: false
-    restjava:
-      enabled: true
     rosetta:
       enabled: true
     test:


### PR DESCRIPTION
**Description**:
Related to PR #8117. Flux config update to not explicitly enable `restjava` in `integration` as `restjava` is now enabled by default in all environments.

**Related issue(s)**:

Resolves #8105

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
