### PR TITLE
Fix type conversion of `stackgres.postgresVersion`

### DIFF
--- a/charts/hedera-mirror/templates/stackgres/stackgres-cluster.yaml
+++ b/charts/hedera-mirror/templates/stackgres/stackgres-cluster.yaml
@@ -37,7 +37,7 @@ spec:
     disableClusterPodAntiAffinity: {{ not .Values.stackgres.podAntiAffinity }}
   postgres:
     extensions: {{ .Values.stackgres.extensions | toYaml | nindent 6 }}
-    version: {{ .Values.stackgres.postgresVersion }}
+    version: {{ .Values.stackgres.postgresVersion | quote }}
   prometheusAutobind: {{ .Values.stackgres.prometheus }}
   replication:
     mode: async  # We might consider setting coordinator to sync or the proposed sync-all in the future


### PR DESCRIPTION
**Description**:

Quote `stackgres.postgresVersion` to fix type conversion during deployment

**Related issue(s)**:

Fixes #8129

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
