### PR TITLE
Add missing logics and validations from services p2

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/Store.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/store/Store.java
@@ -23,10 +23,13 @@ import com.hedera.services.store.models.Token;
 import com.hedera.services.store.models.TokenRelationship;
 import com.hedera.services.store.models.UniqueToken;
 import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenID;
+import org.hyperledger.besu.datatypes.Address;
+
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
-import org.hyperledger.besu.datatypes.Address;
 
 /**
  * An interface which serves as a facade over the mirror-node specific in-memory state. This interface is used by components
@@ -95,6 +98,8 @@ public interface Store {
     boolean exists(Address accountID);
 
     Optional<Long> getHistoricalTimestamp();
+
+    Account loadAccountOrFailWith(final Address evmAddress, @Nullable final ResponseCodeEnum responseCodeEnum);
 
     enum OnMissing {
         THROW,

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtils.java
@@ -153,19 +153,19 @@ public class PrecompilePricingUtils {
         return fees.getServiceFee() + fees.getNetworkFee() + fees.getNodeFee();
     }
 
-    public long computeViewFunctionGas(final Timestamp now, final long minimumTinybarCost) {
+    public long computeViewFunctionGas(final Timestamp now, final long minimumGasCost) {
         final var usagePrices = resourceCosts.defaultPricesGiven(TokenGetInfo, now);
         final var fees = feeCalculator.estimatePayment(SYNTHETIC_REDIRECT_QUERY, usagePrices, now, ANSWER_ONLY);
 
         final long gasPriceInTinybars = feeCalculator.estimatedGasPriceInTinybars(ContractCall, now);
         final long calculatedFeeInTinybars = fees.getNetworkFee() + fees.getNodeFee() + fees.getServiceFee();
-        final long actualFeeInTinybars = Math.max(minimumTinybarCost, calculatedFeeInTinybars);
+        //final long actualFeeInTinybars = Math.max(minimumTinybarCost, calculatedFeeInTinybars);
 
         // convert to gas cost
-        final long baseGasCost = (actualFeeInTinybars + gasPriceInTinybars - 1L) / gasPriceInTinybars;
+        final long baseGasCost = (calculatedFeeInTinybars + gasPriceInTinybars - 1L) / gasPriceInTinybars;
 
-        // charge premium
-        return baseGasCost + (baseGasCost / 5L);
+        // return larger of minimum or gas charge plus premium
+        return Math.max(minimumGasCost, baseGasCost + (baseGasCost / 5L));
     }
 
     public long computeGasRequirement(

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtils.java
@@ -16,6 +16,34 @@
 
 package com.hedera.services.store.contracts.precompile.utils;
 
+import com.hedera.mirror.web3.evm.store.Store;
+import com.hedera.services.fees.FeeCalculator;
+import com.hedera.services.fees.HbarCentExchange;
+import com.hedera.services.fees.calculation.UsagePricesProvider;
+import com.hedera.services.fees.pricing.AssetsLoader;
+import com.hedera.services.hapi.utils.fees.FeeBuilder;
+import com.hedera.services.jproto.JKey;
+import com.hedera.services.store.contracts.precompile.Precompile;
+import com.hedera.services.utils.accessors.AccessorFactory;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.Key;
+import com.hederahashgraph.api.proto.java.KeyList;
+import com.hederahashgraph.api.proto.java.Query;
+import com.hederahashgraph.api.proto.java.SignatureMap;
+import com.hederahashgraph.api.proto.java.SignedTransaction;
+import com.hederahashgraph.api.proto.java.SubType;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionGetRecordQuery;
+import com.hederahashgraph.api.proto.java.TransactionID;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.EnumMap;
+import java.util.Map;
+
 import static com.hedera.services.utils.MiscUtils.asFcKeyUnchecked;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoApproveAllowance;
@@ -43,33 +71,6 @@ import static com.hederahashgraph.api.proto.java.SubType.TOKEN_FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.SubType.TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES;
 import static com.hederahashgraph.api.proto.java.SubType.TOKEN_NON_FUNGIBLE_UNIQUE;
 import static com.hederahashgraph.api.proto.java.SubType.TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES;
-
-import com.hedera.mirror.web3.evm.store.Store;
-import com.hedera.services.fees.FeeCalculator;
-import com.hedera.services.fees.HbarCentExchange;
-import com.hedera.services.fees.calculation.UsagePricesProvider;
-import com.hedera.services.fees.pricing.AssetsLoader;
-import com.hedera.services.hapi.utils.fees.FeeBuilder;
-import com.hedera.services.jproto.JKey;
-import com.hedera.services.store.contracts.precompile.Precompile;
-import com.hedera.services.utils.accessors.AccessorFactory;
-import com.hederahashgraph.api.proto.java.AccountID;
-import com.hederahashgraph.api.proto.java.HederaFunctionality;
-import com.hederahashgraph.api.proto.java.Key;
-import com.hederahashgraph.api.proto.java.KeyList;
-import com.hederahashgraph.api.proto.java.Query;
-import com.hederahashgraph.api.proto.java.SignatureMap;
-import com.hederahashgraph.api.proto.java.SignedTransaction;
-import com.hederahashgraph.api.proto.java.SubType;
-import com.hederahashgraph.api.proto.java.Timestamp;
-import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionGetRecordQuery;
-import com.hederahashgraph.api.proto.java.TransactionID;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.EnumMap;
-import java.util.Map;
 
 /**
  * Copied Logic type from hedera-services. Differences with the original:
@@ -159,7 +160,6 @@ public class PrecompilePricingUtils {
 
         final long gasPriceInTinybars = feeCalculator.estimatedGasPriceInTinybars(ContractCall, now);
         final long calculatedFeeInTinybars = fees.getNetworkFee() + fees.getNodeFee() + fees.getServiceFee();
-        //final long actualFeeInTinybars = Math.max(minimumTinybarCost, calculatedFeeInTinybars);
 
         // convert to gas cost
         final long baseGasCost = (calculatedFeeInTinybars + gasPriceInTinybars - 1L) / gasPriceInTinybars;

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/helpers/AllowanceHelpers.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/txns/crypto/helpers/AllowanceHelpers.java
@@ -16,9 +16,6 @@
 
 package com.hedera.services.txns.crypto.helpers;
 
-import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
-
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.services.hapi.fees.usage.crypto.AllowanceId;
@@ -28,6 +25,7 @@ import com.hedera.services.store.models.NftId;
 import com.hedera.services.store.models.Token;
 import com.hedera.services.store.models.UniqueToken;
 import com.hederahashgraph.api.proto.java.AccountID;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,6 +33,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALLOWANCE_OWNER_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
 
 /**
  *  Copied Logic type from hedera-services. Differences with the original:
@@ -109,7 +111,7 @@ public class AllowanceHelpers {
         } else if (entitiesChanged.containsKey(ownerId.num())) {
             return entitiesChanged.get(ownerId.num());
         } else {
-            return store.getAccount(ownerId.asEvmAddress(), OnMissing.THROW);
+            return store.loadAccountOrFailWith(ownerId.asEvmAddress(), INVALID_ALLOWANCE_OWNER_ID);
         }
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/StoreImplTest.java
@@ -16,13 +16,6 @@
 
 package com.hedera.mirror.web3.evm.store;
 
-import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.AbstractNft;
@@ -57,10 +50,8 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.NftId;
 import com.hedera.services.store.models.TokenRelationship;
 import com.hedera.services.store.models.UniqueToken;
+import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.services.utils.EntityIdUtils;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,6 +59,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mock.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(ContextExtension.class)
 @ExtendWith(MockitoExtension.class)
@@ -153,6 +155,9 @@ class StoreImplTest {
     @Mock(strictness = Strictness.LENIENT)
     private Nft nft;
 
+    @Mock
+    private OptionValidator validator;
+
     private StoreImpl subject;
 
     @BeforeEach
@@ -182,7 +187,7 @@ class StoreImplTest {
                 uniqueTokenDatabaseAccessor,
                 entityDatabaseAccessor);
         final var stackedStateFrames = new StackedStateFrames(accessors);
-        subject = new StoreImpl(stackedStateFrames);
+        subject = new StoreImpl(stackedStateFrames, validator);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdaterTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmStackedWorldStateUpdaterTest.java
@@ -32,6 +32,7 @@ import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmMutableWorldState;
 import com.hedera.node.app.service.evm.store.models.UpdateTrackingAccount;
 import com.hedera.node.app.service.evm.store.tokens.TokenAccessor;
+import com.hedera.services.txns.validation.OptionValidator;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.account.Account;
@@ -40,7 +41,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -88,6 +91,9 @@ class HederaEvmStackedWorldStateUpdaterTest {
     @Mock
     private EntityRepository entityRepository;
 
+    @Mock
+    private OptionValidator validator;
+
     private Store store;
 
     private HederaEvmStackedWorldStateUpdater subject;
@@ -99,7 +105,7 @@ class HederaEvmStackedWorldStateUpdaterTest {
                 entityDatabaseAccessor,
                 new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null, null));
         final var stackedStateFrames = new StackedStateFrames(accessors);
-        store = new StoreImpl(stackedStateFrames);
+        store = new StoreImpl(stackedStateFrames, validator);
         subject = new HederaEvmStackedWorldStateUpdater(
                 updater,
                 accountAccessor,

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmWorldStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/HederaEvmWorldStateTest.java
@@ -16,13 +16,6 @@
 
 package com.hedera.mirror.web3.evm.store.contract;
 
-import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
-import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
 import com.google.protobuf.ByteString;
 import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
@@ -47,9 +40,8 @@ import com.hedera.node.app.service.evm.store.contracts.AbstractCodeCache;
 import com.hedera.node.app.service.evm.store.contracts.HederaEvmEntityAccess;
 import com.hedera.node.app.service.evm.store.tokens.TokenAccessor;
 import com.hedera.services.store.models.Id;
+import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.ContractID;
-import java.util.Collections;
-import java.util.List;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +49,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.hedera.services.utils.EntityIdUtils.accountIdFromEvmAddress;
+import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(ContextExtension.class)
 @ExtendWith(MockitoExtension.class)
@@ -106,6 +108,9 @@ class HederaEvmWorldStateTest {
     @Mock
     private NftRepository nftRepository;
 
+    @Mock
+    private OptionValidator validator;
+
     private StoreImpl store;
 
     private HederaEvmWorldState subject;
@@ -129,7 +134,7 @@ class HederaEvmWorldStateTest {
                 tokenRelationshipDatabaseAccessor,
                 uniqueTokenDatabaseAccessor);
         final var stackedStateFrames = new StackedStateFrames(accessors);
-        store = new StoreImpl(stackedStateFrames);
+        store = new StoreImpl(stackedStateFrames, validator);
         subject = new HederaEvmWorldState(
                 hederaEvmEntityAccess,
                 evmProperties,

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/HTSPrecompiledContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/HTSPrecompiledContractTest.java
@@ -16,19 +16,6 @@
 
 package com.hedera.mirror.web3.evm.store.contract.precompile;
 
-import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
-import static com.hedera.node.app.service.evm.store.contracts.precompile.AbiConstants.ABI_ID_ERC_NAME;
-import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_REDIRECT_FOR_TOKEN;
-import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.contractAddress;
-import static com.hedera.services.store.contracts.precompile.codec.EncodingFacade.SUCCESS_RESULT;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.hyperledger.besu.datatypes.Address.ALTBN128_ADD;
-import static org.hyperledger.besu.datatypes.Address.ALTBN128_MUL;
-import static org.hyperledger.besu.datatypes.Address.BLS12_G1ADD;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
 import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.common.PrecompileContext;
@@ -49,14 +36,10 @@ import com.hedera.services.store.contracts.precompile.HTSPrecompiledContract;
 import com.hedera.services.store.contracts.precompile.PrecompileMapper;
 import com.hedera.services.store.contracts.precompile.codec.EncodingFacade;
 import com.hedera.services.store.contracts.precompile.utils.PrecompilePricingUtils;
+import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
@@ -69,6 +52,25 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
+import static com.hedera.node.app.service.evm.store.contracts.precompile.AbiConstants.ABI_ID_ERC_NAME;
+import static com.hedera.services.store.contracts.precompile.AbiConstants.ABI_ID_REDIRECT_FOR_TOKEN;
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.contractAddress;
+import static com.hedera.services.store.contracts.precompile.codec.EncodingFacade.SUCCESS_RESULT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hyperledger.besu.datatypes.Address.ALTBN128_ADD;
+import static org.hyperledger.besu.datatypes.Address.ALTBN128_MUL;
+import static org.hyperledger.besu.datatypes.Address.BLS12_G1ADD;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(ContextExtension.class)
 @ExtendWith(MockitoExtension.class)
@@ -122,6 +124,9 @@ class HTSPrecompiledContractTest {
     @Mock
     private PrecompilePricingUtils precompilePricingUtils;
 
+    @Mock
+    private OptionValidator validator;
+
     private Deque<MessageFrame> messageFrameStack;
     private Store store;
 
@@ -142,7 +147,7 @@ class HTSPrecompiledContractTest {
 
         final var stackedStateFrames = new StackedStateFrames(accessors);
 
-        store = new StoreImpl(stackedStateFrames);
+        store = new StoreImpl(stackedStateFrames, validator);
         messageFrameStack = new ArrayDeque<>();
         messageFrameStack.push(lastFrame);
         messageFrameStack.push(messageFrame);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/token/TokenAccessorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/token/TokenAccessorImplTest.java
@@ -16,14 +16,6 @@
 
 package com.hedera.mirror.web3.evm.token;
 
-import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
 import com.google.protobuf.ByteString;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.entity.Entity;
@@ -64,9 +56,8 @@ import com.hedera.mirror.web3.repository.TokenBalanceRepository;
 import com.hedera.mirror.web3.repository.TokenRepository;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.EvmNftInfo;
 import com.hedera.node.app.service.evm.store.contracts.precompile.codec.TokenKeyType;
+import com.hedera.services.txns.validation.OptionValidator;
 import com.hederahashgraph.api.proto.java.Key;
-import java.util.List;
-import java.util.Optional;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,6 +65,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(ContextExtension.class)
 @ExtendWith(MockitoExtension.class)
@@ -132,6 +134,9 @@ class TokenAccessorImplTest {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private Token token;
 
+    @Mock
+    private OptionValidator validator;
+
     private List<DatabaseAccessor<Object, ?>> accessors;
     private Store store;
 
@@ -162,7 +167,7 @@ class TokenAccessorImplTest {
                         nftRepository),
                 new UniqueTokenDatabaseAccessor(nftRepository));
         final var stackedStateFrames = new StackedStateFrames(accessors);
-        store = new StoreImpl(stackedStateFrames);
+        store = new StoreImpl(stackedStateFrames, validator);
         tokenAccessor = new TokenAccessorImpl(properties, store, mirrorEvmContractAliases);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/contracts/precompile/utils/PrecompilePricingUtilsTest.java
@@ -16,9 +16,13 @@
 
 package com.hedera.services.store.contracts.precompile.utils;
 
+import static com.hedera.services.store.contracts.precompile.HTSTestsUtil.sender;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.node.app.service.evm.accounts.HederaEvmContractAliases;
@@ -26,11 +30,11 @@ import com.hedera.services.fees.BasicHbarCentExchange;
 import com.hedera.services.fees.FeeCalculator;
 import com.hedera.services.fees.calculation.BasicFcfsUsagePrices;
 import com.hedera.services.fees.pricing.AssetsLoader;
+import com.hedera.services.hapi.utils.fees.FeeObject;
+import com.hedera.services.store.contracts.precompile.Precompile;
 import com.hedera.services.utils.accessors.AccessorFactory;
-import com.hederahashgraph.api.proto.java.ExchangeRate;
-import com.hederahashgraph.api.proto.java.HederaFunctionality;
-import com.hederahashgraph.api.proto.java.SubType;
-import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.*;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Map;
@@ -45,7 +49,8 @@ class PrecompilePricingUtilsTest {
     private static final long COST = 36;
     private static final int CENTS_RATE = 12;
     private static final int HBAR_RATE = 1;
-
+    private static final long GAS_PRICE = 77;
+    private static final long MINIMUM_GAS_COST = 100;
     public static final BigDecimal USD_TO_TINYCENTS = BigDecimal.valueOf(100 * 100_000_000L);
 
     @Mock
@@ -71,6 +76,12 @@ class PrecompilePricingUtilsTest {
 
     @Mock
     private HederaEvmContractAliases hederaEvmContractAliases;
+
+    @Mock
+    private Precompile precompile;
+
+    @Mock
+    private TransactionBody.Builder transactionBody;
 
     @Test
     void failsToLoadCanonicalPrices() throws IOException {
@@ -102,4 +113,100 @@ class PrecompilePricingUtilsTest {
                         .longValue(),
                 price);
     }
+
+    @Test
+    void computeViewFunctionGasMinimumTest() throws IOException {
+        final Timestamp timestamp = Timestamp.newBuilder().setSeconds(123456789).build();
+        FeeObject feeObject = new FeeObject(1, 2, 3);
+        given(assetLoader.loadCanonicalPrices())
+                .willReturn(Map.of(
+                        HederaFunctionality.TokenAssociateToAccount,
+                        Map.of(SubType.DEFAULT, BigDecimal.valueOf(COST))));
+        given(feeCalculator.estimatePayment(any(), any(), any(), any(ResponseType.class))).willReturn(feeObject);
+        given(feeCalculator.estimatedGasPriceInTinybars(any(), any())).willReturn(GAS_PRICE);
+
+        final PrecompilePricingUtils subject = new PrecompilePricingUtils(
+                assetLoader, exchange, feeCalculator, resourceCosts, accessorFactory);
+
+        // minimum gas cost should apply
+        final long price = subject.computeViewFunctionGas(timestamp, MINIMUM_GAS_COST);
+
+        assertEquals(MINIMUM_GAS_COST, price);
+    }
+
+    @Test
+    void computeViewFunctionGasTest() throws IOException {
+        final long nodeFee = 10000;
+        final long networkFee = 20000;
+        final long serviceFee = 30000;
+        final Timestamp timestamp = Timestamp.newBuilder().setSeconds(123456789).build();
+        FeeObject feeObject = new FeeObject(nodeFee, networkFee, serviceFee);
+        given(assetLoader.loadCanonicalPrices())
+                .willReturn(Map.of(
+                        HederaFunctionality.TokenAssociateToAccount,
+                        Map.of(SubType.DEFAULT, BigDecimal.valueOf(COST))));
+        given(feeCalculator.estimatePayment(any(), any(), any(), any(ResponseType.class))).willReturn(feeObject);
+        given(feeCalculator.estimatedGasPriceInTinybars(any(), any())).willReturn(GAS_PRICE);
+
+        final PrecompilePricingUtils subject = new PrecompilePricingUtils(
+                assetLoader, exchange, feeCalculator, resourceCosts, accessorFactory);
+
+        final long price = subject.computeViewFunctionGas(timestamp, MINIMUM_GAS_COST);
+        final long expectedPrice = (nodeFee + networkFee + serviceFee + GAS_PRICE - 1L) / GAS_PRICE;
+
+        // The minimum gas cost does not apply.  The cost is the expected price plus 20%.
+        assertEquals(expectedPrice + expectedPrice / 5, price);
+    }
+
+    @Test
+    void computeGasRequirementMinimumTest() throws IOException {
+        final long gasInTinybars = 10000;
+        final long minimumFeeInTinybars = 20000;
+        final Timestamp timestamp = Timestamp.newBuilder().setSeconds(123456789).build();
+        given(assetLoader.loadCanonicalPrices())
+                .willReturn(Map.of(
+                        HederaFunctionality.TokenAssociateToAccount,
+                        Map.of(SubType.DEFAULT, BigDecimal.valueOf(COST))));
+        given(feeCalculator.estimatedGasPriceInTinybars(any(), any())).willReturn(GAS_PRICE);
+        given(precompile.getMinimumFeeInTinybars(any(), any(), any())).willReturn(minimumFeeInTinybars);
+
+        final PrecompilePricingUtils subject = new PrecompilePricingUtils(
+                assetLoader, exchange, feeCalculator, resourceCosts, accessorFactory);
+        final var subjectSpy = spy(subject);
+
+        doReturn(gasInTinybars).when(subjectSpy).gasFeeInTinybars(any(), any());
+
+        final long price = subjectSpy.computeGasRequirement(timestamp.getSeconds(), precompile, transactionBody, sender);
+        final long expectedPrice = (minimumFeeInTinybars + GAS_PRICE - 1L) / GAS_PRICE;
+
+        // The minimum gas should apply
+        assertEquals(expectedPrice + expectedPrice / 5, price);
+    }
+
+    @Test
+    void computeGasRequirementTest() throws IOException {
+        final long gasInTinybars = 10000;
+        final long minimumFeeInTinybars = 500;
+        final Timestamp timestamp = Timestamp.newBuilder().setSeconds(123456789).build();
+        given(assetLoader.loadCanonicalPrices())
+                .willReturn(Map.of(
+                        HederaFunctionality.TokenAssociateToAccount,
+                        Map.of(SubType.DEFAULT, BigDecimal.valueOf(COST))));
+        given(feeCalculator.estimatedGasPriceInTinybars(any(), any())).willReturn(GAS_PRICE);
+        given(precompile.getMinimumFeeInTinybars(any(), any(), any())).willReturn(minimumFeeInTinybars);
+
+        final PrecompilePricingUtils subject = new PrecompilePricingUtils(
+                assetLoader, exchange, feeCalculator, resourceCosts, accessorFactory);
+        final var subjectSpy = spy(subject);
+
+        doReturn(gasInTinybars).when(subjectSpy).gasFeeInTinybars(any(), any());
+
+        final long price = subjectSpy.computeGasRequirement(timestamp.getSeconds(), precompile, transactionBody, sender);
+        final long expectedPrice = (gasInTinybars + GAS_PRICE - 1L) / GAS_PRICE;
+
+        // The minimum gas cost does not apply.  The cost is the expected price plus 20%.
+        assertEquals(expectedPrice + expectedPrice / 5, price);
+    }
+
+
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/AutoCreationLogicTest.java
@@ -34,6 +34,7 @@ import com.hedera.services.hapi.utils.fees.FeeObject;
 import com.hedera.services.jproto.JKey;
 import com.hedera.services.ledger.BalanceChange;
 import com.hedera.services.store.contracts.precompile.SyntheticTxnFactory;
+import com.hedera.services.txns.validation.OptionValidator;
 import com.hedera.services.utils.IdUtils;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -104,6 +105,9 @@ class AutoCreationLogicTest {
     @Mock
     private EvmProperties evmProperties;
 
+    @Mock
+    private OptionValidator validator;
+
     private AutoCreationLogic subject;
 
     @BeforeEach
@@ -111,7 +115,7 @@ class AutoCreationLogicTest {
         final List<DatabaseAccessor<Object, ?>> accessors =
                 List.of(new AccountDatabaseAccessor(entityDatabaseAccessor, null, null, null, null, null, null));
         final var stackedStateFrames = new StackedStateFrames(accessors);
-        store = new StoreImpl(stackedStateFrames);
+        store = new StoreImpl(stackedStateFrames, validator);
         subject = new AutoCreationLogic(feeCalculator, evmProperties, syntheticTxnFactory, aliasManager);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/DeleteAllowanceLogicTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/txns/crypto/DeleteAllowanceLogicTest.java
@@ -16,20 +16,6 @@
 
 package com.hedera.services.txns.crypto;
 
-import static com.hedera.services.store.models.Id.fromGrpcToken;
-import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
-import static com.hedera.services.utils.EntityNum.fromAccountId;
-import static com.hedera.services.utils.EntityNum.fromTokenId;
-import static com.hedera.services.utils.IdUtils.asAccount;
-import static com.hedera.services.utils.IdUtils.asToken;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import com.hedera.mirror.web3.evm.store.Store;
 import com.hedera.mirror.web3.evm.store.Store.OnMissing;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
@@ -47,16 +33,32 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionID;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static com.hedera.services.store.models.Id.fromGrpcToken;
+import static com.hedera.services.utils.EntityIdUtils.asTypedEvmAddress;
+import static com.hedera.services.utils.EntityNum.fromAccountId;
+import static com.hedera.services.utils.EntityNum.fromTokenId;
+import static com.hedera.services.utils.IdUtils.asAccount;
+import static com.hedera.services.utils.IdUtils.asToken;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALLOWANCE_OWNER_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class DeleteAllowanceLogicTest {
@@ -100,7 +102,7 @@ class DeleteAllowanceLogicTest {
         givenValidTxnCtx();
         ownerAccount = addExistingAllowances(ownerAccount);
         given(store.getAccount(asTypedEvmAddress(payerId), OnMissing.THROW)).willReturn(payerAccount);
-        given(store.getAccount(asTypedEvmAddress(ownerId), OnMissing.THROW)).willReturn(ownerAccount);
+        given(store.loadAccountOrFailWith(asTypedEvmAddress(ownerId), INVALID_ALLOWANCE_OWNER_ID)).willReturn(ownerAccount);
 
         token2Model = token2Model.setTreasury(ownerAccount);
         final var nftId2 = new NftId(token2.getShardNum(), token2.getRealmNum(), token2.getTokenNum(), 12L);
@@ -122,7 +124,7 @@ class DeleteAllowanceLogicTest {
         givenValidTxnCtx();
         ownerAccount = addExistingAllowances(ownerAccount);
         given(store.getAccount(asTypedEvmAddress(payerId), OnMissing.THROW)).willReturn(payerAccount);
-        given(store.getAccount(asTypedEvmAddress(ownerId), OnMissing.THROW)).willReturn(ownerAccount);
+        given(store.loadAccountOrFailWith(asTypedEvmAddress(ownerId), INVALID_ALLOWANCE_OWNER_ID)).willReturn(ownerAccount);
         token2Model = token2Model.setTreasury(ownerAccount);
         final var nftId2 = new NftId(token2.getShardNum(), token2.getRealmNum(), token2.getTokenNum(), 12L);
         given(store.getUniqueToken(nftId2, OnMissing.THROW)).willReturn(uniqueToken2);
@@ -143,7 +145,7 @@ class DeleteAllowanceLogicTest {
         givenValidTxnCtx();
 
         given(store.getAccount(asTypedEvmAddress(payerId), OnMissing.THROW)).willReturn(payerAccount);
-        given(store.getAccount(asTypedEvmAddress(ownerId), OnMissing.THROW)).willReturn(ownerAccount);
+        given(store.loadAccountOrFailWith(asTypedEvmAddress(ownerId), INVALID_ALLOWANCE_OWNER_ID)).willReturn(ownerAccount);
         token2Model = token2Model.setTreasury(payerAccount);
         final var nftId2 = new NftId(token2.getShardNum(), token2.getRealmNum(), token2.getTokenNum(), 12L);
         given(store.getUniqueToken(nftId2, OnMissing.THROW)).willReturn(uniqueToken2);
@@ -169,7 +171,7 @@ class DeleteAllowanceLogicTest {
         op = cryptoDeleteAllowanceTxn.getCryptoDeleteAllowance();
 
         given(store.getAccount(asTypedEvmAddress(payerId), OnMissing.THROW)).willReturn(payerAccount);
-        given(store.getAccount(asTypedEvmAddress(ownerId), OnMissing.THROW)).willReturn(ownerAccount);
+        given(store.loadAccountOrFailWith(asTypedEvmAddress(ownerId), INVALID_ALLOWANCE_OWNER_ID)).willReturn(ownerAccount);
 
         subject.deleteAllowance(store, new ArrayList<>(), op.getNftAllowancesList(), payerId);
 


### PR DESCRIPTION
**Description**:
**PrecompilePricingUtils - computeViewFunctionGas**
Change calculate implementation and now will return a larger of minimum or gas charge plus premium. Add new tests and modify old ones.
 
**AllowanceHelpers - fetchOwxnerAccount** 
**ApproveAllowanceLogic - INVALID_ALLOWANCE_SPENDER_ID**
Add `loadAccountOrFailWith ` and `validateUsable` in `Store` which help to load the account from the state and throw the given code if an exception occurs due to an invalid account. Add new tests and modify old ones.

**Related issue(s)**:

Fixes #8137

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
