### PR TITLE
Trigger k6 rest testsuite when acceptance test pod is deleted

### DIFF
--- a/charts/hedera-mirror-rest/templates/_helpers.tpl
+++ b/charts/hedera-mirror-rest/templates/_helpers.tpl
@@ -47,14 +47,6 @@ Labels
 {{- end -}}
 
 {{/*
-Rest Test Labels
-*/}}
-{{- define "hedera-mirror-rest-test.labels" -}}
-{{ include "hedera-mirror-rest.labels" . }}
-test-trigger: rest-trigger
-{{- end -}}
-
-{{/*
 Monitor labels
 */}}
 {{- define "hedera-mirror-rest-monitor.labels" -}}

--- a/charts/hedera-mirror-rest/templates/tests/pod.yaml
+++ b/charts/hedera-mirror-rest/templates/tests/pod.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations: {{- toYaml .Values.test.annotations | nindent 4 }}
-  labels: {{- include "hedera-mirror-rest-test.labels" . | nindent 4 }}
+  labels: {{- include "hedera-mirror-rest.labels" . | nindent 4 }}
   name: {{ include "hedera-mirror-rest.fullname" . }}-test
   namespace: {{ include "hedera-mirror-rest.namespace" . }}
 spec:

--- a/charts/hedera-mirror/templates/_helpers.tpl
+++ b/charts/hedera-mirror/templates/_helpers.tpl
@@ -98,3 +98,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Acceptance Test Labels
+*/}}
+{{- define "hedera-mirror-acceptance.labels" -}}
+{{ include "hedera-mirror.labels" . }}
+test-trigger: rest-trigger
+{{- end -}}

--- a/charts/hedera-mirror/templates/tests/pod.yaml
+++ b/charts/hedera-mirror/templates/tests/pod.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations: {{- toYaml .Values.test.annotations | nindent 4 }}
-  labels: {{- include "hedera-mirror.labels" . | nindent 4 }}
+  labels: {{- include "hedera-mirror-acceptance.labels" . | nindent 4 }}
   name: {{ include "hedera-mirror.fullname" . }}-acceptance
   namespace: {{ include "hedera-mirror.namespace" . }}
 spec:


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR change how k6 rest testsuite is triggered

- Move k6 rest testsuite trigger label to acceptance test pod

**Related issue(s)**:

Fixes #8237 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
