### PR TITLE
Clear incorrect token metadata / metadata key and fix ingestion logic (0.104)

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/RecordFile.java
@@ -48,6 +48,7 @@ public class RecordFile implements StreamFile<RecordItem> {
     public static final Version HAPI_VERSION_0_23_0 = new Version(0, 23, 0);
     public static final Version HAPI_VERSION_0_27_0 = new Version(0, 27, 0);
     public static final Version HAPI_VERSION_0_47_0 = new Version(0, 47, 0);
+    public static final Version HAPI_VERSION_0_49_0 = new Version(0, 49, 0);
 
     @ToString.Exclude
     private byte[] bytes;

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/DomainBuilder.java
@@ -145,6 +145,8 @@ public class DomainBuilder {
     private final Instant now = Instant.now();
     private final SecureRandom random = new SecureRandom();
 
+    private long timestampOffset = 0;
+
     // Intended for use by unit tests that don't need persistence
     public DomainBuilder() {
         this(null, null);
@@ -1089,8 +1091,16 @@ public class DomainBuilder {
         return RandomStringUtils.random(characters, "0123456789abcdef");
     }
 
+    /**
+     * Reset the timestamp, so next call of timestamp() will return value + 1
+     * @param value The timestamp to reset to
+     */
+    public void resetTimestamp(long value) {
+        timestampOffset = value - timestampNoOffset();
+    }
+
     public long timestamp() {
-        return DomainUtils.convertToNanosMax(now.getEpochSecond(), now.getNano()) + number();
+        return timestampNoOffset() + timestampOffset;
     }
 
     private long tinybar() {
@@ -1102,6 +1112,10 @@ public class DomainBuilder {
                 .atStartOfDay()
                 .toLocalDate()
                 .toEpochDay();
+    }
+
+    private long timestampNoOffset() {
+        return DomainUtils.convertToNanosMax(now.getEpochSecond(), now.getNano()) + number();
     }
 
     private int transactionIndex() {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateTransactionHandler.java
@@ -16,6 +16,8 @@
 
 package com.hedera.mirror.importer.parser.record.transactionhandler;
 
+import static com.hedera.mirror.common.domain.transaction.RecordFile.HAPI_VERSION_0_49_0;
+
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -107,12 +109,17 @@ class TokenUpdateTransactionHandler extends AbstractEntityCrudTransactionHandler
             token.setKycKey(transactionBody.getKycKey().toByteArray());
         }
 
-        if (transactionBody.hasMetadata()) {
-            token.setMetadata(DomainUtils.toBytes(transactionBody.getMetadata().getValue()));
-        }
+        // metadata and metadata key fields are supported from services 0.49.0. This is a workaround of the issue that
+        // services 0.48.x processes such transactions as if the fields are not present.
+        if (recordItem.getHapiVersion().isGreaterThanOrEqualTo(HAPI_VERSION_0_49_0)) {
+            if (transactionBody.hasMetadata()) {
+                token.setMetadata(
+                        DomainUtils.toBytes(transactionBody.getMetadata().getValue()));
+            }
 
-        if (transactionBody.hasMetadataKey()) {
-            token.setMetadataKey(transactionBody.getMetadataKey().toByteArray());
+            if (transactionBody.hasMetadataKey()) {
+                token.setMetadataKey(transactionBody.getMetadataKey().toByteArray());
+            }
         }
 
         if (!transactionBody.getName().isEmpty()) {

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.97.2__clear_token_metadata.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.97.2__clear_token_metadata.sql
@@ -1,0 +1,22 @@
+-- clear token metadata and metadata_key accidentally set prior to services 0.49.0
+with timestamp_info as (
+    -- make it closed-open, if nothing found, it's int8range(0, 0) which is empty
+    -- 1709229598938101716 is the last 0.46.x transaction's timestamp in testnet, mainnet's is at a later time
+    select int8range(coalesce(min(consensus_start), 0), coalesce(max(consensus_end) + 1, 0)) as affected_range
+    from record_file
+    where hapi_version_major = 0 and hapi_version_minor = 47 and consensus_end > 1709229598938101716
+), clear_token_history as (
+  update token_history
+  set metadata = null,
+      metadata_key = null
+  from timestamp_info
+  -- the two ranges overlap and the token timestamp range does not extend to the left of the affected range, i.e.
+  -- the lower bound of the token timestamp range (when the token was created / updated), is in affected_range.
+  -- this is faster since it can utilize the gist index on timestamp_range
+  where timestamp_range && affected_range and timestamp_range &> affected_range
+)
+update token
+set metadata = null,
+    metadata_key = null
+from timestamp_info
+where affected_range @> lower(timestamp_range);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/VersionConverter.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/converter/VersionConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.importer.converter;
+
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.ArgumentConverter;
+import org.springframework.data.util.Version;
+
+public class VersionConverter implements ArgumentConverter {
+
+    @Override
+    public Object convert(Object input, ParameterContext context) throws ArgumentConversionException {
+        if (input == null) {
+            return null;
+        }
+
+        if (input instanceof String inputString) {
+            return Version.parse(inputString);
+        } else {
+            throw new ArgumentConversionException("Input " + input + " is not a string");
+        }
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ClearTokenMetadataMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/ClearTokenMetadataMigrationTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.importer.migration;
+
+import static com.hedera.mirror.common.util.DomainUtils.EMPTY_BYTE_ARRAY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Range;
+import com.hedera.mirror.common.domain.token.Token;
+import com.hedera.mirror.common.domain.transaction.RecordFile;
+import com.hedera.mirror.importer.EnabledIfV1;
+import com.hedera.mirror.importer.ImporterIntegrationTest;
+import com.hedera.mirror.importer.repository.TokenRepository;
+import io.hypersistence.utils.hibernate.type.range.guava.PostgreSQLGuavaRangeType;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.StreamUtils;
+
+@EnabledIfV1
+@Import(DisablePartitionMaintenanceConfiguration.class)
+@RequiredArgsConstructor
+@Tag("migration")
+@TestPropertySource(properties = "spring.flyway.target=1.97.1")
+class ClearTokenMetadataMigrationTest extends ImporterIntegrationTest {
+
+    private static final long CREATE = -1;
+    private static final Predicate<Token> IS_CURRENT = t -> t.getTimestampUpper() == null;
+    private static final long LAST_HAPI_0_46_TIMESTAMP = 1709229598938101716L;
+
+    @Value("classpath:db/migration/v1/V1.97.2__clear_token_metadata.sql")
+    private final Resource migrationSql;
+
+    private final TokenRepository tokenRepository;
+    private List<Token> tokens = new ArrayList<>();
+    private final Map<Long, Token> tokenState = new HashMap<>();
+
+    @AfterEach
+    void teardown() {
+        tokens.clear();
+        tokenState.clear();
+    }
+
+    @Test
+    void empty() {
+        runMigration();
+        assertThat(tokenRepository.findAll()).isEmpty();
+        assertThat(findHistory(Token.class)).isEmpty();
+    }
+
+    @CsvSource(
+            textBlock =
+                    """
+            -1, true
+            0, true
+            1, true
+            2, true
+            3, true
+            4, true
+            1, false
+            3, false
+            """)
+    @ParameterizedTest
+    void migrate(int firstRecordFileIndexToDelete, boolean isBackwards) {
+        // given
+        // reserve 50ns for 2 HAPI 0.46 record files with each spanning 10ns
+        domainBuilder.resetTimestamp(LAST_HAPI_0_46_TIMESTAMP - 50);
+        var recordFiles = Lists.newArrayList(persistRecordFile(46), persistRecordFile(46));
+        domainBuilder.resetTimestamp(LAST_HAPI_0_46_TIMESTAMP);
+        recordFiles.addAll(List.of(
+                persistRecordFile(47), // index 2
+                persistRecordFile(47),
+                // there is no HAPI version 0.48.0 record file in the network because services still generates
+                // them with HAPI version 0.47.0 in release 0.48.x
+                persistRecordFile(49), // index 4
+                persistRecordFile(49)));
+
+        // token1 created in 0.46, without metadata / metadata key, and none of its updates will set the fields
+        long timestamp = recordFiles.getFirst().getConsensusStart();
+        long token1 = createOrUpdateToken(t -> t.metadata(null).metadataKey(null), CREATE, timestamp);
+
+        // token2 created in 0.47, no metadata, with metadata key, however a later update in 0.47 will set metadata
+        timestamp = recordFiles.get(2).getConsensusStart();
+        long token2 = createOrUpdateToken(
+                t -> t.metadata(EMPTY_BYTE_ARRAY).metadataKey(domainBuilder.key()), CREATE, timestamp);
+
+        // an update to set token2's metadata and updates metadata key
+        createOrUpdateToken(
+                t -> t.metadata(domainBuilder.bytes(8)).metadataKey(domainBuilder.key()), token2, ++timestamp);
+
+        // token3 created in 0.47 with metadata / metadata key
+        long token3 = createOrUpdateToken(t -> {}, CREATE, ++timestamp);
+
+        // token3 metadata updated
+        createOrUpdateToken(t -> t.metadata(domainBuilder.bytes(16)), token3, ++timestamp);
+
+        // token1 updated
+        createOrUpdateToken(t -> {}, token1, ++timestamp);
+
+        // corner case, token4 created at the last consensus timestamp of 0.47, with metadata / metadata key
+        timestamp = recordFiles.get(3).getConsensusEnd();
+        createOrUpdateToken(t -> {}, CREATE, timestamp);
+
+        // token5 created in 0.49, without metadata / metadata key
+        timestamp = recordFiles.get(4).getConsensusStart();
+        long token5 = createOrUpdateToken(t -> t.metadata(EMPTY_BYTE_ARRAY).metadataKey(null), CREATE, timestamp);
+
+        // token5 updated, still no metadata / metadata key
+        createOrUpdateToken(t -> {}, token5, ++timestamp);
+
+        // token6 created in 0.49 with metadata / metadata key
+        createOrUpdateToken(t -> {}, CREATE, ++timestamp);
+
+        // token1 updated
+        createOrUpdateToken(t -> {}, token1, ++timestamp);
+
+        // token7 created in the second 0.49 record file, with metadata / metadata key
+        timestamp = recordFiles.get(5).getConsensusStart();
+        createOrUpdateToken(t -> {}, CREATE, recordFiles.get(5).getConsensusStart());
+
+        // token1 updated
+        createOrUpdateToken(t -> {}, token1, ++timestamp);
+
+        prune(firstRecordFileIndexToDelete, isBackwards, recordFiles);
+        persistTokens();
+        var partitioned = tokens.stream()
+                .peek(t -> {
+                    if (t.getTimestampLower() < recordFiles.get(4).getConsensusStart()) {
+                        t.setMetadata(null);
+                        t.setMetadataKey(null);
+                    }
+                })
+                .collect(Collectors.partitioningBy(IS_CURRENT));
+        var expectedCurrent = partitioned.get(true);
+        var expectedHistory = partitioned.get(false);
+
+        // when
+        runMigration();
+
+        // then
+        assertThat(tokenRepository.findAll()).containsExactlyInAnyOrderElementsOf(expectedCurrent);
+        assertThat(findHistory(Token.class)).containsExactlyInAnyOrderElementsOf(expectedHistory);
+    }
+
+    private long createOrUpdateToken(Consumer<Token.TokenBuilder<?, ?>> customizer, long tokenId, long timestamp) {
+        Token.TokenBuilder<?, ?> builder;
+        if (tokenState.containsKey(tokenId)) {
+            // close timestamp range of the current state
+            var current = tokenState.get(tokenId);
+            current.setTimestampUpper(timestamp);
+
+            builder = current.toBuilder();
+        } else {
+            builder = domainBuilder.token().get().toBuilder().createdTimestamp(timestamp);
+        }
+
+        customizer.accept(builder);
+        var token = builder.timestampRange(Range.atLeast(timestamp)).build();
+
+        // get the actual token id, the tokenId value passed in might be -1 to indicate new token creation
+        tokenId = token.getTokenId();
+        tokens.add(token);
+        tokenState.put(tokenId, token);
+        return tokenId;
+    }
+
+    private RecordFile persistRecordFile(int hapiVersionMinor) {
+        var recordFile = domainBuilder
+                .recordFile()
+                .customize(r -> {
+                    long consensusEnd = r.build().getConsensusStart() + 10;
+                    r.consensusEnd(consensusEnd).hapiVersionMinor(hapiVersionMinor);
+                })
+                .persist();
+        // advance more than 10ns so the next timestamp would not fall into the same record file
+        for (int i = 0; i < 12; i++) {
+            domainBuilder.timestamp();
+        }
+
+        return recordFile;
+    }
+
+    private void persistTokens() {
+        var partitioned = tokens.stream().collect(Collectors.partitioningBy(IS_CURRENT));
+        var current = partitioned.get(true);
+        var history = partitioned.get(false);
+
+        tokenRepository.saveAll(current);
+        if (!history.isEmpty()) {
+            jdbcOperations.batchUpdate(
+                    """
+                insert into token_history (created_timestamp, decimals, fee_schedule_key, freeze_default, freeze_key,
+                  freeze_status, initial_supply, kyc_key, kyc_status, max_supply, metadata, metadata_key, name,
+                  pause_key, pause_status, supply_key, supply_type, symbol, timestamp_range, token_id, total_supply,
+                  treasury_account_id, type, wipe_key)
+                values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?::token_pause_status,?,?::token_supply_type,?,?::int8range,?,?,?,?::token_type,?)
+                """,
+                    history,
+                    history.size(),
+                    (ps, token) -> {
+                        ps.setLong(1, token.getCreatedTimestamp());
+                        ps.setInt(2, token.getDecimals());
+                        ps.setBytes(3, token.getFeeScheduleKey());
+                        ps.setBoolean(4, token.getFreezeDefault());
+                        ps.setBytes(5, token.getFreezeKey());
+                        ps.setInt(6, token.getFreezeStatus().ordinal());
+                        ps.setLong(7, token.getInitialSupply());
+                        ps.setBytes(8, token.getKycKey());
+                        ps.setInt(9, token.getKycStatus().ordinal());
+                        ps.setLong(10, token.getMaxSupply());
+                        ps.setBytes(11, token.getMetadata());
+                        ps.setBytes(12, token.getMetadataKey());
+                        ps.setString(13, token.getName());
+                        ps.setBytes(14, token.getPauseKey());
+                        ps.setString(15, token.getPauseStatus().name());
+                        ps.setBytes(16, token.getSupplyKey());
+                        ps.setString(17, token.getSupplyType().name());
+                        ps.setString(18, token.getSymbol());
+                        ps.setString(19, PostgreSQLGuavaRangeType.INSTANCE.asString(token.getTimestampRange()));
+                        ps.setLong(20, token.getTokenId());
+                        ps.setLong(21, token.getTotalSupply());
+                        ps.setLong(22, token.getTreasuryAccountId().getId());
+                        ps.setString(23, token.getType().name());
+                        ps.setBytes(24, token.getWipeKey());
+                    });
+        }
+    }
+
+    private void prune(int firstRecordFileIndexToDelete, boolean isBackwards, List<RecordFile> recordFiles) {
+        try {
+            var recordFile = recordFiles.get(firstRecordFileIndexToDelete);
+            long consensusEnd = recordFile.getConsensusEnd();
+            if (isBackwards) {
+                jdbcOperations.update("delete from record_file where consensus_end <= ?", consensusEnd);
+                tokens = tokens.stream()
+                        .filter(t -> t.getTimestampLower() > consensusEnd)
+                        .collect(Collectors.toList());
+            } else {
+                jdbcOperations.update("delete from record_file where consensus_end >= ?", consensusEnd);
+                tokens = tokens.stream()
+                        .filter(t -> t.getTimestampLower() < recordFile.getConsensusStart())
+                        .collect(Collectors.toList());
+            }
+        } catch (IndexOutOfBoundsException e) {
+            // do nothing
+        }
+    }
+
+    @SneakyThrows
+    private void runMigration() {
+        try (var is = migrationSql.getInputStream()) {
+            var script = StreamUtils.copyToString(is, StandardCharsets.UTF_8);
+            jdbcOperations.execute(script);
+        }
+    }
+}

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.importer.parser.domain;
 
 import static com.hedera.mirror.common.domain.DomainBuilder.KEY_LENGTH_ECDSA;
 import static com.hedera.mirror.common.domain.DomainBuilder.KEY_LENGTH_ED25519;
+import static com.hedera.mirror.common.domain.transaction.RecordFile.HAPI_VERSION_0_49_0;
 import static com.hedera.mirror.common.util.DomainUtils.TINYBARS_IN_ONE_HBAR;
 import static com.hederahashgraph.api.proto.java.CustomFee.FeeCase.FIXED_FEE;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
@@ -779,7 +780,8 @@ public class RecordItemBuilder {
                 .setToken(tokenId())
                 .setTreasury(accountId())
                 .setWipeKey(key());
-        return new Builder<>(TransactionType.TOKENUPDATE, transactionBody);
+        return new Builder<>(TransactionType.TOKENUPDATE, transactionBody)
+                .recordItem(r -> r.hapiVersion(HAPI_VERSION_0_49_0));
     }
 
     public Builder<TokenCreateTransactionBody.Builder> tokenCreate() {
@@ -804,6 +806,7 @@ public class RecordItemBuilder {
                 .addCustomFees(customFee(FIXED_FEE))
                 .setWipeKey(key());
         return new Builder<>(TransactionType.TOKENCREATION, transactionBody)
+                .recordItem(r -> r.hapiVersion(HAPI_VERSION_0_49_0))
                 .receipt(r -> r.setTokenID(tokenId))
                 .record(r -> r.addAutomaticTokenAssociations(
                         TokenAssociation.newBuilder().setAccountId(treasury).setTokenId(tokenId)));


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR backports the fix to `release/0.104`

- Only process token metadata / metadata key in TokenCreate and TokenUpdate transactions when HAPI version >= 0.49.0
- Add a db migration to clear incorrect token metadata / metadata key

**Related issue(s)**:

Relates to #8263

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
