### PR TITLE
Bump securego/gosec to v2.20.0

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,14 +2,14 @@ name: Security
 on:
   pull_request:
     branches:
-      - 'main'
-      - 'release/**'
+      - "main"
+      - "release/**"
   push:
     branches:
-      - 'main'
-      - 'release/**'
+      - "main"
+      - "release/**"
     tags:
-      - 'v*'
+      - "v*"
 
 defaults:
   run:
@@ -102,7 +102,7 @@ jobs:
           go-version: 1.22
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@417a44c73be12f54ac1732daaca952f3d3a0ba9d # master
+        uses: securego/gosec@6fbd381238e97e1d1f3358f0d6d65de78dcf9245 # v2.20.0
         with:
           args: ./...
 


### PR DESCRIPTION
**Description**:

Bump `securego/gosec` from `master` to `v2.20.0`

**Related issue(s)**:

**Notes for reviewer**:

We temporarily set it to master to be able to upgrade Go to the latest.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
