### PR TITLE
Check support of negative one value for maxAutomaticTokenAssociations

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/EntityRecordItemListenerContractTest.java
@@ -138,6 +138,7 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
                     }
                     b.clearAutoRenewAccountId()
                             .setDeclineReward(true)
+                            .setMaxAutomaticTokenAssociations(-1)
                             .setStakedAccountId(AccountID.newBuilder()
                                     .setAccountNum(domainBuilder.id())
                                     .build());
@@ -156,7 +157,8 @@ class EntityRecordItemListenerContractTest extends AbstractEntityRecordItemListe
                 () -> assertContractEntity(recordItem),
                 () -> assertThat(entityRepository.findById(entityId.getId()))
                         .get()
-                        .returns(1L, Entity::getEthereumNonce),
+                        .returns(1L, Entity::getEthereumNonce)
+                        .returns(-1, Entity::getMaxAutomaticTokenAssociations),
                 () -> assertThat(contractResultRepository.findAll()).hasSize(1),
                 () -> assertContractCreateResult(transactionBody, record),
                 () -> assertContractStateChanges(recordItem),

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/CryptoUpdateTransactionHandlerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.Range;
 import com.google.protobuf.BoolValue;
+import com.google.protobuf.Int32Value;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityTransaction;
@@ -88,10 +89,12 @@ class CryptoUpdateTransactionHandlerTest extends AbstractTransactionHandlerTest 
         RecordItem withStakedNodeIdSet = recordItemBuilder
                 .cryptoUpdate()
                 .recordItem(r -> r.hapiVersion(new Version(0, 28, 0)))
-                .transactionBody(body -> body.clear().setStakedAccountId(accountId))
+                .transactionBody(body ->
+                        body.clear().setStakedAccountId(accountId).setMaxAutomaticTokenAssociations(Int32Value.of(-1)))
                 .build();
         setupForCryptoUpdateTransactionTest(withStakedNodeIdSet, t -> assertThat(t)
                 .returns(null, Entity::getDeclineReward)
+                .returns(-1, Entity::getMaxAutomaticTokenAssociations)
                 .returns(accountNum, Entity::getStakedAccountId)
                 .returns(-1L, Entity::getStakedNodeId)
                 .returns(


### PR DESCRIPTION
**Description**:
This PR checks for the support of `-1` for maxAutomaticTokenAssociations to support frictionless airdrops in the future.

This PR modifies 
* Adds tests to verify `-1` value works for maxAutomaticTokenAssociations.

**Related issue(s)**:

Fixes #8273

**Notes for reviewer**:
I looks like there aren't any special operations done with maxAutomaticTokenAssociations, which would be affected because of a -1 value.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
