### PR TITLE
Fix NFT allowance acceptance test regression

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -691,6 +691,12 @@ public class TokenClient extends AbstractNetworkClient {
                 TokenKycStatus.KycNotApplicable,
                 TokenFreezeStatus.FreezeNotApplicable,
                 false),
+        ALLOWANCE_NON_FUNGIBLE(
+                "allowance_non_fungible",
+                TokenType.NON_FUNGIBLE_UNIQUE,
+                TokenKycStatus.KycNotApplicable,
+                TokenFreezeStatus.FreezeNotApplicable,
+                false),
         NFT(
                 "non_fungible",
                 TokenType.NON_FUNGIBLE_UNIQUE,

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -216,11 +216,13 @@ public class TokenFeature extends AbstractFeature {
             TokenClient.TokenNameEnum tokenName, AccountClient.AccountNameEnum spenderName) {
         verifyMirrorTransactionsResponse(mirrorClient, HttpStatus.OK.value());
 
-        var tokenId = tokenClient.getToken(tokenName).tokenId();
-        var spender = accountClient.getAccount(spenderName);
+        var owner = accountClient.getClient().getOperatorAccountId().toString();
+        var spender = accountClient.getAccount(spenderName).getAccountId().toString();
+        var token = tokenClient.getToken(tokenName).tokenId().toString();
 
-        // Once we change this API to not return approved_for_all=false this test will change to check for an empty list
-        verifyMirrorAPIApprovedNftAllowanceResponse(tokenId, spender, false, true);
+        var mirrorNftAllowanceResponse = mirrorClient.getAccountNftAllowanceByOwner(owner, token, spender);
+
+        assertThat(mirrorNftAllowanceResponse.getAllowances()).isEmpty();
     }
 
     @Then("the mirror node REST API should confirm the debit of {long} from {token} allowance of {long} for {account}")

--- a/hedera-mirror-test/src/test/resources/features/token/nftAllowance.feature
+++ b/hedera-mirror-test/src/test/resources/features/token/nftAllowance.feature
@@ -13,8 +13,6 @@ Feature: Account NFT Allowance Coverage Feature
     Then the mirror node REST API should confirm the NFT transfer and confirm the new owner is <recipient>
     When I delete the allowance on NFT <tokenName> for spender <spender>
     Then the mirror node REST API should confirm the approved allowance for NFT <tokenName> and <spender> is no longer available
-    When <recipient> transfers NFT <tokenName> to OPERATOR with approval=false
-    Then the mirror node REST API should confirm the NFT transfer and confirm the new owner is OPERATOR
     Examples:
-      | tokenName | spender | recipient |
-      | NFT       | BOB     | ALICE     |
+      | tokenName              | spender | recipient |
+      | ALLOWANCE_NON_FUNGIBLE | BOB     | ALICE     |


### PR DESCRIPTION
**Description**:
Fix regression by checking for empty response once allowance are deleted

This PR modifies 
* Nft allowances acceptance tests to reflect approved_for_all=true
* Create new NFT token class 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
