### PR TITLE
test: add abstract ControllerTest in hedera-mirror-node.web3

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -16,438 +16,367 @@
 
 package com.hedera.mirror.web3.controller;
 
+import static com.hedera.mirror.web3.exception.BlockNumberNotFoundException.UNKNOWN_BLOCK_NUMBER;
 import static com.hedera.mirror.web3.validation.HexValidator.MESSAGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.exception.BlockNumberNotFoundException;
 import com.hedera.mirror.web3.exception.BlockNumberOutOfRangeException;
 import com.hedera.mirror.web3.exception.EntityNotFoundException;
 import com.hedera.mirror.web3.exception.InvalidParametersException;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
-import com.hedera.mirror.web3.service.ContractCallService;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
 import com.hedera.mirror.web3.viewmodel.GenericErrorResponse;
-import io.github.bucket4j.Bucket;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import jakarta.annotation.Resource;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.core.StringContains;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = ContractController.class)
-class ContractControllerTest {
+class ContractControllerTest extends ControllerTest {
 
-    private static final String CALL_URI = "/api/v1/contracts/call";
-    private static final String ONE_BYTE_HEX = "80";
-    private static final long THROTTLE_GAS_LIMIT = 10_000_000L;
+    @Nested
+    @DisplayName(ContractsCall.CALL_URI)
+    class ContractsCall extends EndpointTest {
 
-    @Resource
-    private MockMvc mockMvc;
+        private static final String CALL_URI = "/api/v1/contracts/call";
+        private static final String ONE_BYTE_HEX = "80";
+        private static final long THROTTLE_GAS_LIMIT = 10_000_000L;
 
-    @Resource
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private ContractCallService service;
-
-    @MockBean(name = "rateLimitBucket")
-    private Bucket rateLimitBucket;
-
-    @MockBean(name = "gasLimitBucket")
-    private Bucket gasLimitBucket;
-
-    @Autowired
-    private MirrorNodeEvmProperties evmProperties;
-
-    @BeforeEach
-    void setUp() {
-        given(rateLimitBucket.tryConsume(1)).willReturn(true);
-        given(gasLimitBucket.tryConsume(THROTTLE_GAS_LIMIT)).willReturn(true);
-    }
-
-    @SneakyThrows
-    private String convert(Object object) {
-        return objectMapper.writeValueAsString(object);
-    }
-
-    @SneakyThrows
-    private ResultActions contractCall(ContractCallRequest request) {
-        return mockMvc.perform(post(CALL_URI)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(convert(request)));
-    }
-
-    @NullAndEmptySource
-    @ValueSource(strings = {"0x00000000000000000000000000000000000007e7"})
-    @ParameterizedTest
-    void estimateGas(String to) throws Exception {
-        final var request = request();
-        request.setEstimate(true);
-        request.setValue(0);
-        request.setTo(to);
-        contractCall(request).andExpect(status().isOk());
-    }
-
-    @ValueSource(longs = {2000, -2000, 16_000_000L, 0})
-    @ParameterizedTest
-    void estimateGasWithInvalidGasParameter(long gas) throws Exception {
-        final var errorString = gas < 21000L
-                ? numberErrorString("gas", "greater", 21000L)
-                : numberErrorString("gas", "less", 15_000_000L);
-        given(gasLimitBucket.tryConsume(gas)).willReturn(true);
-        final var request = request();
-        request.setEstimate(true);
-        request.setGas(gas);
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(convert(new GenericErrorResponse(errorString))));
-    }
-
-    @Test
-    void exceedingRateLimit() throws Exception {
-        for (var i = 0; i < 3; i++) {
-            contractCall(request()).andExpect(status().isOk());
+        @Override
+        protected HttpMethod getMethod() {
+            return HttpMethod.POST;
         }
 
-        given(rateLimitBucket.tryConsume(1)).willReturn(false);
-        contractCall(request()).andExpect(status().isTooManyRequests());
-    }
+        @Override
+        protected String getUrl() {
+            return CALL_URI;
+        }
 
-    @Test
-    void exceedingGasLimit() throws Exception {
-        given(gasLimitBucket.tryConsume(THROTTLE_GAS_LIMIT)).willReturn(false);
-        contractCall(request()).andExpect(status().isTooManyRequests());
-    }
+        @Override
+        protected MockHttpServletRequestBuilder customizeRequest(MockHttpServletRequestBuilder request) {
+            return request.content(convertToJson(request()));
+        }
 
-    @Test
-    void restoreGasInThrottleBucketOnValidationFail() throws Exception {
-        var request = request();
-        request.setData("With invalid symbol!");
-        contractCall(request).andExpect(status().isBadRequest());
-        verify(gasLimitBucket).tryConsume(request.getGas());
-        verify(gasLimitBucket).addTokens(request.getGas());
-    }
+        @SneakyThrows
+        private ResultActions contractCall(Object requestBody) {
+            return mockMvc.perform(buildRequest(requestBody));
+        }
 
-    @ValueSource(
-            strings = {
-                " ",
-                "0x",
-                "0xghijklmno",
-                "0x00000000000000000000000000000000000004e",
-                "0x00000000000000000000000000000000000004e2a",
-                "0x000000000000000000000000000000Z0000007e7",
-                "00000000001239847e"
-            })
-    @ParameterizedTest
-    void callInvalidTo(String to) throws Exception {
-        final var request = request();
-        request.setValue(0);
-        request.setTo(to);
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(new StringContains("to field")));
-    }
+        @NullAndEmptySource
+        @ValueSource(strings = {"0x00000000000000000000000000000000000007e7"})
+        @ParameterizedTest
+        void estimateGas(String to) throws Exception {
+            final var request = request();
+            request.setEstimate(true);
+            request.setValue(0);
+            request.setTo(to);
+            contractCall(request).andExpect(status().isOk());
+        }
 
-    @Test
-    void callInvalidToDueToTransfer() throws Exception {
-        final var request = request();
-        request.setTo(null);
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(new StringContains("to field")));
-    }
+        @ValueSource(longs = {2000, -2000, 16_000_000L, 0})
+        @ParameterizedTest
+        void estimateGasWithInvalidGasParameter(long gas) throws Exception {
+            final var errorString = gas < 21000L
+                    ? numberErrorString("gas", "greater", 21000L)
+                    : numberErrorString("gas", "less", 15_000_000L);
+            given(gasLimitBucket.tryConsume(gas)).willReturn(true);
+            final var request = request();
+            request.setEstimate(true);
+            request.setGas(gas);
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(errorString)));
+        }
 
-    @Test
-    void callMissingTo() throws Exception {
-        final var exceptionMessage = "No such contract or token";
-        final var request = request();
+        @Test
+        void restoreGasInThrottleBucketOnValidationFail() throws Exception {
+            var request = request();
+            request.setData("With invalid symbol!");
+            contractCall(request).andExpect(status().isBadRequest());
+            verify(gasLimitBucket).tryConsume(request.getGas());
+            verify(gasLimitBucket).addTokens(request.getGas());
+        }
 
-        given(service.processCall(any())).willThrow(new EntityNotFoundException(exceptionMessage));
+        @ValueSource(
+                strings = {
+                        " ",
+                        "0x",
+                        "0xghijklmno",
+                        "0x00000000000000000000000000000000000004e",
+                        "0x00000000000000000000000000000000000004e2a",
+                        "0x000000000000000000000000000000Z0000007e7",
+                        "00000000001239847e"
+                })
+        @ParameterizedTest
+        void callInvalidTo(String to) throws Exception {
+            final var request = request();
+            request.setValue(0);
+            request.setTo(to);
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(new StringContains("to field")));
+        }
 
-        contractCall(request)
-                .andExpect(status().isNotFound())
-                .andExpect(content().string(convert(new GenericErrorResponse(exceptionMessage))));
-    }
+        @Test
+        void callInvalidToDueToTransfer() throws Exception {
+            final var request = request();
+            request.setTo(null);
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(new StringContains("to field")));
+        }
 
-    @EmptySource
-    @ValueSource(
-            strings = {
-                " ",
-                "0x",
-                "0xghijklmno",
-                "0x00000000000000000000000000000000000004e",
-                "0x00000000000000000000000000000000000004e2a",
-                "0x000000000000000000000000000000Z0000007e7",
-                "00000000001239847e"
-            })
-    @ParameterizedTest
-    void callInvalidFrom(String from) throws Exception {
-        final var errorString = "from field ".concat(MESSAGE);
-        final var request = request();
-        request.setFrom(from);
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(convert(new GenericErrorResponse(errorString))));
-    }
+        @Test
+        void callMissingTo() throws Exception {
+            final var exceptionMessage = "No such contract or token";
+            final var request = request();
 
-    @Test
-    void callInvalidValue() throws Exception {
-        final var error = "value field must be greater than or equal to 0";
-        final var request = request();
-        request.setValue(-1L);
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(convert(new GenericErrorResponse(error))));
-    }
+            given(contractCallService.processCall(any())).willThrow(new EntityNotFoundException(exceptionMessage));
 
-    @Test
-    void exceedingDataCallSizeOnEstimate() throws Exception {
-        var error = "data field of size 262148 contains invalid hexadecimal characters or exceeds 262144 characters";
-        final var request = request();
-        final var dataAsHex =
-                ONE_BYTE_HEX.repeat((int) evmProperties.getMaxDataSize().toBytes() + 1);
-        request.setData("0x" + dataAsHex);
-        request.setEstimate(true);
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(convert(new GenericErrorResponse(error))));
-    }
+            contractCall(request)
+                    .andExpect(status().isNotFound())
+                    .andExpect(responseBody(new GenericErrorResponse(exceptionMessage)));
+        }
 
-    @Test
-    void exceedingDataCreateSizeOnEstimate() throws Exception {
-        var error = "data field of size 262148 contains invalid hexadecimal characters or exceeds 262144 characters";
-        final var request = request();
-        final var dataAsHex =
-                ONE_BYTE_HEX.repeat((int) evmProperties.getMaxDataSize().toBytes() + 1);
-        request.setTo(null);
-        request.setValue(0);
-        request.setData("0x" + dataAsHex);
-        request.setEstimate(true);
+        @EmptySource
+        @ValueSource(
+                strings = {
+                        " ",
+                        "0x",
+                        "0xghijklmno",
+                        "0x00000000000000000000000000000000000004e",
+                        "0x00000000000000000000000000000000000004e2a",
+                        "0x000000000000000000000000000000Z0000007e7",
+                        "00000000001239847e"
+                })
+        @ParameterizedTest
+        void callInvalidFrom(String from) throws Exception {
+            final var errorString = "from field ".concat(MESSAGE);
+            final var request = request();
+            request.setFrom(from);
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(errorString)));
+        }
 
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(convert(new GenericErrorResponse(error))));
-    }
+        @Test
+        void callInvalidValue() throws Exception {
+            final var error = "value field must be greater than or equal to 0";
+            final var request = request();
+            request.setValue(-1L);
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(error)));
+        }
 
-    @Test
-    void callWithMalformedJsonBody() throws Exception {
-        var request = "{from: 0x00000000000000000000000000000000000004e2\"";
-        mockMvc.perform(post(CALL_URI)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(request))
-                .andExpect(status().isBadRequest())
-                .andExpect(content()
-                        .string(convert(new GenericErrorResponse(
-                                "Unable to parse JSON",
-                                "JSON parse error: Unexpected character ('f' (code 102)): was expecting double-quote to start field name",
-                                StringUtils.EMPTY))));
-    }
+        @Test
+        void exceedingDataCallSizeOnEstimate() throws Exception {
+            var error = "data field of size 262148 contains invalid hexadecimal characters or exceeds 262144 characters";
+            final var request = request();
+            final var dataAsHex =
+                    ONE_BYTE_HEX.repeat((int) evmProperties.getMaxDataSize().toBytes() + 1);
+            request.setData("0x" + dataAsHex);
+            request.setEstimate(true);
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(error)));
+        }
 
-    @Test
-    void callWithUnsupportedMediaTypeBody() throws Exception {
-        final var request = request();
-        mockMvc.perform(post(CALL_URI)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.TEXT_PLAIN)
-                        .content(convert(request)))
-                .andExpect(status().isUnsupportedMediaType())
-                .andExpect(content()
-                        .string(convert(new GenericErrorResponse(
-                                "Unsupported Media Type",
-                                "Content-Type 'text/plain;charset=UTF-8' is not supported",
-                                StringUtils.EMPTY))));
-    }
+        @Test
+        void exceedingDataCreateSizeOnEstimate() throws Exception {
+            var error = "data field of size 262148 contains invalid hexadecimal characters or exceeds 262144 characters";
+            final var request = request();
+            final var dataAsHex =
+                    ONE_BYTE_HEX.repeat((int) evmProperties.getMaxDataSize().toBytes() + 1);
+            request.setTo(null);
+            request.setValue(0);
+            request.setData("0x" + dataAsHex);
+            request.setEstimate(true);
 
-    @Test
-    void callRevertMethodAndExpectDetailMessage() throws Exception {
-        final var detailedErrorMessage = "Custom revert message";
-        final var hexDataErrorMessage =
-                "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000015437573746f6d20726576657274206d6573736167650000000000000000000000";
-        final var request = request();
-        request.setData("0xa26388bb");
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(error)));
+        }
 
-        given(service.processCall(any()))
-                .willThrow(new MirrorEvmTransactionException(
-                        CONTRACT_REVERT_EXECUTED, detailedErrorMessage, hexDataErrorMessage));
+        @Test
+        void callWithMalformedJsonBody() throws Exception {
+            var request = "{from: 0x00000000000000000000000000000000000004e2\"";
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(
+                                    "Unable to parse JSON",
+                                    "JSON parse error: Unexpected character ('f' (code 102)): was expecting double-quote to start field name",
+                                    StringUtils.EMPTY)));
+        }
 
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content()
-                        .string(convert(new GenericErrorResponse(
-                                CONTRACT_REVERT_EXECUTED.name(), detailedErrorMessage, hexDataErrorMessage))));
-    }
+        @Test
+        void callRevertMethodAndExpectDetailMessage() throws Exception {
+            final var detailedErrorMessage = "Custom revert message";
+            final var hexDataErrorMessage =
+                    "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000015437573746f6d20726576657274206d6573736167650000000000000000000000";
+            final var request = request();
+            request.setData("0xa26388bb");
 
-    @Test
-    void callWithInvalidParameter() throws Exception {
-        final var error = "No such contract or token";
-        final var request = request();
+            given(contractCallService.processCall(any()))
+                    .willThrow(new MirrorEvmTransactionException(
+                            CONTRACT_REVERT_EXECUTED, detailedErrorMessage, hexDataErrorMessage));
 
-        given(service.processCall(any())).willThrow(new InvalidParametersException(error));
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(convert(new GenericErrorResponse(error))));
-    }
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(
+                                    CONTRACT_REVERT_EXECUTED.name(), detailedErrorMessage, hexDataErrorMessage)));
+        }
 
-    @Test
-    void callInvalidGasPrice() throws Exception {
-        final var errorString = numberErrorString("gasPrice", "greater", 0);
-        final var request = request();
-        request.setGasPrice(-1L);
+        @Test
+        void callWithInvalidParameter() throws Exception {
+            final var error = "No such contract or token";
+            final var request = request();
 
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(convert(new GenericErrorResponse(errorString))));
-    }
+            given(contractCallService.processCall(any())).willThrow(new InvalidParametersException(error));
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(error)));
+        }
 
-    @Test
-    void transferWithoutSender() throws Exception {
-        final var errorString = "from field must not be empty";
-        final var request = request();
-        request.setFrom(null);
+        @Test
+        void callInvalidGasPrice() throws Exception {
+            final var errorString = numberErrorString("gasPrice", "greater", 0);
+            final var request = request();
+            request.setGasPrice(-1L);
 
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(convert(new GenericErrorResponse(errorString))));
-    }
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(errorString)));
+        }
 
-    @NullAndEmptySource
-    @ParameterizedTest
-    @ValueSource(strings = {"earliest", "latest", "0", "0x1a", "pending", "safe", "finalized"})
-    void callValidBlockType(String value) throws Exception {
-        final var request = request();
-        request.setBlock(BlockType.of(value));
+        @Test
+        void transferWithoutSender() throws Exception {
+            final var errorString = "from field must not be empty";
+            final var request = request();
+            request.setFrom(null);
 
-        contractCall(request).andExpect(status().isOk());
-    }
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(errorString)));
+        }
 
-    @Test
-    void callNegativeBlock() throws Exception {
-        mockMvc.perform(post(CALL_URI)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"block\": \"-1\"}"))
-                .andExpect(status().isBadRequest());
-    }
+        @NullAndEmptySource
+        @ParameterizedTest
+        @ValueSource(strings = {"earliest", "latest", "0", "0x1a", "pending", "safe", "finalized"})
+        void callValidBlockType(String value) throws Exception {
+            final var request = request();
+            request.setBlock(BlockType.of(value));
 
-    @Test
-    void callWithBlockNumberOutOfRangeExceptionTest() throws Exception {
-        final var request = request();
-        given(service.processCall(any())).willThrow(new BlockNumberOutOfRangeException("Unknown block number"));
+            contractCall(request).andExpect(status().isOk());
+        }
 
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(convert(new GenericErrorResponse("Unknown block number"))));
-    }
+        @Test
+        void callNegativeBlock() throws Exception {
+            final var request = request();
+            request.setBlock(new BlockType("-1", -1));
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(
+                            "Unable to parse JSON",
+                            "JSON parse error: Invalid block value: %d".formatted(request.getBlock().number()),
+                            StringUtils.EMPTY)));
+        }
 
-    @Test
-    void callWithBlockNumberNotFoundExceptionTest() throws Exception {
-        final var request = request();
-        given(service.processCall(any())).willThrow(new BlockNumberNotFoundException());
+        @Test
+        void callWithBlockNumberOutOfRangeExceptionTest() throws Exception {
+            final var request = request();
 
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(convert(new GenericErrorResponse("Unknown block number"))));
-    }
+            given(contractCallService.processCall(any()))
+                    .willThrow(new BlockNumberOutOfRangeException(UNKNOWN_BLOCK_NUMBER));
 
-    @Test
-    void callSuccess() throws Exception {
-        final var request = request();
-        request.setData("0x1079023a0000000000000000000000000000000000000000000000000000000000000156");
-        request.setValue(0);
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(UNKNOWN_BLOCK_NUMBER)));
+        }
 
-        contractCall(request).andExpect(status().isOk());
-    }
+        @Test
+        void callWithBlockNumberNotFoundExceptionTest() throws Exception {
+            final var request = request();
 
-    @NullAndEmptySource
-    @ParameterizedTest
-    void callSuccessWithNullAndEmptyData(String data) throws Exception {
-        final var request = request();
-        request.setData(data);
-        request.setValue(0);
+            given(contractCallService.processCall(any())).willThrow(new BlockNumberNotFoundException());
 
-        contractCall(request).andExpect(status().isOk());
-    }
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse("Unknown block number")));
+        }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"1", "1aa"})
-    void callBadRequestWithInvalidHexData(String data) throws Exception {
-        final var request = request();
-        request.setData(data);
-        request.setValue(0);
+        @Test
+        void callSuccess() throws Exception {
+            final var request = request();
+            request.setData("0x1079023a0000000000000000000000000000000000000000000000000000000000000156");
+            request.setValue(0);
 
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(new StringContains("contains invalid odd length characters")));
-    }
+            contractCall(request).andExpect(status().isOk());
+        }
 
-    @Test
-    void transferSuccess() throws Exception {
-        final var request = request();
-        request.setData(null);
+        @NullAndEmptySource
+        @ParameterizedTest
+        void callSuccessWithNullAndEmptyData(String data) throws Exception {
+            final var request = request();
+            request.setData(data);
+            request.setValue(0);
 
-        contractCall(request).andExpect(status().isOk());
-    }
+            contractCall(request).andExpect(status().isOk());
+        }
 
-    /*
-     * https://stackoverflow.com/questions/62723224/webtestclient-cors-with-spring-boot-and-webflux
-     * The Spring WebTestClient CORS testing requires that the URI contain any hostname and port.
-     */
-    @Test
-    void callSuccessCors() throws Exception {
-        mockMvc.perform(options(CALL_URI)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header("Origin", "http://example.com")
-                        .header("Access-Control-Request-Method", "POST"))
-                .andExpect(header().string("Access-Control-Allow-Origin", "*"))
-                .andExpect(header().string("Access-Control-Allow-Methods", "POST"));
-    }
+        @ParameterizedTest
+        @ValueSource(strings = {"1", "1aa"})
+        void callBadRequestWithInvalidHexData(String data) throws Exception {
+            final var request = request();
+            request.setData(data);
+            request.setValue(0);
 
-    private ContractCallRequest request() {
-        final var request = new ContractCallRequest();
-        request.setBlock(BlockType.LATEST);
-        request.setData("0x1079023a");
-        request.setFrom("0x00000000000000000000000000000000000004e2");
-        request.setGas(THROTTLE_GAS_LIMIT);
-        request.setGasPrice(78282329L);
-        request.setTo("0x00000000000000000000000000000000000004e4");
-        request.setValue(23);
-        return request;
-    }
+            contractCall(request)
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string(new StringContains("contains invalid odd length characters")));
+        }
 
-    private String numberErrorString(String field, String direction, long num) {
-        return String.format("%s field must be %s than or equal to %d", field, direction, num);
+        @Test
+        void transferSuccess() throws Exception {
+            final var request = request();
+            request.setData(null);
+
+            contractCall(request).andExpect(status().isOk());
+        }
+
+        private ContractCallRequest request() {
+            final var request = new ContractCallRequest();
+            request.setBlock(BlockType.LATEST);
+            request.setData("0x1079023a");
+            request.setFrom("0x00000000000000000000000000000000000004e2");
+            request.setGas(THROTTLE_GAS_LIMIT);
+            request.setGasPrice(78282329L);
+            request.setTo("0x00000000000000000000000000000000000004e4");
+            request.setValue(23);
+            return request;
+        }
     }
 
     @TestConfiguration

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ControllerTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.controller;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.service.ContractCallService;
+import com.hedera.mirror.web3.viewmodel.GenericErrorResponse;
+import io.github.bucket4j.Bucket;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.annotation.Resource;
+import jakarta.persistence.EntityManager;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.lang.Nullable;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.support.TransactionOperations;
+
+@ContextConfiguration(classes = { ControllerTest.Config.class })
+@ExtendWith(SpringExtension.class)
+public abstract class ControllerTest {
+
+    @Resource
+    protected MockMvc mockMvc;
+
+    @Resource
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected MirrorNodeEvmProperties evmProperties;
+
+    @MockBean
+    protected ContractCallService contractCallService;
+
+    @MockBean(name = "rateLimitBucket")
+    protected Bucket rateLimitBucket;
+
+    @MockBean(name = "gasLimitBucket")
+    protected Bucket gasLimitBucket;
+
+    @BeforeEach
+    final void mockBuckets() {
+        when(rateLimitBucket.tryConsume(anyLong())).thenReturn(true);
+        when(gasLimitBucket.tryConsume(anyLong())).thenReturn(true);
+    }
+
+    protected abstract class EndpointTest {
+
+        protected abstract HttpMethod getMethod();
+
+        protected abstract String getUrl();
+
+        protected Object[] getParameters() {
+            return new Object[0];
+        }
+
+        /*
+         * This method allows subclasses to do any setup work like entity persistence and provide a default URI and
+         * parameters for the parent class to run its common set of tests.
+         */
+        protected MockHttpServletRequestBuilder customizeRequest(MockHttpServletRequestBuilder requestBuilder) {
+            return requestBuilder;
+        }
+
+        protected MockHttpServletRequestBuilder buildRequest() {
+            return buildRequest(null);
+        }
+
+        protected MockHttpServletRequestBuilder buildRequest(@Nullable Object requestBody) {
+            final MockHttpServletRequestBuilder requestBuilder = customizeRequest(
+                    MockMvcRequestBuilders
+                            .request(getMethod(), getUrl(), getParameters())
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            if (requestBody != null) {
+                final String json = requestBody instanceof String ? (String) requestBody : convertToJson(requestBody);
+                return requestBuilder.content(json);
+            } else {
+                return requestBuilder;
+            }
+        }
+
+        protected ResultMatcher responseBody(final Object expectedBody) {
+            return content().string(convertToJson(expectedBody));
+        }
+
+        protected String numberErrorString(String field, String direction, long num) {
+            return String.format("%s field must be %s than or equal to %d", field, direction, num);
+        }
+
+        @SneakyThrows
+        protected String convertToJson(Object object) {
+            return objectMapper.writeValueAsString(object);
+        }
+
+        /*
+         * https://stackoverflow.com/questions/62723224/webtestclient-cors-with-spring-boot-and-webflux
+         * The Spring WebTestClient CORS testing requires that the URI contain any hostname and port.
+         */
+        @Test
+        void cors() throws Exception {
+            mockMvc.perform(options(getUrl(), getParameters())
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header("Origin", "https://example.com")
+                            .header("Access-Control-Request-Method", getMethod().name()))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string("Access-Control-Allow-Origin", "*"))
+                    .andExpect(header().string("Access-Control-Allow-Methods", getMethod().name()));
+        }
+
+        @Test
+        void unsupportedMediaType() throws Exception {
+            if (getMethod() == HttpMethod.GET) {
+                return;
+            }
+            mockMvc.perform(buildRequest()
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.TEXT_PLAIN)
+                            .content("text"))
+                    .andExpect(status().isUnsupportedMediaType())
+                    .andExpect(content()
+                            .string(convertToJson(new GenericErrorResponse(
+                                    "Unsupported Media Type",
+                                    "Content-Type 'text/plain;charset=UTF-8' is not supported",
+                                    StringUtils.EMPTY
+                            ))));
+        }
+
+        @Test
+        void exceedingRateLimit() throws Exception {
+            for (var i = 0; i < 3; i++) {
+                mockMvc.perform(buildRequest()).andExpect(status().isOk());
+            }
+            when(rateLimitBucket.tryConsume(1)).thenReturn(false);
+            mockMvc.perform(buildRequest()).andExpect(status().isTooManyRequests());
+        }
+
+        @Test
+        void exceedingGasLimit() throws Exception {
+            for (var i = 0; i < 3; i++) {
+                mockMvc.perform(buildRequest()).andExpect(status().isOk());
+            }
+            when(gasLimitBucket.tryConsume(anyLong())).thenReturn(false);
+            mockMvc.perform(buildRequest()).andExpect(status().isTooManyRequests());
+        }
+    }
+
+    @TestConfiguration
+    public static class Config {
+
+        @Bean
+        MirrorNodeEvmProperties evmProperties() {
+            return new MirrorNodeEvmProperties();
+        }
+
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
+        @Bean
+        EntityManager entityManager() {
+            return mock(EntityManager.class);
+        }
+
+        @Bean
+        TransactionOperations transactionOperations() {
+            return mock(TransactionOperations.class);
+        }
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ControllerTest.java
@@ -167,6 +167,20 @@ public abstract class ControllerTest {
         }
 
         @Test
+        void malformedJsonBody() throws Exception {
+            if (getMethod() == HttpMethod.GET) {
+                return;
+            }
+            var requestJson = "{from: 0x00000000000000000000000000000000000004e2\"";
+            mockMvc.perform(buildRequest(requestJson))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(responseBody(new GenericErrorResponse(
+                            "Unable to parse JSON",
+                            "JSON parse error: Unexpected character ('f' (code 102)): was expecting double-quote to start field name",
+                            StringUtils.EMPTY)));
+        }
+
+        @Test
         void exceedingRateLimit() throws Exception {
             for (var i = 0; i < 3; i++) {
                 mockMvc.perform(buildRequest()).andExpect(status().isOk());

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/OpcodesControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/OpcodesControllerTest.java
@@ -206,7 +206,7 @@ class OpcodesControllerTest extends ControllerTest {
                     tracerOptionsCaptor.capture()
             )).thenCallRealMethod();
 
-            mockMvc.perform(buildRequest())
+            performRequest()
                     .andExpect(status().isNotImplemented())
                     .andExpect(responseBody(new GenericErrorResponse("Not implemented")));
         }
@@ -228,7 +228,7 @@ class OpcodesControllerTest extends ControllerTest {
                     tracerOptionsCaptor.capture()
             )).thenThrow(new MirrorEvmTransactionException(CONTRACT_REVERT_EXECUTED, detailedErrorMessage, hexDataErrorMessage));
 
-            mockMvc.perform(buildRequest())
+            performRequest()
                     .andExpect(status().isBadRequest())
                     .andExpect(responseBody(new GenericErrorResponse(
                             CONTRACT_REVERT_EXECUTED.name(), detailedErrorMessage, hexDataErrorMessage)));
@@ -254,7 +254,7 @@ class OpcodesControllerTest extends ControllerTest {
 
             for (final var options : tracerOptions) {
                 opcodeTracerOptions = options;
-                mockMvc.perform(buildRequest())
+                performRequest()
                         .andExpect(status().isOk())
                         .andExpect(responseBody(Builder.opcodesResponse(opcodesResultCaptor.get())));
 
@@ -275,7 +275,7 @@ class OpcodesControllerTest extends ControllerTest {
 
             when(recordFileRepository.findByTimestamp(anyLong())).thenReturn(Optional.empty());
 
-            mockMvc.perform(buildRequest())
+            performRequest()
                     .andExpect(status().isNotFound())
                     .andExpect(responseBody(new GenericErrorResponse("Record file with transaction not found")));
         }
@@ -292,7 +292,7 @@ class OpcodesControllerTest extends ControllerTest {
                     any(EntityId.class), anyLong(), anyLong()
             )).thenReturn(Optional.empty());
 
-            mockMvc.perform(buildRequest())
+            performRequest()
                     .andExpect(status().isNotFound())
                     .andExpect(responseBody(new GenericErrorResponse("Transaction not found")));
         }
@@ -317,7 +317,7 @@ class OpcodesControllerTest extends ControllerTest {
 
             this.transactionIdOrHash = transactionIdOrHash;
 
-            mockMvc.perform(buildRequest())
+            performRequest()
                     .andExpect(status().isBadRequest())
                     .andExpect(content().string(new StringContains(expectedMessage)));
         }


### PR DESCRIPTION
**Description**:
This PR adds an abstract `ControllerTest` class, which contains:
- common bean configurations
- common boilerplate code for the controller tests
- common tests for each controller:
  - `cors()`
  - `unsupportedMediaType()`
  - `malformedJsonBody()`
  - `exceedingRateLimit()`
  - `exceedingGasLimit()`
- common helper methods which are used in the controller tests:
  - `responseBody()`
  - `convertToJson()`
  - `numberErrorString()`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
