### PR TITLE
Adding network tests to the rest monitor.

### DIFF
--- a/hedera-mirror-rest/monitoring/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/config/default.serverlist.json
@@ -35,7 +35,8 @@
   },
   "network": {
     "enabled": true,
-    "intervalMultiplier": 1
+    "intervalMultiplier": 1,
+    "limit": 2
   },
   "stateproof": {
     "enabled": true,


### PR DESCRIPTION
**Description**:
This PR adds network monitor endpoints to the rest monitor.

This PR modifies ...
* Adds `/network/fees` and `/network/exchangerate` and `/network/nodes` and `/network/supply`

**Related issue(s)**:

Part of #4050

**Notes for reviewer**:
There are more endpoints to come as part of this ticket but separate PRs.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
