### PR TITLE
Add @web3 to equivalence.feature.

### DIFF
--- a/hedera-mirror-test/src/test/resources/features/contract/equivalence.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/equivalence.feature
@@ -1,4 +1,4 @@
-@contractbase @fullsuite @equivalence @acceptance
+@contractbase @fullsuite @web3 @equivalence @acceptance
 Feature: in-equivalence tests
 
   Scenario Outline: Validate in-equivalence system accounts for balance, extcodesize, extcodecopy, extcodehash


### PR DESCRIPTION
**Description**:

In the performance environment acceptance tests are run with "... and not @web3" and `equivalence.feature` needs to be part of that exclusion group.

- Add @web3 to `contract/equivalence.feature`.

**Related issue(s)**:

Fixes #8415

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
