### PR TITLE
Add system file fallback to Web3

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoader.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoader.java
@@ -29,7 +29,6 @@ import com.hederahashgraph.api.proto.java.CurrentAndNextFeeSchedule;
 import com.hederahashgraph.api.proto.java.ExchangeRateSet;
 import jakarta.inject.Named;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -50,16 +49,17 @@ import org.springframework.retry.support.RetryTemplate;
 public class RatesAndFeesLoader {
     private static final EntityId EXCHANGE_RATE_ENTITY_ID = EntityId.of(0L, 0L, 112L);
     private static final EntityId FEE_SCHEDULE_ENTITY_ID = EntityId.of(0L, 0L, 111L);
+    private static final String RETRY_NANOS = "nanos";
     private final RetryListener retryListener = new RetryListener() {
         @Override
         public <T, E extends Throwable> void onError(
                 RetryContext context, RetryCallback<T, E> callback, Throwable throwable) {
             var fileId = (long) context.getAttribute("fileId");
-            var nanos = (long) context.getAttribute("nanos");
+            var nanosLog = (long) context.getAttribute("nanosLog");
             log.warn(
                     "Failed to load file data for fileId {} at {}, failing back to previous file. Retry attempt {}. Exception: ",
                     fileId,
-                    nanos,
+                    nanosLog,
                     context.getRetryCount(),
                     throwable);
         }
@@ -81,7 +81,7 @@ public class RatesAndFeesLoader {
     @Cacheable(cacheNames = CACHE_NAME_EXCHANGE_RATE, key = "'now'", unless = "#result == null")
     public ExchangeRateSet loadExchangeRates(final long nanoSeconds) {
         try {
-            return getFileData(EXCHANGE_RATE_ENTITY_ID.getId(), Arrays.asList(nanoSeconds), ExchangeRateSet::parseFrom);
+            return getFileData(EXCHANGE_RATE_ENTITY_ID.getId(), nanoSeconds, ExchangeRateSet::parseFrom);
         } catch (InvalidProtocolBufferException e) {
             log.warn("Corrupt rate file at {}, may require remediation!", EXCHANGE_RATE_ENTITY_ID);
             throw new IllegalStateException(String.format("Rates %s are corrupt!", EXCHANGE_RATE_ENTITY_ID));
@@ -97,26 +97,26 @@ public class RatesAndFeesLoader {
     @Cacheable(cacheNames = CACHE_NAME_FEE_SCHEDULE, key = "'now'", unless = "#result == null")
     public CurrentAndNextFeeSchedule loadFeeSchedules(final long nanoSeconds) {
         try {
-            return getFileData(
-                    FEE_SCHEDULE_ENTITY_ID.getId(), Arrays.asList(nanoSeconds), CurrentAndNextFeeSchedule::parseFrom);
+            return getFileData(FEE_SCHEDULE_ENTITY_ID.getId(), nanoSeconds, CurrentAndNextFeeSchedule::parseFrom);
         } catch (InvalidProtocolBufferException e) {
             log.warn("Corrupt fee schedules file at {}, may require remediation!", FEE_SCHEDULE_ENTITY_ID, e);
             throw new IllegalStateException(String.format("Fee schedule %s is corrupt!", FEE_SCHEDULE_ENTITY_ID));
         }
     }
 
-    private <T> T getFileData(long fileId, final List<Long> nanoSeconds, FileDataParser<T> parser)
+    private <T> T getFileData(long fileId, final long nanoSeconds, FileDataParser<T> parser)
             throws InvalidProtocolBufferException {
         return retryTemplate.execute(retryContext -> {
-            long nanos = nanoSeconds.getFirst();
+            long nanos = retryContext.hasAttribute(RETRY_NANOS)
+                    ? (long) retryContext.getAttribute(RETRY_NANOS)
+                    : nanoSeconds;
+
             var fileDataList = fileDataRepository.getFileAtTimestamp(fileId, nanos);
 
-            // If unable to parse the file, decrement the timestamp and parse the previous file
-            // The decremented value will be used by the RetryTemplate upon the next try
-            nanoSeconds.set(0, fileDataList.getFirst().getConsensusTimestamp() - 1);
-            // Set the values for exception handling in the RetryListener
+            // Set the values used by the RetryListener
             retryContext.setAttribute("fileId", fileId);
-            retryContext.setAttribute("nanos", nanos);
+            retryContext.setAttribute("nanosLog", nanos);
+            retryContext.setAttribute(RETRY_NANOS, fileDataList.getFirst().getConsensusTimestamp() - 1);
 
             var fileDataBytes = getBytesFromFileData(fileDataList);
             return parser.parse(fileDataBytes);

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoader.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoader.java
@@ -22,14 +22,19 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_FEE_
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.file.FileData;
 import com.hedera.mirror.web3.repository.FileDataRepository;
 import com.hederahashgraph.api.proto.java.CurrentAndNextFeeSchedule;
 import com.hederahashgraph.api.proto.java.ExchangeRateSet;
 import jakarta.inject.Named;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Rates and fees loader, currently working only with current timestamp.
@@ -44,37 +49,77 @@ public class RatesAndFeesLoader {
     private final FileDataRepository fileDataRepository;
 
     /**
-     * Loads the exchange rates for a given time. Currently, works only with current timestamp.
+     * Loads the exchange rates for a given time.
      *
      * @param nanoSeconds timestamp
      * @return exchange rates set
      */
-    @Cacheable(cacheNames = CACHE_NAME_EXCHANGE_RATE, key = "'now'", unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME_EXCHANGE_RATE, unless = "#result == null")
     public ExchangeRateSet loadExchangeRates(final long nanoSeconds) {
-        final var ratesFile = fileDataRepository.getFileAtTimestamp(EXCHANGE_RATE_ENTITY_ID.getId(), nanoSeconds);
         try {
-            return ExchangeRateSet.parseFrom(ratesFile);
+            return getFileData(EXCHANGE_RATE_ENTITY_ID.getId(), nanoSeconds, ExchangeRateSet::parseFrom);
         } catch (InvalidProtocolBufferException e) {
-            log.warn("Corrupt rate file at {}, may require remediation!", EXCHANGE_RATE_ENTITY_ID, e);
+            log.warn("Corrupt rate file at {}, may require remediation!", EXCHANGE_RATE_ENTITY_ID);
             throw new IllegalStateException(String.format("Rates %s are corrupt!", EXCHANGE_RATE_ENTITY_ID));
         }
     }
 
     /**
-     * Load the fee schedules for a given time. Currently, works only with current timestamp.
+     * Load the fee schedules for a given time.
      *
      * @param nanoSeconds timestamp
      * @return current and next fee schedules
      */
-    @Cacheable(cacheNames = CACHE_NAME_FEE_SCHEDULE, key = "'now'", unless = "#result == null")
+    @Cacheable(cacheNames = CACHE_NAME_FEE_SCHEDULE, unless = "#result == null")
     public CurrentAndNextFeeSchedule loadFeeSchedules(final long nanoSeconds) {
-        final var feeScheduleFile = fileDataRepository.getFileAtTimestamp(FEE_SCHEDULE_ENTITY_ID.getId(), nanoSeconds);
-
         try {
-            return CurrentAndNextFeeSchedule.parseFrom(feeScheduleFile);
+            return getFileData(FEE_SCHEDULE_ENTITY_ID.getId(), nanoSeconds, CurrentAndNextFeeSchedule::parseFrom);
         } catch (InvalidProtocolBufferException e) {
             log.warn("Corrupt fee schedules file at {}, may require remediation!", FEE_SCHEDULE_ENTITY_ID, e);
             throw new IllegalStateException(String.format("Fee schedule %s is corrupt!", FEE_SCHEDULE_ENTITY_ID));
         }
+    }
+
+    private <T> T getFileData(long fileId, long nanoSeconds, FileDataParser<T> parser)
+            throws InvalidProtocolBufferException {
+        int retry = 1;
+        int maxRetries = 10;
+
+        // Fallback to an older version of the file if the current file cannot be parsed
+        while (true) {
+            var file = fileDataRepository.getFileAtTimestamp(fileId, nanoSeconds);
+            var fileDataBytes = getBytesFromFileData(file);
+            try {
+                return parser.parse(fileDataBytes.toByteArray());
+            } catch (InvalidProtocolBufferException e) {
+                if (retry >= maxRetries) {
+                    throw e;
+                }
+
+                retry++;
+                log.warn(
+                        "Failed to load file data for fileId {} at {}, failing back to previous file. Retry attempt {}",
+                        fileId,
+                        nanoSeconds,
+                        retry,
+                        e);
+                nanoSeconds = CollectionUtils.lastElement(file).getConsensusTimestamp() - 1;
+            }
+        }
+    }
+
+    private ByteArrayOutputStream getBytesFromFileData(List<FileData> files) {
+        try (var bos = new ByteArrayOutputStream()) {
+            for (var i = 0; i < files.size(); i++) {
+                bos.write(files.get(i).getFileData());
+            }
+            return bos;
+        } catch (IOException ex) {
+            throw new IllegalStateException("Error concatenating fileData entries", ex);
+        }
+    }
+
+    private interface FileDataParser<T> {
+        T parse(byte[] bytes) throws InvalidProtocolBufferException;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoader.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoader.java
@@ -34,7 +34,6 @@ import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.util.CollectionUtils;
 
 /**
  * Rates and fees loader, currently working only with current timestamp.
@@ -87,8 +86,8 @@ public class RatesAndFeesLoader {
 
         // Fallback to an older version of the file if the current file cannot be parsed
         while (true) {
-            var file = fileDataRepository.getFileAtTimestamp(fileId, nanoSeconds);
-            var fileDataBytes = getBytesFromFileData(file);
+            var fileDataList = fileDataRepository.getFileAtTimestamp(fileId, nanoSeconds);
+            var fileDataBytes = getBytesFromFileData(fileDataList);
             try {
                 return parser.parse(fileDataBytes.toByteArray());
             } catch (InvalidProtocolBufferException e) {
@@ -103,7 +102,7 @@ public class RatesAndFeesLoader {
                         nanoSeconds,
                         retry,
                         e);
-                nanoSeconds = CollectionUtils.lastElement(file).getConsensusTimestamp() - 1;
+                nanoSeconds = fileDataList.getFirst().getConsensusTimestamp() - 1;
             }
         }
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/FileDataRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/FileDataRepository.java
@@ -28,19 +28,20 @@ public interface FileDataRepository extends CrudRepository<FileData, Long> {
             value =
                     """
             select * from file_data
-            where file_data.entity_id = ?1
-              and file_data.consensus_timestamp >= (
-                select file_data.consensus_timestamp
+            where entity_id = ?1
+              and consensus_timestamp >= (
+                select consensus_timestamp
                 from file_data
-                where file_data.entity_id = ?1
-                  and file_data.consensus_timestamp <= ?2
-                  and (file_data.transaction_type = 17
-                         or (file_data.transaction_type = 19
+                where entity_id = ?1
+                  and consensus_timestamp <= ?2
+                  and (transaction_type = 17
+                         or (transaction_type = 19
                               and
-                             length(file_data.file_data) <> 0))
-              order by file_data.consensus_timestamp desc
+                             length(file_data) <> 0))
+              order by consensus_timestamp desc
               limit 1
-            ) and file_data.consensus_timestamp <= ?2""",
+            ) and consensus_timestamp <= ?2
+            order by consensus_timestamp""",
             nativeQuery = true)
     List<FileData> getFileAtTimestamp(long fileId, long timestamp);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/FileDataRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/FileDataRepository.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.web3.repository;
 
 import com.hedera.mirror.common.domain.file.FileData;
+import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
@@ -26,17 +27,20 @@ public interface FileDataRepository extends CrudRepository<FileData, Long> {
     @Query(
             value =
                     """
-                with latest_create as (
-                      select max(file_data.consensus_timestamp) as consensus_timestamp
-                      from file_data
-                      where file_data.entity_id = ?1 and file_data.transaction_type in (17, 19)
-                    )
-                    select
-                    string_agg(file_data.file_data, '' order by file_data.consensus_timestamp) as file_data
-                    from file_data
-                    join latest_create l on file_data.consensus_timestamp >= l.consensus_timestamp
-                    where file_data.entity_id = ?1 and file_data.transaction_type in (16, 17, 19)
-                      and ?2 >= l.consensus_timestamp""",
+            select * from file_data
+            where file_data.entity_id = ?1
+              and file_data.consensus_timestamp >= (
+                select file_data.consensus_timestamp
+                from file_data
+                where file_data.entity_id = ?1
+                  and file_data.consensus_timestamp <= ?2
+                  and (file_data.transaction_type = 17
+                         or (file_data.transaction_type = 19
+                              and
+                             length(file_data.file_data) <> 0))
+              order by file_data.consensus_timestamp desc
+              limit 1
+            ) and file_data.consensus_timestamp <= ?2""",
             nativeQuery = true)
-    byte[] getFileAtTimestamp(long fileId, long timestamp);
+    List<FileData> getFileAtTimestamp(long fileId, long timestamp);
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoaderIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoaderIntegrationTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.evm.pricing;
+
+import static com.hedera.mirror.common.domain.transaction.TransactionType.FILEAPPEND;
+import static com.hedera.mirror.common.domain.transaction.TransactionType.FILECREATE;
+import static com.hedera.mirror.common.domain.transaction.TransactionType.FILEUPDATE;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.web3.Web3IntegrationTest;
+import com.hederahashgraph.api.proto.java.CurrentAndNextFeeSchedule;
+import com.hederahashgraph.api.proto.java.ExchangeRate;
+import com.hederahashgraph.api.proto.java.ExchangeRateSet;
+import com.hederahashgraph.api.proto.java.FeeData;
+import com.hederahashgraph.api.proto.java.FeeSchedule;
+import com.hederahashgraph.api.proto.java.TimestampSeconds;
+import com.hederahashgraph.api.proto.java.TransactionFeeSchedule;
+import jakarta.annotation.Resource;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@RequiredArgsConstructor
+class RatesAndFeesLoaderIntegrationTest extends Web3IntegrationTest {
+
+    @Resource
+    private RatesAndFeesLoader subject;
+
+    private static final ExchangeRateSet exchangeRatesSet = ExchangeRateSet.newBuilder()
+            .setCurrentRate(ExchangeRate.newBuilder()
+                    .setCentEquiv(1)
+                    .setHbarEquiv(12)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(200L))
+                    .build())
+            .setNextRate(ExchangeRate.newBuilder()
+                    .setCentEquiv(2)
+                    .setHbarEquiv(31)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(2_234_567_890L))
+                    .build())
+            .build();
+
+    private static final ExchangeRateSet exchangeRatesSet2 = ExchangeRateSet.newBuilder()
+            .setCurrentRate(ExchangeRate.newBuilder()
+                    .setCentEquiv(3)
+                    .setHbarEquiv(14)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(300))
+                    .build())
+            .setNextRate(ExchangeRate.newBuilder()
+                    .setCentEquiv(4)
+                    .setHbarEquiv(33)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(2_234_567_893L))
+                    .build())
+            .build();
+
+    private static final CurrentAndNextFeeSchedule feeSchedules = CurrentAndNextFeeSchedule.newBuilder()
+            .setCurrentFeeSchedule(FeeSchedule.newBuilder()
+                    .setExpiryTime(TimestampSeconds.newBuilder().setSeconds(200L))
+                    .addTransactionFeeSchedule(TransactionFeeSchedule.newBuilder()
+                            .setHederaFunctionality(ContractCall)
+                            .addFees(FeeData.newBuilder().build())))
+            .setNextFeeSchedule(FeeSchedule.newBuilder()
+                    .setExpiryTime(TimestampSeconds.newBuilder().setSeconds(2_234_567_890L))
+                    .addTransactionFeeSchedule(TransactionFeeSchedule.newBuilder()
+                            .setHederaFunctionality(ContractCall)
+                            .addFees(FeeData.newBuilder().build())))
+            .build();
+
+    private static final CurrentAndNextFeeSchedule feeSchedules2 = CurrentAndNextFeeSchedule.newBuilder()
+            .setCurrentFeeSchedule(FeeSchedule.newBuilder()
+                    .setExpiryTime(TimestampSeconds.newBuilder().setSeconds(300L))
+                    .addTransactionFeeSchedule(TransactionFeeSchedule.newBuilder()
+                            .setHederaFunctionality(ContractCall)
+                            .addFees(FeeData.newBuilder().build())))
+            .setNextFeeSchedule(FeeSchedule.newBuilder()
+                    .setExpiryTime(TimestampSeconds.newBuilder().setSeconds(2_234_567_890L))
+                    .addTransactionFeeSchedule(TransactionFeeSchedule.newBuilder()
+                            .setHederaFunctionality(ContractCall)
+                            .addFees(FeeData.newBuilder().build())))
+            .build();
+
+    private static final EntityId FEE_SCHEDULE_ENTITY_ID = EntityId.of(0L, 0L, 111L);
+    private static final EntityId EXCHANGE_RATE_ENTITY_ID = EntityId.of(0L, 0L, 112L);
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void getFileForExchangeRateFallback(boolean corrupt) {
+        var exchangeSetBytes = exchangeRatesSet.toByteArray();
+        var exchangeSetPart1 = Arrays.copyOfRange(exchangeSetBytes, 0, 10);
+        var exchangeSetPart2 = Arrays.copyOfRange(exchangeSetBytes, 10, 20);
+        var exchangeSetPart3 = Arrays.copyOfRange(exchangeSetBytes, 20, exchangeSetBytes.length);
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILECREATE.getProtoId())
+                        .fileData(exchangeSetPart1)
+                        .entityId(EXCHANGE_RATE_ENTITY_ID)
+                        .consensusTimestamp(200L))
+                .persist();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEAPPEND.getProtoId())
+                        .fileData(exchangeSetPart2)
+                        .entityId(EXCHANGE_RATE_ENTITY_ID)
+                        .consensusTimestamp(205L))
+                .persist();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEAPPEND.getProtoId())
+                        .fileData(exchangeSetPart3)
+                        .entityId(EXCHANGE_RATE_ENTITY_ID)
+                        .consensusTimestamp(210L))
+                .persist();
+
+        var fileData = corrupt ? "corrupt".getBytes() : exchangeRatesSet2.toByteArray();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEUPDATE.getProtoId())
+                        .fileData(fileData)
+                        .entityId(EXCHANGE_RATE_ENTITY_ID)
+                        .consensusTimestamp(300L))
+                .persist();
+
+        var expected = corrupt ? exchangeRatesSet : exchangeRatesSet2;
+        var actual = subject.loadExchangeRates(350L);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void getFileForFeeScheduleFallback(boolean corrupt) {
+        var feeSchedulesBytes = feeSchedules.toByteArray();
+        var feeSchedulesPart1 = Arrays.copyOfRange(feeSchedulesBytes, 0, 10);
+        var feeSchedulesPart2 = Arrays.copyOfRange(feeSchedulesBytes, 10, 20);
+        var feeSchedulesPart3 = Arrays.copyOfRange(feeSchedulesBytes, 20, feeSchedulesBytes.length);
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEUPDATE.getProtoId())
+                        .fileData(feeSchedulesPart1)
+                        .entityId(FEE_SCHEDULE_ENTITY_ID)
+                        .consensusTimestamp(200L))
+                .persist();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEAPPEND.getProtoId())
+                        .fileData(feeSchedulesPart2)
+                        .entityId(FEE_SCHEDULE_ENTITY_ID)
+                        .consensusTimestamp(205L))
+                .persist();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEAPPEND.getProtoId())
+                        .fileData(feeSchedulesPart3)
+                        .entityId(FEE_SCHEDULE_ENTITY_ID)
+                        .consensusTimestamp(210L))
+                .persist();
+
+        var fileData = corrupt ? "corrupt".getBytes() : feeSchedules2.toByteArray();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEUPDATE.getProtoId())
+                        .fileData(fileData)
+                        .entityId(FEE_SCHEDULE_ENTITY_ID)
+                        .consensusTimestamp(300L))
+                .persist();
+
+        var expected = corrupt ? feeSchedules : feeSchedules2;
+        var actual = subject.loadFeeSchedules(350L);
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoaderIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoaderIntegrationTest.java
@@ -130,13 +130,32 @@ class RatesAndFeesLoaderIntegrationTest extends Web3IntegrationTest {
                         .consensusTimestamp(210L))
                 .persist();
 
-        var fileData = corrupt ? "corrupt".getBytes() : exchangeRatesSet2.toByteArray();
+        var exchangeSet2Bytes = exchangeRatesSet2.toByteArray();
+        var exchangeSet2Part1 = Arrays.copyOfRange(exchangeSet2Bytes, 0, 10);
+        var exchangeSet2Part2 = Arrays.copyOfRange(exchangeSet2Bytes, 10, 20);
+        var exchangeSet2Part3 = Arrays.copyOfRange(exchangeSet2Bytes, 20, exchangeSet2Bytes.length);
         domainBuilder
                 .fileData()
                 .customize(f -> f.transactionType(FILEUPDATE.getProtoId())
-                        .fileData(fileData)
+                        .fileData(exchangeSet2Part1)
                         .entityId(EXCHANGE_RATE_ENTITY_ID)
                         .consensusTimestamp(300L))
+                .persist();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEAPPEND.getProtoId())
+                        .fileData(exchangeSet2Part2)
+                        .entityId(EXCHANGE_RATE_ENTITY_ID)
+                        .consensusTimestamp(305L))
+                .persist();
+
+        var fileData = corrupt ? "corrupt".getBytes() : exchangeSet2Part3;
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEAPPEND.getProtoId())
+                        .fileData(fileData)
+                        .entityId(EXCHANGE_RATE_ENTITY_ID)
+                        .consensusTimestamp(310L))
                 .persist();
 
         var expected = corrupt ? exchangeRatesSet : exchangeRatesSet2;
@@ -173,13 +192,32 @@ class RatesAndFeesLoaderIntegrationTest extends Web3IntegrationTest {
                         .consensusTimestamp(210L))
                 .persist();
 
-        var fileData = corrupt ? "corrupt".getBytes() : feeSchedules2.toByteArray();
+        var feeSchedules2Bytes = feeSchedules2.toByteArray();
+        var feeSchedules2Part1 = Arrays.copyOfRange(feeSchedules2Bytes, 0, 10);
+        var feeSchedules2Part2 = Arrays.copyOfRange(feeSchedules2Bytes, 10, 20);
+        var feeSchedules2Part3 = Arrays.copyOfRange(feeSchedules2Bytes, 20, feeSchedules2Bytes.length);
         domainBuilder
                 .fileData()
                 .customize(f -> f.transactionType(FILEUPDATE.getProtoId())
-                        .fileData(fileData)
+                        .fileData(feeSchedules2Part1)
                         .entityId(FEE_SCHEDULE_ENTITY_ID)
                         .consensusTimestamp(300L))
+                .persist();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEAPPEND.getProtoId())
+                        .fileData(feeSchedules2Part2)
+                        .entityId(FEE_SCHEDULE_ENTITY_ID)
+                        .consensusTimestamp(305L))
+                .persist();
+
+        var fileData = corrupt ? "corrupt".getBytes() : feeSchedules2Part3;
+        domainBuilder
+                .fileData()
+                .customize(f -> f.transactionType(FILEAPPEND.getProtoId())
+                        .fileData(fileData)
+                        .entityId(FEE_SCHEDULE_ENTITY_ID)
+                        .consensusTimestamp(310L))
                 .persist();
 
         var expected = corrupt ? feeSchedules : feeSchedules2;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/FileDataRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/FileDataRepositoryTest.java
@@ -18,7 +18,6 @@ package com.hedera.mirror.web3.repository;
 
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -121,7 +120,7 @@ class FileDataRepositoryTest extends Web3IntegrationTest {
 
         var fileData3 = fileDataRepository.getFileAtTimestamp(
                 EXCHANGE_RATE_ENTITY_ID.getId(), fileData2.get(0).getConsensusTimestamp() - 1);
-        assertTrue(fileData3.isEmpty());
+        assert (fileData3).isEmpty();
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/FileDataRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/FileDataRepositoryTest.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.web3.repository;
 
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -120,7 +121,7 @@ class FileDataRepositoryTest extends Web3IntegrationTest {
 
         var fileData3 = fileDataRepository.getFileAtTimestamp(
                 EXCHANGE_RATE_ENTITY_ID.getId(), fileData2.get(0).getConsensusTimestamp() - 1);
-        assertThat(fileData3).asList().isEmpty();
+        assertTrue(fileData3.isEmpty());
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/FileDataRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/FileDataRepositoryTest.java
@@ -49,6 +49,33 @@ class FileDataRepositoryTest extends Web3IntegrationTest {
                     .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(2_234_567_890L))
                     .build())
             .build();
+
+    private static final ExchangeRateSet exchangeRatesSet200 = ExchangeRateSet.newBuilder()
+            .setCurrentRate(ExchangeRate.newBuilder()
+                    .setCentEquiv(2)
+                    .setHbarEquiv(13)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(200))
+                    .build())
+            .setNextRate(ExchangeRate.newBuilder()
+                    .setCentEquiv(3)
+                    .setHbarEquiv(32)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(2_234_567_893L))
+                    .build())
+            .build();
+
+    private static final ExchangeRateSet exchangeRatesSet300 = ExchangeRateSet.newBuilder()
+            .setCurrentRate(ExchangeRate.newBuilder()
+                    .setCentEquiv(3)
+                    .setHbarEquiv(14)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(300))
+                    .build())
+            .setNextRate(ExchangeRate.newBuilder()
+                    .setCentEquiv(4)
+                    .setHbarEquiv(33)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(2_234_567_893L))
+                    .build())
+            .build();
+
     private static final CurrentAndNextFeeSchedule feeSchedules = CurrentAndNextFeeSchedule.newBuilder()
             .setCurrentFeeSchedule(FeeSchedule.newBuilder()
                     .setExpiryTime(TimestampSeconds.newBuilder().setSeconds(expiry))
@@ -68,6 +95,35 @@ class FileDataRepositoryTest extends Web3IntegrationTest {
     private final FileDataRepository fileDataRepository;
 
     @Test
+    void getHistoricalFileForExchangeRates() throws InvalidProtocolBufferException {
+        domainBuilder
+                .fileData()
+                .customize(f -> f.fileData(exchangeRatesSet200.toByteArray())
+                        .entityId(EXCHANGE_RATE_ENTITY_ID)
+                        .consensusTimestamp(200L))
+                .persist();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.fileData(exchangeRatesSet300.toByteArray())
+                        .entityId(EXCHANGE_RATE_ENTITY_ID)
+                        .consensusTimestamp(300L))
+                .persist();
+
+        var fileDataCurrent = fileDataRepository.getFileAtTimestamp(EXCHANGE_RATE_ENTITY_ID.getId(), 301);
+        var fileData1 = fileDataRepository.getFileAtTimestamp(EXCHANGE_RATE_ENTITY_ID.getId(), 300);
+        assertThat(fileDataCurrent).isEqualTo(fileData1);
+        assertThat(ExchangeRateSet.parseFrom(fileData1.get(0).getFileData())).isEqualTo(exchangeRatesSet300);
+
+        var fileData2 = fileDataRepository.getFileAtTimestamp(
+                EXCHANGE_RATE_ENTITY_ID.getId(), fileData1.get(0).getConsensusTimestamp() - 1);
+        assertThat(ExchangeRateSet.parseFrom(fileData2.get(0).getFileData())).isEqualTo(exchangeRatesSet200);
+
+        var fileData3 = fileDataRepository.getFileAtTimestamp(
+                EXCHANGE_RATE_ENTITY_ID.getId(), fileData2.get(0).getConsensusTimestamp() - 1);
+        assertThat(fileData3).asList().isEmpty();
+    }
+
+    @Test
     void getFileForExchangeRates() throws InvalidProtocolBufferException {
         domainBuilder
                 .fileData()
@@ -76,8 +132,8 @@ class FileDataRepositoryTest extends Web3IntegrationTest {
                         .consensusTimestamp(expiry))
                 .persist();
 
-        final var actualBytes = fileDataRepository.getFileAtTimestamp(EXCHANGE_RATE_ENTITY_ID.getId(), expiry);
-        assertThat(ExchangeRateSet.parseFrom(actualBytes)).isEqualTo(exchangeRatesSet);
+        final var fileData = fileDataRepository.getFileAtTimestamp(EXCHANGE_RATE_ENTITY_ID.getId(), expiry);
+        assertThat(ExchangeRateSet.parseFrom(fileData.getFirst().getFileData())).isEqualTo(exchangeRatesSet);
     }
 
     @Test
@@ -89,7 +145,8 @@ class FileDataRepositoryTest extends Web3IntegrationTest {
                         .consensusTimestamp(expiry))
                 .persist();
 
-        final var actualBytes = fileDataRepository.getFileAtTimestamp(FEE_SCHEDULE_ENTITY_ID.getId(), expiry);
-        assertThat(CurrentAndNextFeeSchedule.parseFrom(actualBytes)).isEqualTo(feeSchedules);
+        final var fileData = fileDataRepository.getFileAtTimestamp(FEE_SCHEDULE_ENTITY_ID.getId(), expiry);
+        assertThat(CurrentAndNextFeeSchedule.parseFrom(fileData.getFirst().getFileData()))
+                .isEqualTo(feeSchedules);
     }
 }


### PR DESCRIPTION
**Description**:

- Updates the feeSchedule and exchangeRate apis to return historical values.
- Adds a fallback mechanism to the feeSchedule and exchangeRate apis. If the timestamp requested version of the file cannot be parsed the api will automatically fall back to the most recent version that can be parsed.

**Related issue(s)**:

Fixes #8348 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
