### PR TITLE
Fix flaky MetricsConfigurationTest and BalanceReconciliationServiceTest

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MetricsConfigurationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/config/MetricsConfigurationTest.java
@@ -27,7 +27,10 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @RequiredArgsConstructor
 class MetricsConfigurationTest extends ImporterIntegrationTest {
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reconciliation/BalanceReconciliationServiceTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reconciliation/BalanceReconciliationServiceTest.java
@@ -51,8 +51,11 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.transaction.support.TransactionTemplate;
 
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 @RequiredArgsConstructor
 class BalanceReconciliationServiceTest extends ImporterIntegrationTest {
 


### PR DESCRIPTION
**Description**:

* Fix flaky `MetricsConfigurationTest` and `BalanceReconciliationServiceTest` by ensuring they get a fresh `ApplicationContext`
* Suppress verbose PostgreSQL container warning `terminating connection due to unexpected postmaster exit`

**Related issue(s)**:

Fixes #8427

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
