### PR TITLE
Refactor `SelfDestructOperationTest`

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/operations/SelfDestructOperationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/operations/SelfDestructOperationTest.java
@@ -16,42 +16,81 @@
 
 package com.hedera.mirror.web3.evm.contracts.operations;
 
+import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_CALL;
+import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.protobuf.ByteString;
+import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
+import com.hedera.mirror.web3.service.ContractCallService;
 import com.hedera.mirror.web3.service.ContractCallTestSetup;
+import com.hedera.mirror.web3.service.model.CallServiceParameters;
+import com.hedera.mirror.web3.utils.FunctionEncodeDecoder;
 import com.hedera.mirror.web3.viewmodel.BlockType;
+import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
+import java.nio.file.Path;
+import lombok.RequiredArgsConstructor;
 import org.apache.tuweni.bytes.Bytes;
+import org.bouncycastle.util.encoders.Hex;
+import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
 
-public class SelfDestructOperationTest extends ContractCallTestSetup {
+@RequiredArgsConstructor
+class SelfDestructOperationTest extends ContractCallTestSetup {
+
+    private final ContractCallService contractCallService;
+
+    private final FunctionEncodeDecoder functionEncodeDecoder;
+
+    @Value("classpath:contracts/SelfDestructContract/SelfDestructContract.bin")
+    private Path selfDestructContractPath;
+
+    @BeforeEach
+    void setUp() {
+        exchangeRatesPersist();
+        feeSchedulesPersist();
+    }
 
     @Test
-    void testSuccesfullExecute() {
-        final var destroyContractInput = "0x9a0313ab000000000000000000000000" + SENDER_ALIAS.toUnprefixedHexString();
-        final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(destroyContractInput),
-                SELF_DESTRUCT_CONTRACT_ADDRESS,
-                ETH_CALL,
-                0L,
-                BlockType.LATEST);
+    void testSuccessfulExecute() {
+        final var senderAddress = toAddress(EntityId.of(0, 0, 1043));
+        final var senderPublicKey = ByteString.copyFrom(
+                Hex.decode("3a2103af80b90d25145da28c583359beb47b21796b2fe1a23c1511e443e7a64dfdb27d"));
+        final var senderAlias = Address.wrap(
+                Bytes.wrap(recoverAddressFromPubKey(senderPublicKey.substring(2).toByteArray())));
+        domainBuilder
+                .entity()
+                .customize(e -> e.evmAddress(senderAlias.toArray()))
+                .persist();
+        final var contractAddress = toAddress(selfDestructContractPersist());
+        final var destroyContractInput = "0x9a0313ab000000000000000000000000" + senderAlias.toUnprefixedHexString();
+        final var serviceParameters = serviceParametersForExecution()
+                .sender(new HederaEvmAccount(senderAddress))
+                .callData(Bytes.fromHexString(destroyContractInput))
+                .receiver(contractAddress)
+                .build();
         assertThat(contractCallService.processCall(serviceParameters)).isEqualTo("0x");
     }
 
     @Test
     void testExecuteWithInvalidOwner() {
+        final var contractAddress = toAddress(selfDestructContractPersist());
+        final var senderAddress = toAddress(EntityId.of(0, 0, 1043));
+        final var systemAccountAddress = toAddress(EntityId.of(0, 0, 700));
         final var destroyContractInput =
-                "0x9a0313ab000000000000000000000000" + SYSTEM_ACCOUNT_ADDRESS.toUnprefixedHexString();
-        final var serviceParameters = serviceParametersForExecution(
-                Bytes.fromHexString(destroyContractInput),
-                SELF_DESTRUCT_CONTRACT_ADDRESS,
-                ETH_CALL,
-                0L,
-                BlockType.LATEST);
+                "0x9a0313ab000000000000000000000000" + systemAccountAddress.toUnprefixedHexString();
+        final var serviceParameters = serviceParametersForExecution()
+                .sender(new HederaEvmAccount(senderAddress))
+                .receiver(contractAddress)
+                .callData(Bytes.fromHexString(destroyContractInput))
+                .build();
 
         assertEquals(
                 INVALID_SOLIDITY_ADDRESS.name(),
@@ -59,5 +98,33 @@ public class SelfDestructOperationTest extends ContractCallTestSetup {
                                 MirrorEvmTransactionException.class,
                                 () -> contractCallService.processCall(serviceParameters))
                         .getMessage());
+    }
+
+    private EntityId selfDestructContractPersist() {
+        final var selfDestructContractBytes = functionEncodeDecoder.getContractBytes(selfDestructContractPath);
+        final var selfDestructContractEntity = domainBuilder.entity().persist();
+
+        domainBuilder
+                .contract()
+                .customize(c -> c.id(selfDestructContractEntity.toEntityId().getId())
+                        .runtimeBytecode(selfDestructContractBytes))
+                .persist();
+
+        domainBuilder
+                .recordFile()
+                .customize(f -> f.bytes(selfDestructContractBytes))
+                .persist();
+
+        return selfDestructContractEntity.toEntityId();
+    }
+
+    private CallServiceParameters.CallServiceParametersBuilder serviceParametersForExecution() {
+        return CallServiceParameters.builder()
+                .value(0L)
+                .gas(15_000_000L)
+                .isStatic(false)
+                .callType(ETH_CALL)
+                .isEstimate(false)
+                .block(BlockType.LATEST);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallTestSetup.java
@@ -101,7 +101,7 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final long expiry = 1_234_567_890L;
 
     // The block numbers lower than EVM v0.34 are considered part of EVM v0.30 which includes all precompiles
-    protected static final long EVM_V_34_BLOCK = 50L;
+    public static final long EVM_V_34_BLOCK = 50L;
     protected static final long EVM_V_38_BLOCK = 100L;
     protected static final long EVM_V_46_BLOCK = 150L;
     protected static final BigInteger SUCCESS_RESULT = BigInteger.valueOf(ResponseCodeEnum.SUCCESS_VALUE);
@@ -138,7 +138,6 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
     protected static final Address PRNG_CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1266));
     protected static final Address ADDRESS_THIS_CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1269));
     protected static final Address INTERNAL_CALLS_CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1270));
-    protected static final Address SELF_DESTRUCT_CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1278));
     protected static final Address MODIFICATION_WITHOUT_KEY_CONTRACT_ADDRESS = toAddress(EntityId.of(0, 0, 1279));
 
     // Account addresses
@@ -1092,7 +1091,6 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
         final var nestedContractId = dynamicEthCallContractPresist();
         nestedEthCallsContractPersist();
         final var redirectContract = redirectContractPersist();
-        selfDestructContractPersist();
         fileDataPersist();
 
         receiverPersist();
@@ -2860,30 +2858,5 @@ public class ContractCallTestSetup extends Web3IntegrationTest {
                 .customize(f -> f.bytes(internalCallerContractBytes))
                 .persist();
         return internalCallerContractEntityId;
-    }
-
-    private void selfDestructContractPersist() {
-        final var evmCodesContractBytes = functionEncodeDecoder.getContractBytes(SELF_DESTRUCT_CONTRACT_BYTES_PATH);
-        final var evmCodesContractEntityId = fromEvmAddress(SELF_DESTRUCT_CONTRACT_ADDRESS.toArrayUnsafe());
-        final var evmCodesContractEvmAddress = toEvmAddress(evmCodesContractEntityId);
-
-        domainBuilder
-                .entity()
-                .customize(e -> e.id(evmCodesContractEntityId.getId())
-                        .num(evmCodesContractEntityId.getNum())
-                        .evmAddress(evmCodesContractEvmAddress)
-                        .type(CONTRACT)
-                        .balance(1500L))
-                .persist();
-
-        domainBuilder
-                .contract()
-                .customize(c -> c.id(evmCodesContractEntityId.getId()).runtimeBytecode(evmCodesContractBytes))
-                .persist();
-
-        domainBuilder
-                .recordFile()
-                .customize(f -> f.bytes(evmCodesContractBytes))
-                .persist();
     }
 }


### PR DESCRIPTION
**Description**:

The idea of this change is to make the test independent of ContractCallTestSetup class and only reuse `serviceParametersForExecution` method from the base class. 

**Related issue(s)**: https://github.com/hashgraph/hedera-mirror-node/issues/8448 

Fixes #

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
