### PR TITLE
Add accounts allowances, accounts nft and the `/contract/call` tests

### DIFF
--- a/hedera-mirror-rest/monitoring/account_tests.js
+++ b/hedera-mirror-rest/monitoring/account_tests.js
@@ -25,7 +25,7 @@ import {
   checkRespObjDefined,
   CheckRunner,
   DEFAULT_LIMIT,
-  getAPIResponse,
+  fetchAPIResponse,
   getUrl,
   hasEmptyList,
   testRunner,
@@ -57,7 +57,7 @@ const mandatoryParams = [
  */
 const getAccountsWithAccountCheck = async (server) => {
   let url = getUrl(server, accountsPath, {limit: resourceLimit});
-  const accounts = await getAPIResponse(url, jsonRespKey);
+  const accounts = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -80,7 +80,7 @@ const getAccountsWithAccountCheck = async (server) => {
     'account.id': highestAccount,
     limit: 1,
   });
-  const singleAccount = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
+  const singleAccount = await fetchAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -104,7 +104,7 @@ const getAccountsWithAccountCheck = async (server) => {
  */
 const getSingleAccount = async (server) => {
   let url = getUrl(server, accountsPath, {limit: resourceLimit});
-  const accounts = await getAPIResponse(url, jsonRespKey);
+  const accounts = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -124,7 +124,7 @@ const getSingleAccount = async (server) => {
 
   const highestAccount = _.max(_.map(accounts, (acct) => acct.account));
   url = getUrl(server, `${accountsPath}/${highestAccount}`);
-  const singleAccount = await getAPIResponse(url);
+  const singleAccount = await fetchAPIResponse(url);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -153,7 +153,7 @@ const getSingleAccountTokenRelationships = async (server) => {
   const tokensLimit = 1;
   const tokenMandatoryParams = ['token_id'];
   const token_url = getUrl(server, tokensPath, {limit: tokensLimit, order: 'asc'});
-  const tokens = await getAPIResponse(token_url, tokensJsonRespKey);
+  const tokens = await fetchAPIResponse(token_url, tokensJsonRespKey);
 
   const tokenResult = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -180,7 +180,7 @@ const getSingleAccountTokenRelationships = async (server) => {
 
   const balancesLimit = 1;
   let balances_url = getUrl(server, tokenBalancesPath(token_id), {limit: balancesLimit});
-  let balances = await getAPIResponse(balances_url, tokenBalancesJsonRespKey);
+  let balances = await fetchAPIResponse(balances_url, tokenBalancesJsonRespKey);
   const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'balances is undefined'});
@@ -199,7 +199,7 @@ const getSingleAccountTokenRelationships = async (server) => {
   const accountsTokenPath = `/accounts/${accountId}/tokens`;
   const accountsLimit = 1;
   let url = getUrl(server, accountsTokenPath, {limit: accountsLimit, order: 'asc'});
-  const tokenRelationships = await getAPIResponse(url, tokensJsonRespKey, hasEmptyList(tokensJsonRespKey));
+  const tokenRelationships = await fetchAPIResponse(url, tokensJsonRespKey, hasEmptyList(tokensJsonRespKey));
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'tokens is undefined '})
@@ -224,7 +224,7 @@ const getAccountStakingRewards = async (server) => {
   const rewardsJsonRespKey = 'rewards';
   let url = getUrl(server, stakingRewardsPath, {limit: resourceLimit});
   const rewardMandatoryParams = ['account_id', 'amount', 'timestamp'];
-  const rewards = await getAPIResponse(url, rewardsJsonRespKey);
+  const rewards = await fetchAPIResponse(url, rewardsJsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -253,7 +253,7 @@ const getCryptoAllowances = async (server) => {
   const accountId = config[resource].cryptoAllowanceOwnerId;
   const cryptoAllowancesPath = `${accountsPath}/${accountId}/allowances/crypto`;
   let url = getUrl(server, cryptoAllowancesPath, {limit: resourceLimit});
-  const allowances = await getAPIResponse(url, allowancesJsonRespKey);
+  const allowances = await fetchAPIResponse(url, allowancesJsonRespKey);
   const allowancesMandatoryParams = ['amount', 'amount_granted', 'owner', 'spender', 'timestamp'];
 
   let result = new CheckRunner()
@@ -283,7 +283,7 @@ const getTokenAllowances = async (server) => {
   const accountId = config[resource].tokenAllowanceOwnerId;
   const tokenAllowancesPath = `${accountsPath}/${accountId}/allowances/tokens`;
   let url = getUrl(server, tokenAllowancesPath, {limit: resourceLimit});
-  const allowances = await getAPIResponse(url, allowancesJsonRespKey);
+  const allowances = await fetchAPIResponse(url, allowancesJsonRespKey);
   const tokenAllowancesMandatoryParams = ['amount', 'amount_granted', 'owner', 'spender', 'timestamp', 'token_id'];
 
   let result = new CheckRunner()
@@ -313,7 +313,7 @@ const getNftAllowances = async (server) => {
   const accountId = config[resource].nftAllowanceOwnerId;
   const nftAllowancesPath = `${accountsPath}/${accountId}/allowances/nfts`;
   let url = getUrl(server, nftAllowancesPath, {limit: resourceLimit});
-  const allowances = await getAPIResponse(url, allowancesJsonRespKey);
+  const allowances = await fetchAPIResponse(url, allowancesJsonRespKey);
   const nftAllowancesMandatoryParams = ['approved_for_all', 'owner', 'spender', 'timestamp', 'token_id'];
 
   let result = new CheckRunner()
@@ -344,7 +344,7 @@ const getNfts = async (server) => {
   const nftsPath = `${accountsPath}/${accountId}/nfts`;
   let url = getUrl(server, nftsPath, {limit: resourceLimit});
   const nftJsonResponseKey = 'nfts';
-  const allowances = await getAPIResponse(url, nftJsonResponseKey);
+  const allowances = await fetchAPIResponse(url, nftJsonResponseKey);
   const nftsMandatoryParams = [
     'account_id',
     'created_timestamp',

--- a/hedera-mirror-rest/monitoring/balance_tests.js
+++ b/hedera-mirror-rest/monitoring/balance_tests.js
@@ -26,7 +26,7 @@ import {
   checkRespObjDefined,
   CheckRunner,
   DEFAULT_LIMIT,
-  getAPIResponse,
+  fetchAPIResponse,
   getUrl,
   hasEmptyList,
   testRunner,
@@ -44,7 +44,7 @@ const mandatoryParams = ['account', 'balance'];
  */
 const getBalancesCheck = async (server) => {
   const url = getUrl(server, balancesPath, {limit: resourceLimit});
-  const balances = await getAPIResponse(url, jsonRespKey);
+  const balances = await fetchAPIResponse(url, jsonRespKey);
 
   const result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -75,7 +75,7 @@ const getBalancesCheck = async (server) => {
  */
 const getSingleBalanceById = async (server) => {
   let url = getUrl(server, balancesPath, {limit: 10});
-  const balances = await getAPIResponse(url, jsonRespKey);
+  const balances = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -95,7 +95,7 @@ const getSingleBalanceById = async (server) => {
 
   const highestAccount = _.max(_.map(balances, (balance) => balance.account));
   url = getUrl(server, balancesPath, {'account.id': highestAccount});
-  const singleBalance = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
+  const singleBalance = await fetchAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/block_tests.js
+++ b/hedera-mirror-rest/monitoring/block_tests.js
@@ -25,7 +25,7 @@ import {
   checkRespObjDefined,
   CheckRunner,
   DEFAULT_LIMIT,
-  getAPIResponse,
+  fetchAPIResponse,
   getUrl,
   testRunner,
 } from './utils';
@@ -54,7 +54,7 @@ const mandatoryParams = [
  */
 const getSingleBlockById = async (server) => {
   let url = getUrl(server, blocksPath, {limit: 10});
-  const blocks = await getAPIResponse(url, jsonRespKey);
+  const blocks = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -74,7 +74,7 @@ const getSingleBlockById = async (server) => {
 
   const highestBlock = _.max(_.map(blocks, (block) => block.number));
   url = getUrl(server, `${blocksPath}/${highestBlock}`);
-  const singleBlock = await getAPIResponse(url);
+  const singleBlock = await fetchAPIResponse(url);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/config/default.serverlist.json
@@ -19,6 +19,11 @@
     "intervalMultiplier": 1,
     "limit": 10,
     "stakingRewardAccountId": null,
+    "cryptoAllowanceOwnerId": "",
+    "nftAllowanceOwnerId": "",
+    "_comment": "nftAccountId value might not be the same as nftAllowanceOwnerId in different environments",
+    "nftAccountId": "",
+    "tokenAllowanceOwnerId": "",
     "tokenRelationshipEnabled": true
   },
   "balance": {

--- a/hedera-mirror-rest/monitoring/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/config/default.serverlist.json
@@ -21,7 +21,6 @@
     "stakingRewardAccountId": null,
     "cryptoAllowanceOwnerId": "",
     "nftAllowanceOwnerId": "",
-    "_comment": "nftAccountId value might not be the same as nftAllowanceOwnerId in different environments",
     "nftAccountId": "",
     "tokenAllowanceOwnerId": "",
     "tokenRelationshipEnabled": true

--- a/hedera-mirror-rest/monitoring/contracts_tests.js
+++ b/hedera-mirror-rest/monitoring/contracts_tests.js
@@ -97,11 +97,17 @@ const postContractCall = async (server) => {
           "gasPrice": 100000000,
           "to": "0x0000000000000000000000000000000000000168"
     }`;
+  const contractCallResponseParams = ['result'];
+
   const singleContract = await fetchAPIResponse(url, '', undefined, body);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'contracts call is undefined'})
+    .withCheckSpec(checkMandatoryParams, {
+      params: contractCallResponseParams,
+      message: 'contract call response object is missing some mandatory fields',
+    })
     .run(singleContract);
   if (!result.passed) {
     return {url, ...result};

--- a/hedera-mirror-rest/monitoring/contracts_tests.js
+++ b/hedera-mirror-rest/monitoring/contracts_tests.js
@@ -28,6 +28,7 @@ import {
   getAPIResponse,
   getUrl,
   testRunner,
+  postAPICall,
 } from './utils';
 
 const contractsPath = '/contracts';
@@ -53,7 +54,7 @@ const mandatoryParams = [
 const contractResultParams = ['address', 'bloom', 'contract_id', 'from', 'gas_limit', 'hash', 'timestamp', 'to'];
 
 /**
- * Verify Verify /contracts and /contracts/{contractId} can be retrieved
+ * Verify /contracts and /contracts/{contractId} can be retrieved
  * @param {Object} server API host endpoint
  */
 const getContractById = async (server) => {
@@ -80,6 +81,37 @@ const getContractById = async (server) => {
     url,
     passed: true,
     message: 'Successfully called contracts for single contract',
+  };
+};
+
+/**
+ * Verify /contracts/call can be called
+ * @param {Object} server API host endpoint
+ */
+const postContractCall = async (server) => {
+  let url = getUrl(server, `${contractsPath}/call`);
+  let body = `{
+      "block": "latest",
+          "data": "0x2e3cff6a0000000000000000000000000000000000000000000000000000000000000064",
+          "estimate": false,
+          "gas": 15000000,
+          "gasPrice": 100000000,
+          "to": "0x0000000000000000000000000000000000000168"
+    }`;
+  const singleContract = await postAPICall(url, body);
+
+  let result = new CheckRunner()
+    .withCheckSpec(checkAPIResponseError)
+    .withCheckSpec(checkRespObjDefined, {message: 'contracts call is undefined'})
+    .run(singleContract);
+  if (!result.passed) {
+    return {url, ...result};
+  }
+
+  return {
+    url,
+    passed: true,
+    message: 'Successfully called contracts call for single contract',
   };
 };
 
@@ -361,6 +393,7 @@ const runTests = async (server, testResult) => {
   const runTest = testRunner(server, testResult, resource);
   return Promise.all([
     runTest(getContractById),
+    runTest(postContractCall),
     runTest(getContractResults),
     runTest(getContractResultsLogs),
     runTest(getContractState),

--- a/hedera-mirror-rest/monitoring/contracts_tests.js
+++ b/hedera-mirror-rest/monitoring/contracts_tests.js
@@ -25,10 +25,9 @@ import {
   checkRespObjDefined,
   CheckRunner,
   DEFAULT_LIMIT,
-  getAPIResponse,
+  fetchAPIResponse,
   getUrl,
   testRunner,
-  postAPICall,
 } from './utils';
 
 const contractsPath = '/contracts';
@@ -66,7 +65,7 @@ const getContractById = async (server) => {
 
   const contract = _.max(_.map(contracts, (contract) => contract.contract_id));
   url = getUrl(server, `${contractsPath}/${contract}`);
-  const singleContract = await getAPIResponse(url);
+  const singleContract = await fetchAPIResponse(url);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -98,7 +97,7 @@ const postContractCall = async (server) => {
           "gasPrice": 100000000,
           "to": "0x0000000000000000000000000000000000000168"
     }`;
-  const singleContract = await postAPICall(url, body);
+  const singleContract = await fetchAPIResponse(url, body);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -132,7 +131,7 @@ const getContractResults = async (server) => {
   }
 
   let url = getUrl(server, `${contractsPath}/${contractId}/results`);
-  const contractResults = await getAPIResponse(url, jsonResultsRespKey);
+  const contractResults = await fetchAPIResponse(url, jsonResultsRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -148,7 +147,7 @@ const getContractResults = async (server) => {
 
   const timestamp = _.max(_.map(contractResults, (result) => result.timestamp));
   url = getUrl(server, `${contractsPath}/${contractId}/results/${timestamp}`);
-  const contractResultsAtTimestamp = await getAPIResponse(url);
+  const contractResultsAtTimestamp = await fetchAPIResponse(url);
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
     .withCheckSpec(checkRespObjDefined, {message: 'contract results at a given timestamp is undefined'})
@@ -188,7 +187,7 @@ const getContractResultsLogs = async (server) => {
   const jsonLogsRespKey = 'logs';
   const contractLogsParams = ['address', 'bloom', 'contract_id', 'index', 'topics'];
   let url = getUrl(server, `${contractsPath}/${contractId}/results/logs`);
-  let contractLogs = await getAPIResponse(url, jsonLogsRespKey);
+  let contractLogs = await fetchAPIResponse(url, jsonLogsRespKey);
 
   // Verify contracts logs for a particular contractId
   let result = new CheckRunner()
@@ -205,7 +204,7 @@ const getContractResultsLogs = async (server) => {
 
   // Verify contracts logs list
   url = getUrl(server, `${contractsPath}/results/logs`, {limit: resourceLimit});
-  contractLogs = await getAPIResponse(url, jsonLogsRespKey);
+  contractLogs = await fetchAPIResponse(url, jsonLogsRespKey);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -245,7 +244,7 @@ const getContractState = async (server) => {
   const jsonStateRespKey = 'state';
   const contract = _.max(_.map(contracts, (contract) => contract.contract_id));
   url = getUrl(server, `${contractsPath}/${contract}/state`);
-  const contractState = await getAPIResponse(url, jsonStateRespKey);
+  const contractState = await fetchAPIResponse(url, jsonStateRespKey);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -282,7 +281,7 @@ const getContractResultsByTransaction = async (server) => {
 
   const contractResultParams = ['address', 'failed_initcode', 'hash', 'logs'];
   url = getUrl(server, `${contractsPath}/results/${transactionId}`);
-  const contractResults = await getAPIResponse(url);
+  const contractResults = await fetchAPIResponse(url);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -315,7 +314,7 @@ const getContractResultsByTransaction = async (server) => {
     'value',
   ];
   url = getUrl(server, `${contractsPath}/results/${transactionId}/actions`);
-  const contractActions = await getAPIResponse(url, jsonActionsRespKey);
+  const contractActions = await fetchAPIResponse(url, jsonActionsRespKey);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -341,7 +340,7 @@ const getContractResultsByTransaction = async (server) => {
  */
 async function getContractsList(server) {
   let url = getUrl(server, contractsPath, {limit: resourceLimit});
-  const contracts = await getAPIResponse(url, jsonRespKey);
+  const contracts = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -365,7 +364,7 @@ async function getContractsList(server) {
 async function getContractsResultsList(server) {
   const contractsResultsPath = '/contracts/results';
   let url = getUrl(server, contractsResultsPath, {limit: resourceLimit});
-  const contractsResults = await getAPIResponse(url, jsonResultsRespKey);
+  const contractsResults = await fetchAPIResponse(url, jsonResultsRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/network_tests.js
+++ b/hedera-mirror-rest/monitoring/network_tests.js
@@ -23,7 +23,7 @@ import {
   checkRespObjDefined,
   CheckRunner,
   DEFAULT_LIMIT,
-  getAPIResponse,
+  fetchAPIResponse,
   getUrl,
   testRunner,
 } from './utils';
@@ -41,7 +41,7 @@ const resourceLimit = config[resource].limit || DEFAULT_LIMIT;
  */
 const getNetworkExchangeRate = async (server) => {
   let url = getUrl(server, network + '/exchangerate');
-  const networkExchangeRate = await getAPIResponse(url, jsonRespKey);
+  const networkExchangeRate = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -66,7 +66,7 @@ const getNetworkExchangeRate = async (server) => {
 const getNetworkFees = async (server) => {
   let url = getUrl(server, network + '/fees');
   const jsonFeesRespKey = 'fees';
-  const networkFees = await getAPIResponse(url, jsonFeesRespKey);
+  const networkFees = await fetchAPIResponse(url, jsonFeesRespKey);
   const returnParams = ['gas', 'transaction_type'];
 
   let result = new CheckRunner()
@@ -95,7 +95,7 @@ const getNetworkFees = async (server) => {
  */
 const getNetworkNodes = async (server) => {
   let url = getUrl(server, network + '/nodes', {limit: resourceLimit});
-  const networkNodes = await getAPIResponse(url, jsonNodesRespKey);
+  const networkNodes = await fetchAPIResponse(url, jsonNodesRespKey);
   const returnParams = [
     'description',
     'file_id',
@@ -145,7 +145,7 @@ const getNetworkNodes = async (server) => {
  */
 const getNetworkStake = async (server) => {
   let url = getUrl(server, network + '/stake');
-  const networkStake = await getAPIResponse(url, jsonRespKey);
+  const networkStake = await fetchAPIResponse(url, jsonRespKey);
   const mandatoryParams = [
     'max_stake_rewarded',
     'max_staking_reward_rate_per_hbar',
@@ -189,7 +189,7 @@ const getNetworkStake = async (server) => {
  */
 const getNetworkSupply = async (server) => {
   let url = getUrl(server, network + '/supply');
-  const networkSupply = await getAPIResponse(url, jsonRespKey);
+  const networkSupply = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/schedule_tests.js
+++ b/hedera-mirror-rest/monitoring/schedule_tests.js
@@ -23,7 +23,7 @@ import {
   checkRespObjDefined,
   CheckRunner,
   DEFAULT_LIMIT,
-  getAPIResponse,
+  fetchAPIResponse,
   getUrl,
   testRunner,
 } from './utils';
@@ -39,7 +39,7 @@ const jsonRespKey = 'schedules';
  */
 const getScheduleById = async (server) => {
   let url = getUrl(server, schedulesPath, {limit: resourceLimit});
-  const schedules = await getAPIResponse(url, jsonRespKey);
+  const schedules = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -55,7 +55,7 @@ const getScheduleById = async (server) => {
 
   const scheduleId = _.max(_.map(schedules, (schedule) => schedule.schedule_id));
   url = getUrl(server, `${schedulesPath}/${scheduleId}`);
-  const schedule = await getAPIResponse(url);
+  const schedule = await fetchAPIResponse(url);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/stateproof_tests.js
+++ b/hedera-mirror-rest/monitoring/stateproof_tests.js
@@ -20,7 +20,7 @@ import {
   checkRespArrayLength,
   checkRespObjDefined,
   CheckRunner,
-  getAPIResponse,
+  fetchAPIResponse,
   getUrl,
   testRunner,
 } from './utils';
@@ -40,7 +40,7 @@ const stateproofPath = (transactionId) => `${transactionsPath}/${transactionId}/
  */
 const checkStateproofForValidTransaction = async (server) => {
   let url = getUrl(server, transactionsPath, {limit: 1, order: 'desc', result: 'success'});
-  const transactions = await getAPIResponse(url, transactionsJsonKey);
+  const transactions = await fetchAPIResponse(url, transactionsJsonKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -56,7 +56,7 @@ const checkStateproofForValidTransaction = async (server) => {
 
   const {transaction_id: transactionId, nonce, scheduled} = transactions[0];
   url = getUrl(server, stateproofPath(transactionId), {nonce, scheduled});
-  const stateproof = await getAPIResponse(url);
+  const stateproof = await fetchAPIResponse(url);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/token_tests.js
+++ b/hedera-mirror-rest/monitoring/token_tests.js
@@ -28,7 +28,7 @@ import {
   checkRespObjDefined,
   CheckRunner,
   DEFAULT_LIMIT,
-  getAPIResponse,
+  fetchAPIResponse,
   getUrl,
   hasEmptyList,
   testRunner,
@@ -49,7 +49,7 @@ const tokenMandatoryParams = ['token_id', 'symbol', 'admin_key'];
  */
 const getTokensCheck = async (server) => {
   const url = getUrl(server, tokensPath, {limit: tokensLimit});
-  const tokens = await getAPIResponse(url, tokensJsonRespKey);
+  const tokens = await fetchAPIResponse(url, tokensJsonRespKey);
 
   const result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -76,7 +76,7 @@ const getTokensCheck = async (server) => {
 
 const getFirstTokenIdWithCheckResult = async (server) => {
   const url = getUrl(server, tokensPath, {limit: 1});
-  const tokens = await getAPIResponse(url, tokensJsonRespKey);
+  const tokens = await fetchAPIResponse(url, tokensJsonRespKey);
 
   const result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -125,7 +125,7 @@ const getTokensWithLimitParam = async (server) => {
  */
 const getTokensWithOrderParam = async (server) => {
   let url = getUrl(server, tokensPath, {order: 'asc'});
-  let tokens = await getAPIResponse(url, tokensJsonRespKey);
+  let tokens = await fetchAPIResponse(url, tokensJsonRespKey);
 
   const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -141,7 +141,7 @@ const getTokensWithOrderParam = async (server) => {
   }
 
   url = getUrl(server, tokensPath, {order: 'desc'});
-  tokens = await getAPIResponse(url, tokensJsonRespKey);
+  tokens = await fetchAPIResponse(url, tokensJsonRespKey);
 
   result = checkRunner
     .resetCheckSpec(checkElementsOrder, {asc: false, compare: accountIdCompare, key: 'token_id', name: 'token ID'})
@@ -197,7 +197,7 @@ const getTokenInfoCheck = async (server) => {
   }
 
   const url = getUrl(server, tokenInfoPath(tokenId));
-  const tokenInfo = await getAPIResponse(url);
+  const tokenInfo = await fetchAPIResponse(url);
 
   const tokenInfoResult = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -241,7 +241,7 @@ const getTokenBalancesCheck = async (server) => {
   }
 
   const url = getUrl(server, tokenBalancesPath(tokenId), {limit: tokenBalancesLimit});
-  const balances = await getAPIResponse(url, tokenBalancesJsonRespKey);
+  const balances = await fetchAPIResponse(url, tokenBalancesJsonRespKey);
 
   const balancesResult = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -284,7 +284,7 @@ const getTokenBalancesWithLimitParam = async (server) => {
   }
 
   const url = getUrl(server, tokenBalancesPath(tokenId), {limit: 1});
-  const balances = await getAPIResponse(url, tokenBalancesJsonRespKey);
+  const balances = await fetchAPIResponse(url, tokenBalancesJsonRespKey);
 
   const balancesResult = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -327,7 +327,7 @@ const getTokenBalancesWithTimestampParam = async (server) => {
   }
 
   let url = getUrl(server, tokenBalancesPath(tokenId), {limit: 1});
-  const resp = await getAPIResponse(url);
+  const resp = await fetchAPIResponse(url);
   let balances = resp instanceof Error ? resp : resp[tokenBalancesJsonRespKey];
 
   const checkRunner = new CheckRunner()
@@ -349,7 +349,7 @@ const getTokenBalancesWithTimestampParam = async (server) => {
     timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
     limit: 1,
   });
-  balances = await getAPIResponse(url, tokenBalancesJsonRespKey);
+  balances = await fetchAPIResponse(url, tokenBalancesJsonRespKey);
 
   balancesResult = checkRunner.run(balances);
   if (!balancesResult.passed) {
@@ -381,7 +381,7 @@ const getTokenBalancesForAccount = async (server) => {
   }
 
   let url = getUrl(server, tokenBalancesPath(tokenId), {limit: 1});
-  let balances = await getAPIResponse(url, tokenBalancesJsonRespKey, hasEmptyList(tokenBalancesJsonRespKey));
+  let balances = await fetchAPIResponse(url, tokenBalancesJsonRespKey, hasEmptyList(tokenBalancesJsonRespKey));
 
   const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -397,7 +397,7 @@ const getTokenBalancesForAccount = async (server) => {
 
   const accountId = balances[0].account;
   url = getUrl(server, tokenBalancesPath(tokenId), {'account.id': accountId});
-  balances = await getAPIResponse(url, tokenBalancesJsonRespKey);
+  balances = await fetchAPIResponse(url, tokenBalancesJsonRespKey);
 
   balancesResult = checkRunner
     .withCheckSpec(checkEntityId, {accountId, message: 'account was not found'})

--- a/hedera-mirror-rest/monitoring/topic_tests.js
+++ b/hedera-mirror-rest/monitoring/topic_tests.js
@@ -24,7 +24,7 @@ import {
   checkMandatoryParams,
   checkResourceFreshness,
   DEFAULT_LIMIT,
-  getAPIResponse,
+  fetchAPIResponse,
   getUrl,
   testRunner,
   CheckRunner,
@@ -96,7 +96,7 @@ const checkSingleField = (elements, option) => {
  */
 const getTopicById = async (server) => {
   let url = getUrl(server, `/topics/${topicId}`, {limit: resourceLimit});
-  let topic = await getAPIResponse(url, jsonRespKey);
+  let topic = await fetchAPIResponse(url, jsonRespKey);
   const requiredParams = [
     'admin_key',
     'auto_renew_account',
@@ -137,7 +137,7 @@ const getTopicById = async (server) => {
  */
 const getTopicMessages = async (server) => {
   let url = getUrl(server, topicMessagesPath(topicId), {limit: resourceLimit});
-  let messages = await getAPIResponse(url, jsonRespKey);
+  let messages = await fetchAPIResponse(url, jsonRespKey);
 
   const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -158,7 +158,7 @@ const getTopicMessages = async (server) => {
   }
 
   url = getUrl(server, topicMessagesPath(topicId), {limit: resourceLimit, order: 'desc'});
-  messages = await getAPIResponse(url, jsonRespKey);
+  messages = await fetchAPIResponse(url, jsonRespKey);
 
   result = checkRunner
     .resetCheckSpec(checkElementsOrder, {asc: false, key: 'consensus_timestamp', name: 'consensus timestamp'})
@@ -183,7 +183,7 @@ const getTopicMessages = async (server) => {
  */
 const getTopicMessagesBySequenceNumberFilter = async (server) => {
   let url = getUrl(server, topicMessagesPath(topicId), {sequencenumber: 1});
-  let messages = await getAPIResponse(url, jsonRespKey);
+  let messages = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -207,7 +207,7 @@ const getTopicMessagesBySequenceNumberFilter = async (server) => {
   }
 
   url = getUrl(server, topicMessagesPath(topicId), {sequencenumber: ['gte:1', 'lte:3']});
-  messages = await getAPIResponse(url, jsonRespKey);
+  messages = await fetchAPIResponse(url, jsonRespKey);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -226,7 +226,7 @@ const getTopicMessagesBySequenceNumberFilter = async (server) => {
   }
 
   url = getUrl(server, topicMessagesPath(topicId), {sequencenumber: ['gte:3', 'lt:3']});
-  messages = await getAPIResponse(url, jsonRespKey);
+  messages = await fetchAPIResponse(url, jsonRespKey);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -255,7 +255,7 @@ const getTopicMessagesBySequenceNumberFilter = async (server) => {
  */
 const getTopicMessagesByTopicIDAndSequenceNumberPath = async (server) => {
   const url = getUrl(server, topicMessagesPath(topicId, 1));
-  const message = await getAPIResponse(url);
+  const message = await fetchAPIResponse(url);
 
   const result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -284,7 +284,7 @@ const getTopicMessagesByTopicIDAndSequenceNumberPath = async (server) => {
  */
 const getTopicMessagesByConsensusTimestamp = async (server) => {
   let url = getUrl(server, topicMessagesPath(topicId), {limit: resourceLimit});
-  const messages = await getAPIResponse(url, jsonRespKey);
+  const messages = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -304,7 +304,7 @@ const getTopicMessagesByConsensusTimestamp = async (server) => {
 
   const consensusTimestamp = messages[0].consensus_timestamp;
   url = getUrl(server, `/topics/messages/${consensusTimestamp}`);
-  const message = await getAPIResponse(url);
+  const message = await fetchAPIResponse(url);
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)

--- a/hedera-mirror-rest/monitoring/transaction_tests.js
+++ b/hedera-mirror-rest/monitoring/transaction_tests.js
@@ -28,7 +28,7 @@ import {
   checkRespObjDefined,
   CheckRunner,
   DEFAULT_LIMIT,
-  getAPIResponse,
+  fetchAPIResponse,
   getUrl,
   hasEmptyList,
   testRunner,
@@ -80,7 +80,7 @@ const checkTransactionTransfers = (transactions, option) => {
  */
 const getTransactionsWithAccountCheck = async (server) => {
   let url = getUrl(server, transactionsPath, {limit: resourceLimit, type: 'credit'});
-  const transactions = await getAPIResponse(url, jsonRespKey);
+  const transactions = await fetchAPIResponse(url, jsonRespKey);
 
   let result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -121,7 +121,7 @@ const getTransactionsWithAccountCheck = async (server) => {
     type: 'credit',
     limit: 1,
   });
-  const accTransactions = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
+  const accTransactions = await fetchAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -156,7 +156,7 @@ const getTransactionsWithAccountCheck = async (server) => {
  */
 const getTransactionsWithOrderParam = async (server) => {
   const url = getUrl(server, transactionsPath, {order: 'asc', limit: resourceLimit});
-  const transactions = await getAPIResponse(url, jsonRespKey);
+  const transactions = await fetchAPIResponse(url, jsonRespKey);
 
   const result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -188,7 +188,7 @@ const getTransactionsWithOrderParam = async (server) => {
  */
 const getTransactionsWithLimitParams = async (server) => {
   const url = getUrl(server, transactionsPath, {limit: 10});
-  const transactions = await getAPIResponse(url, jsonRespKey);
+  const transactions = await fetchAPIResponse(url, jsonRespKey);
 
   const result = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -215,7 +215,7 @@ const getTransactionsWithLimitParams = async (server) => {
  */
 const getTransactionsWithTimeAndLimitParams = async (server) => {
   let url = getUrl(server, transactionsPath, {limit: 1});
-  let transactions = await getAPIResponse(url, jsonRespKey);
+  let transactions = await fetchAPIResponse(url, jsonRespKey);
 
   const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -235,7 +235,7 @@ const getTransactionsWithTimeAndLimitParams = async (server) => {
     timestamp: [`gt:${minusOne.toString()}`, `lt:${plusOne.toString()}`],
     limit: 1,
   });
-  transactions = await getAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
+  transactions = await fetchAPIResponse(url, jsonRespKey, hasEmptyList(jsonRespKey));
 
   result = checkRunner.run(transactions);
   if (!result.passed) {
@@ -256,7 +256,7 @@ const getTransactionsWithTimeAndLimitParams = async (server) => {
 const getSuccessfulTransactionById = async (server) => {
   // look for the latest successful transaction
   let url = getUrl(server, transactionsPath, {limit: 1, result: 'success'});
-  const transactions = await getAPIResponse(url, jsonRespKey);
+  const transactions = await fetchAPIResponse(url, jsonRespKey);
 
   const checkRunner = new CheckRunner()
     .withCheckSpec(checkAPIResponseError)
@@ -276,7 +276,7 @@ const getSuccessfulTransactionById = async (server) => {
 
   // filter the scheduled transaction
   url = getUrl(server, `${transactionsPath}/${transactions[0].transaction_id}`, {scheduled: false});
-  const singleTransactions = await getAPIResponse(url, jsonRespKey);
+  const singleTransactions = await fetchAPIResponse(url, jsonRespKey);
 
   // only verify the single successful transaction
   result = new CheckRunner()

--- a/hedera-mirror-rest/monitoring/utils.js
+++ b/hedera-mirror-rest/monitoring/utils.js
@@ -196,7 +196,6 @@ class ServerTestResult {
   }
 
   addTestResult(testResult) {
-    logger.log(`Test result for ${testResult.message}`);
     this.result.testResults.push(testResult);
     if (testResult.result === 'passed') {
       this.result.numPassedTests += 1;

--- a/hedera-mirror-rest/monitoring/utils.js
+++ b/hedera-mirror-rest/monitoring/utils.js
@@ -133,7 +133,12 @@ const fetchAPIResponse = async (url, key = undefined, retryPredicate = noRetry, 
   try {
     let opts = {signal: controller.signal};
     if (body !== undefined) {
-      opts = {method: 'POST', body: body, headers: {'Content-type': 'application/json; charset=UTF-8'}};
+      opts = {
+        method: 'POST',
+        body: body,
+        headers: {'Content-type': 'application/json; charset=UTF-8'},
+        signal: controller.signal,
+      };
     }
     const json = await fetchWithRetry(url, opts, retryPredicate);
 


### PR DESCRIPTION
**Description**:
This PR adds remaining accounts allowances, accounts nft and the `/contract/call` endpoints to the rest monitor

This PR adds
* Accounts allowances - `/{idOrAliasOrEvmAddress}/allowances/crypto` , ` /{idOrAliasOrEvmAddress}/allowances/nfts` ,`/{idOrAliasOrEvmAddress}/allowances/tokens`
* Accounts nfts - `/accounts/{idOrAliasOrEvmAddress}/nfts`
* Contract call -  `/contracts/call` - Invoke a smart contract

**Related issue(s)**:

Fixes #8429

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
