### PR TITLE
Change FixFungibleTokenTotalSupplyMigration to use deduped token balance info

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/FixFungibleTokenTotalSupplyMigrationTest.java
@@ -134,10 +134,11 @@ class FixFungibleTokenTotalSupplyMigrationTest extends ImporterIntegrationTest {
                 .customize(tb -> tb.balance(token3.getTotalSupply() - 5000L)
                         .id(new TokenBalance.Id(accountBalanceTimestamp, treasury, token3EntityId)))
                 .persist();
+        // deduped so the timestamp is 100ns earlier
         domainBuilder
                 .tokenBalance()
-                .customize(tb ->
-                        tb.balance(5000L).id(new TokenBalance.Id(accountBalanceTimestamp, account, token3EntityId)))
+                .customize(tb -> tb.balance(5000L)
+                        .id(new TokenBalance.Id(accountBalanceTimestamp - 100, account, token3EntityId)))
                 .persist();
         // no token4 balance distribution in account balance file
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the issue which causes incorrect fungible total supply

- Fix the SQL to get token balance info from deduped `token_balance` table
- Update the minimum required version

**Related issue(s)**:

Fixes #8433 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
This will only happen on a database with existing data and `FixFungibleTokenTotalSupplyMigration` never ran before.

Thus

- we don't want to increase the checksum and rerun it
- no need to backport

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
