### PR TITLE
Fix invalid next link when the last pagination param has eq operator

### DIFF
--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/common/LinkFactoryImpl.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/common/LinkFactoryImpl.java
@@ -110,13 +110,13 @@ class LinkFactoryImpl implements LinkFactory {
             Map<String, String> paginationParamsMap,
             Direction order,
             LinkedMultiValueMap<String, String> queryParams) {
-        var sortMap = new TreeMap<String, Boolean>();
-        sort.map(Sort.Order::getProperty).forEach(s -> sortMap.put(s, containsEq(queryParams.get(s))));
+        var sortEqMap = new TreeMap<String, Boolean>();
+        sort.map(Sort.Order::getProperty).forEach(s -> sortEqMap.put(s, containsEq(queryParams.get(s))));
 
-        var sortKeys = sortMap.keySet().toArray();
+        var sortKeys = sortEqMap.keySet().toArray();
         for (int i = 0; i < sortKeys.length; i++) {
             var key = sortKeys[i].toString();
-            if (queryParams.containsKey(key) && Boolean.TRUE.equals(sortMap.get(key))) {
+            if (queryParams.containsKey(key) && Boolean.TRUE.equals(sortEqMap.get(key))) {
                 // This query parameter has already been added with an eq
                 continue;
             }
@@ -124,7 +124,7 @@ class LinkFactoryImpl implements LinkFactory {
             var exclusive = true;
             if (sortKeys.length > i + 1) {
                 var succeedingKey = sortKeys[i + 1];
-                exclusive = sortMap.get(succeedingKey);
+                exclusive = sortEqMap.get(succeedingKey);
             }
 
             var value = paginationParamsMap.get(key);

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/common/LinkFactoryTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/common/LinkFactoryTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 
 import com.hedera.mirror.rest.model.Links;
 import com.hedera.mirror.rest.model.NftAllowance;
-import com.hedera.mirror.rest.model.Transaction;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -147,19 +146,6 @@ class LinkFactoryTest {
                 .returns(expectedLink, Links::getNext);
     }
 
-    @Test
-    void testSortOmitted() {
-        // given
-        var transaction = new Transaction().consensusTimestamp("123456789.000000123");
-
-        // when then
-        assertThat(linkFactory.create(
-                        List.of(transaction),
-                        PageRequest.ofSize(1),
-                        t -> Map.of("timestamp", t.getConsensusTimestamp())))
-                .returns("/api?timestamp=123456789.000000123", Links::getNext);
-    }
-
     @DisplayName("Get pagination links unknown parameter")
     @Test
     void testUnknownParameter() {
@@ -186,10 +172,8 @@ class LinkFactoryTest {
         "desc,   gt:0.0.100,  gte:0.0.100, lte:0.0.7000, gt:0.0.6000,  /api?order=desc&account.id=gt:0.0.100&account.id=gte:0.0.100&account.id=lte:0.0.1000&token.id=gt:0.0.6000&token.id=lt:0.0.6458",
         "asc,   lt:0.0.2000,   gt:0.0.100,  gt:0.0.6000, lt:0.0.7000,  /api?order=asc&account.id=lt:0.0.2000&account.id=gte:0.0.1000&token.id=lt:0.0.7000&token.id=gt:0.0.6458",
         "desc,  lt:0.0.2000,   gt:0.0.100,  gt:0.0.6000, lt:0.0.7000,  /api?order=desc&account.id=gt:0.0.100&account.id=lte:0.0.1000&token.id=gt:0.0.6000&token.id=lt:0.0.6458",
-        "asc,      0.0.1000,     0.0.1000,     0.0.1000,    0.0.1000,  /api?order=asc&account.id=0.0.1000&token.id=0.0.1000",
-        "desc,     0.0.1000,     0.0.1000,     0.0.1000,    0.0.1000,  /api?order=desc&account.id=0.0.1000&token.id=0.0.1000",
         "asc,      0.0.1000,  gt:0.0.1000, lte:0.0.7000, gt:0.0.6000,  /api?order=asc&account.id=0.0.1000&token.id=lte:0.0.7000&token.id=gt:0.0.6458",
-        "desc,     0.0.1000,  gt:0.0.1000, lte:0.0.7000, gt:0.0.6000,  /api?order=desc&account.id=0.0.1000&token.id=gt:0.0.6000&token.id=lt:0.0.6458",
+        "desc,     0.0.1000,  gt:0.0.1000, lte:0.0.7000, gt:0.0.6000,  /api?order=desc&account.id=0.0.1000&account.id=gt:0.0.1000&token.id=gt:0.0.6000&token.id=lt:0.0.6458",
     })
     void testMultipleParameters(
             String order,

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/common/LinkFactoryTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/common/LinkFactoryTest.java
@@ -157,7 +157,7 @@ class LinkFactoryTest {
                         List.of(transaction),
                         PageRequest.ofSize(1),
                         t -> Map.of("timestamp", t.getConsensusTimestamp())))
-                .returns("/api?timestamp=gt:123456789.000000123", Links::getNext);
+                .returns("/api?timestamp=123456789.000000123", Links::getNext);
     }
 
     @DisplayName("Get pagination links unknown parameter")

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/common/LinkFactoryTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/common/LinkFactoryTest.java
@@ -88,15 +88,18 @@ class LinkFactoryTest {
     @DisplayName("Get pagination links for all query parameters")
     @ParameterizedTest
     @CsvSource({
-        "1, ASC,  eq:0.0.1000, eq:0.0.1000, false, /api?limit=1&order=ASC&account.id=eq:0.0.1000&account.id=gte:0.0.1000&token.id=eq:0.0.1000&token.id=gt:0.0.6458&owner=false",
-        "1, asc,  lt:0.0.2000, 0.0.1000,    false, /api?limit=1&order=asc&account.id=lt:0.0.2000&account.id=gte:0.0.1000&token.id=0.0.1000&token.id=gt:0.0.6458&owner=false",
-        "1, DESC, 0.0.1000,    0.0.1000,    false, /api?limit=1&order=DESC&account.id=0.0.1000&account.id=lte:0.0.1000&token.id=0.0.1000&token.id=lt:0.0.6458&owner=false",
+        "1, ASC,  eq:0.0.1000, eq:0.0.1000, false, /api?limit=1&order=ASC&account.id=eq:0.0.1000&token.id=eq:0.0.1000&owner=false",
+        "1, asc,  lt:0.0.2000, 0.0.1000,    false, /api?limit=1&order=asc&account.id=lt:0.0.2000&account.id=gt:0.0.1000&token.id=0.0.1000&owner=false",
+        "1, DESC, 0.0.1000,    0.0.1000,    false, /api?limit=1&order=DESC&account.id=0.0.1000&token.id=0.0.1000&owner=false",
         "1, desc, gt:0.0.900,  gt:0.0.900,  false, /api?limit=1&order=desc&account.id=gt:0.0.900&account.id=lte:0.0.1000&token.id=gt:0.0.900&token.id=lt:0.0.6458&owner=false",
-        "1, desc, gt:0.0.900, gte:0.0.900, false,  /api?limit=1&order=desc&account.id=gt:0.0.900&account.id=lte:0.0.1000&token.id=gte:0.0.900&token.id=lt:0.0.6458&owner=false",
+        "1, desc, gt:0.0.900, gte:0.0.900,  false,  /api?limit=1&order=desc&account.id=gt:0.0.900&account.id=lte:0.0.1000&token.id=gte:0.0.900&token.id=lt:0.0.6458&owner=false",
         "1, desc, lt:0.0.9000, gte:0.0.900, false, /api?limit=1&order=desc&token.id=gte:0.0.900&token.id=lt:0.0.6458&owner=false&account.id=lte:0.0.1000",
         "1, desc, lt:0.0.9000, gte:0.0.900, true,  /api?limit=1&order=desc&token.id=gte:0.0.900&token.id=lt:0.0.6458&owner=true&account.id=lte:0.0.2000",
         "2, ASC,  0.0.1000,    0.0.1000, false,",
         "2, desc, 0.0.1000,    0.0.1000, false,",
+        "1, asc,  gte:0.0.2000, 0.0.1000,   false, /api?limit=1&order=asc&token.id=0.0.1000&owner=false&account.id=gt:0.0.1000",
+        "1, desc, gte:0.0.2000, 0.0.1000,   false, /api?limit=1&order=desc&account.id=gte:0.0.2000&account.id=lt:0.0.1000&token.id=0.0.1000&owner=false",
+        "1, desc, 0.0.2000, gte:0.0.1000,   false, /api?limit=1&order=desc&account.id=0.0.2000&token.id=gte:0.0.1000&token.id=lt:0.0.6458&owner=false",
     })
     void testAllQueryParameters(
             String limit,
@@ -128,7 +131,7 @@ class LinkFactoryTest {
     @DisplayName("Get pagination links with no primary sort")
     @ParameterizedTest
     @CsvSource({
-        "0.0.1000,    0.0.1000,    /api?limit=1&account.id=0.0.1000&account.id=gte:0.0.1000&token.id=0.0.1000&token.id=gt:0.0.6458",
+        "0.0.1000,    0.0.1000,    /api?limit=1&account.id=0.0.1000&token.id=0.0.1000",
         "lt:0.0.9000, gte:0.0.900, /api?limit=1&account.id=lt:0.0.9000&account.id=gte:0.0.1000&token.id=gt:0.0.6458",
     })
     void testNoPrimarySort(String accountParameter, String tokenParameter, String expectedLink) {
@@ -170,7 +173,7 @@ class LinkFactoryTest {
 
         assertThat(linkFactory.create(List.of(nftAllowance), pageable, extractor))
                 .returns(
-                        "/api?limit=1&account.id=0.0.1000&account.id=gte:0.0.1000&unknown=value&unknown=value2&token.id=gt:0.0.6458",
+                        "/api?limit=1&account.id=0.0.1000&unknown=value&unknown=value2&token.id=gt:0.0.6458",
                         Links::getNext);
     }
 
@@ -183,10 +186,10 @@ class LinkFactoryTest {
         "desc,   gt:0.0.100,  gte:0.0.100, lte:0.0.7000, gt:0.0.6000,  /api?order=desc&account.id=gt:0.0.100&account.id=gte:0.0.100&account.id=lte:0.0.1000&token.id=gt:0.0.6000&token.id=lt:0.0.6458",
         "asc,   lt:0.0.2000,   gt:0.0.100,  gt:0.0.6000, lt:0.0.7000,  /api?order=asc&account.id=lt:0.0.2000&account.id=gte:0.0.1000&token.id=lt:0.0.7000&token.id=gt:0.0.6458",
         "desc,  lt:0.0.2000,   gt:0.0.100,  gt:0.0.6000, lt:0.0.7000,  /api?order=desc&account.id=gt:0.0.100&account.id=lte:0.0.1000&token.id=gt:0.0.6000&token.id=lt:0.0.6458",
-        "asc,      0.0.1000,     0.0.1000,     0.0.1000,    0.0.1000,  /api?order=asc&account.id=0.0.1000&account.id=0.0.1000&account.id=gte:0.0.1000&token.id=0.0.1000&token.id=0.0.1000&token.id=gt:0.0.6458",
-        "desc,     0.0.1000,     0.0.1000,     0.0.1000,    0.0.1000,  /api?order=desc&account.id=0.0.1000&account.id=0.0.1000&account.id=lte:0.0.1000&token.id=0.0.1000&token.id=0.0.1000&token.id=lt:0.0.6458",
-        "asc,      0.0.1000,  gt:0.0.1000, lte:0.0.7000, gt:0.0.6000,  /api?order=asc&account.id=0.0.1000&account.id=gte:0.0.1000&token.id=lte:0.0.7000&token.id=gt:0.0.6458",
-        "desc,     0.0.1000,  gt:0.0.1000, lte:0.0.7000, gt:0.0.6000,  /api?order=desc&account.id=0.0.1000&account.id=gt:0.0.1000&account.id=lte:0.0.1000&token.id=gt:0.0.6000&token.id=lt:0.0.6458",
+        "asc,      0.0.1000,     0.0.1000,     0.0.1000,    0.0.1000,  /api?order=asc&account.id=0.0.1000&token.id=0.0.1000",
+        "desc,     0.0.1000,     0.0.1000,     0.0.1000,    0.0.1000,  /api?order=desc&account.id=0.0.1000&token.id=0.0.1000",
+        "asc,      0.0.1000,  gt:0.0.1000, lte:0.0.7000, gt:0.0.6000,  /api?order=asc&account.id=0.0.1000&token.id=lte:0.0.7000&token.id=gt:0.0.6458",
+        "desc,     0.0.1000,  gt:0.0.1000, lte:0.0.7000, gt:0.0.6000,  /api?order=desc&account.id=0.0.1000&token.id=gt:0.0.6000&token.id=lt:0.0.6458",
     })
     void testMultipleParameters(
             String order,

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/AllowancesControllerTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/AllowancesControllerTest.java
@@ -269,13 +269,11 @@ class AllowancesControllerTest extends ControllerTest {
                     .customize(nfta -> nfta.owner(allowance1.getOwner()).approvedForAll(true))
                     .persist();
             var uriParams = "?account.id={account.id}&limit=1&order=asc";
-            var nextLink =
-                    "/api/v1/accounts/%s/allowances/nfts?account.id=%s&account.id=gte:%s&limit=1&order=asc&token.id=gt:%s"
-                            .formatted(
-                                    allowance2.getOwner(),
-                                    EntityId.of(allowance2.getSpender()),
-                                    EntityId.of(allowance2.getSpender()),
-                                    EntityId.of(allowance2.getTokenId()));
+            var nextLink = "/api/v1/accounts/%s/allowances/nfts?account.id=%s&limit=1&order=asc&token.id=gt:%s"
+                    .formatted(
+                            allowance2.getOwner(),
+                            EntityId.of(allowance2.getSpender()),
+                            EntityId.of(allowance2.getTokenId()));
 
             // When
             var result = restClient
@@ -489,6 +487,54 @@ class AllowancesControllerTest extends ControllerTest {
 
             // Then
             assertThat(result).isEqualTo(getExpectedResponse(List.of(allowance2, allowance1), next));
+        }
+
+        @Test
+        void succeedingExclusiveLink() {
+            // Given
+            var entityBuilder = domainBuilder.entity();
+            var entity = entityBuilder.persist();
+            var allowance1 = domainBuilder
+                    .nftAllowance()
+                    .customize(nfta -> nfta.owner(entity.getId())
+                            .spender(99700)
+                            .tokenId(99800)
+                            .approvedForAll(true))
+                    .persist();
+            var allowance2 = domainBuilder
+                    .nftAllowance()
+                    .customize(nfta -> nfta.owner(allowance1.getOwner())
+                            .spender(99701)
+                            .tokenId(99800)
+                            .approvedForAll(true))
+                    .persist();
+            var allowance3 = domainBuilder
+                    .nftAllowance()
+                    .customize(nfta -> nfta.owner(allowance1.getOwner())
+                            .spender(99702)
+                            .tokenId(99800)
+                            .approvedForAll(true))
+                    .persist();
+
+            var uri = "?limit=2&account.id=gte:0.0.99700&token.id=0.0.99800";
+            var result =
+                    restClient.get().uri(uri, allowance1.getOwner()).retrieve().body(NftAllowancesResponse.class);
+            var nextLinkQueryParameters = "?limit=2&token.id=0.0.99800&account.id=gt:0.0.99701";
+            var expectedLink =
+                    "/api/v1/accounts/%s/allowances/nfts".formatted(allowance1.getOwner()) + nextLinkQueryParameters;
+
+            // Then
+            assertThat(result).isEqualTo(getExpectedResponse(List.of(allowance1, allowance2), expectedLink));
+
+            // When follow link
+            result = restClient
+                    .get()
+                    .uri(nextLinkQueryParameters, allowance1.getOwner())
+                    .retrieve()
+                    .body(NftAllowancesResponse.class);
+
+            // Then
+            assertThat(result).isEqualTo(getExpectedResponse(List.of(allowance3), null));
         }
 
         private NftAllowancesResponse getExpectedResponse(List<NftAllowance> nftAllowances, String next) {

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/AllowancesControllerTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/AllowancesControllerTest.java
@@ -111,6 +111,8 @@ class AllowancesControllerTest extends ControllerTest {
             // Then
             assertThat(result).isEqualTo(getExpectedResponse(List.of(allowance1), baseLink + nextParams));
 
+            System.out.println("Next params: " + nextParams);
+
             // When follow link
             result = restClient
                     .get()


### PR DESCRIPTION
**Description**:

Fixes the next link generation and corrects the succeeding query parameter operators.

**Related issue(s)**:

Fixes #8407

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
