### PR TITLE
Disable contract call js monitor endpoint

### DIFF
--- a/hedera-mirror-rest/monitoring/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/config/default.serverlist.json
@@ -40,6 +40,7 @@
   "contract": {
     "contractId": "",
     "enabled": true,
+    "contractCallEnabled": false,
     "intervalMultiplier": 1,
     "limit": 2
   },

--- a/hedera-mirror-rest/monitoring/contracts_tests.js
+++ b/hedera-mirror-rest/monitoring/contracts_tests.js
@@ -33,6 +33,7 @@ import {
 const contractsPath = '/contracts';
 const resource = 'contract';
 const resourceLimit = config[resource].limit || DEFAULT_LIMIT;
+const contractCallEnabled = config[resource].contractCallEnabled;
 const jsonRespKey = 'contracts';
 const jsonResultsRespKey = 'results';
 const mandatoryParams = [
@@ -401,7 +402,7 @@ const runTests = async (server, testResult) => {
   const runTest = testRunner(server, testResult, resource);
   return Promise.all([
     runTest(getContractById),
-    runTest(postContractCall),
+    contractCallEnabled ? runTest(postContractCall) : '',
     runTest(getContractResults),
     runTest(getContractResultsLogs),
     runTest(getContractState),


### PR DESCRIPTION
**Description**:
This PR disables the contract call js monitor endpoint based on config.

This PR 
* Sets `contractCallEnabled` config value to false and disables contract call js monitor endpoint.


**Related issue(s)**:

The config can be set to true after #8508 is fixed.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
