### PR TITLE
Suppress recoverable error for inactive evm addresses

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
@@ -103,7 +103,7 @@ public class ContractResultServiceImpl implements ContractResultService {
                         && transactionRecord.getReceipt().getContractID().hasEvmAddress())
                 && EntityId.isEmpty(contractId)
                 && !contractCallOrCreate
-                && (!ContractID.getDefaultInstance().equals(functionResult.getContractID()));
+                && !ContractID.getDefaultInstance().equals(functionResult.getContractID());
         if (isRecoverableError) {
             Utility.handleRecoverableError(
                     "Invalid contract id for contract result at {}", recordItem.getConsensusTimestamp());

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/ContractResultServiceImpl.java
@@ -44,7 +44,6 @@ import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionBody;
-import com.hederahashgraph.api.proto.java.TransactionRecord;
 import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +88,8 @@ public class ContractResultServiceImpl implements ContractResultService {
 
         // contractResult
         var transactionHandler = transactionHandlerFactory.get(TransactionType.of(transaction.getType()));
-        var throwRecoverableError = shouldThrowRecoverableError(functionResult, recordItem, transactionRecord);
+        var throwRecoverableError = !(recordItem.isSuccessful()
+                && (transactionRecord.getReceipt().getContractID().hasEvmAddress()));
         // in pre-compile case transaction is not a contract type and entityId will be of a different type
         var contractId = (contractCallOrCreate
                         ? Optional.ofNullable(transaction.getEntityId())
@@ -150,13 +150,6 @@ public class ContractResultServiceImpl implements ContractResultService {
 
     private boolean isContractCreateOrCall(TransactionBody transactionBody) {
         return transactionBody.hasContractCall() || transactionBody.hasContractCreateInstance();
-    }
-
-    private boolean shouldThrowRecoverableError(
-            ContractFunctionResult functionResult, RecordItem recordItem, TransactionRecord transactionRecord) {
-        return !(recordItem.isSuccessful()
-                && (transactionRecord.getReceipt().getContractID().hasEvmAddress()
-                        || functionResult.getContractID().hasEvmAddress()));
     }
 
     private void processContractAction(ContractAction action, int index, RecordItem recordItem) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdService.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/domain/EntityIdService.java
@@ -54,6 +54,15 @@ public interface EntityIdService {
     Optional<EntityId> lookup(ContractID contractId);
 
     /**
+     * Converts a protobuf ContractID to an EntityID, resolving any EVM addresses that may be present.
+     *
+     * @param contractId The protobuf contract ID
+     * @param throwRecoverableError If true, will throw a recoverable error if an EVM address cannot be found.
+     * @return An optional of the converted EntityId if it can be resolved, or EntityId.EMPTY if none can be resolved.
+     */
+    Optional<EntityId> lookup(ContractID contractId, boolean throwRecoverableError);
+
+    /**
      * Specialized form of lookup(ContractID) that returns the first contract ID parameter that resolves to a non-empty
      * EntityId.
      *

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplTest.java
@@ -114,15 +114,15 @@ class ContractResultServiceImplTest {
         return Stream.of(
                 Arguments.of(withoutDefaultContractId, null, true),
                 Arguments.of(withoutDefaultContractId, EntityId.EMPTY, true),
-                Arguments.of(withInactiveEvm, null, false),
-                Arguments.of(withInactiveEvm, EntityId.EMPTY, false),
-                Arguments.of(withActiveEvm, null, true),
-                Arguments.of(withActiveEvm, EntityId.EMPTY, true),
                 Arguments.of(withDefaultContractId, null, false),
                 Arguments.of(withDefaultContractId, EntityId.EMPTY, false),
                 Arguments.of(contractCreate, EntityId.EMPTY, false),
                 Arguments.of(contractCreate, null, false),
-                Arguments.of(contractCreate, EntityId.of(0, 0, 5), false));
+                Arguments.of(contractCreate, EntityId.of(0, 0, 5), false),
+                Arguments.of(withInactiveEvm, null, false),
+                Arguments.of(withInactiveEvm, EntityId.EMPTY, false),
+                Arguments.of(withActiveEvm, null, true),
+                Arguments.of(withActiveEvm, EntityId.EMPTY, true));
     }
 
     @BeforeEach

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplTest.java
@@ -92,20 +92,12 @@ class ContractResultServiceImplTest {
                         .record(x -> x.setContractCallResult(builder.contractFunctionResult()))
                         .build();
 
-        var contractId = ContractID.newBuilder()
+        var contractIdWithEvm = ContractID.newBuilder()
                 .setEvmAddress(ByteString.copyFromUtf8("1234"))
                 .build();
         Function<RecordItemBuilder, RecordItem> withInactiveEvm =
                 (RecordItemBuilder builder) -> builder.tokenMint(TokenType.FUNGIBLE_COMMON)
-                        .receipt(x -> x.setContractID(contractId))
-                        .record(x -> x.setContractCallResult(builder.contractFunctionResult()))
-                        .build();
-
-        var contractIdNoEvm = ContractID.newBuilder().setContractNum(5).build();
-        Function<RecordItemBuilder, RecordItem> withActiveEvm =
-                (RecordItemBuilder builder) -> builder.tokenMint(TokenType.FUNGIBLE_COMMON)
-                        .receipt(x -> x.setContractID(contractIdNoEvm))
-                        .record(x -> x.setContractCallResult(builder.contractFunctionResult(contractIdNoEvm)))
+                        .record(x -> x.setContractCallResult(builder.contractFunctionResult(contractIdWithEvm)))
                         .build();
 
         Function<RecordItemBuilder, RecordItem> contractCreate =
@@ -120,9 +112,7 @@ class ContractResultServiceImplTest {
                 Arguments.of(contractCreate, null, false),
                 Arguments.of(contractCreate, EntityId.of(0, 0, 5), false),
                 Arguments.of(withInactiveEvm, null, false),
-                Arguments.of(withInactiveEvm, EntityId.EMPTY, false),
-                Arguments.of(withActiveEvm, null, true),
-                Arguments.of(withActiveEvm, EntityId.EMPTY, true));
+                Arguments.of(withInactiveEvm, EntityId.EMPTY, false));
     }
 
     @BeforeEach


### PR DESCRIPTION
**Description**:
Suppresses recoverable errors when unable to lookup an entity id for an inactive evm address.

**Related issue(s)**:

Fixes #8290

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
