### PR TITLE
Deploy 0.106.1 to staging-lg.

### DIFF
--- a/clusters/preprod/staging-lg/helmrelease.yaml
+++ b/clusters/preprod/staging-lg/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       valuesFiles:
         - values.yaml
         - values-prod.yaml
-      version: '0.105.0'
+      version: '0.106.1'
   dependsOn:
     - name: mirror
       namespace: common


### PR DESCRIPTION
**Description**:

Post mainnet update of staging-lg for 0.106.1. The preprod common chart is already up to date.

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
