### PR TITLE
Disable REST monitor stateproof test in testnet-eu.

### DIFF
--- a/clusters/testnet-eu/testnet/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet/helmrelease.yaml
@@ -61,6 +61,17 @@ spec:
       enabled: false
     rest:
       enabled: true
+      monitor:
+        config: |-
+          {
+            "servers": [
+              {
+                "baseUrl": "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}",
+                "name": "kubernetes"
+              }
+            ],
+            "stateproof": { "enabled": false }
+          }
     restjava:
       enabled: true
     rosetta:


### PR DESCRIPTION
**Description**:

Disable REST monitor stateproof test in testnet-eu. Not yet citus.

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
