### PR TITLE
Automate multi-cluster deployment PRs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,71 @@
+name: Deploy
+
+on:
+  repository_dispatch:
+    types:
+      - HelmRelease/mirror.*
+
+permissions:
+  contents: write
+  pull-requests: write
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  LC_ALL: C.UTF-8
+
+jobs:
+  promote:
+    name: Deploy
+    runs-on: [self-hosted, linux, large, ephemeral]
+    if: github.event.client_payload.severity == 'info'
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout Repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          ref: deploy
+          token: ${{ secrets.HEDERA_BOT_TOKEN }}
+
+      - name: Get chart version
+        id: release
+        run: |
+          VERSION=$(echo ${{ github.event.client_payload.metadata.revision }} | cut -d '+' -f1)
+          echo VERSION=${VERSION} >> $GITHUB_OUTPUT
+
+      - name: Set chart version in HelmRelease
+        env:
+          CHART_PATH: ${{ github.event.client_payload.metadata.path }}
+          CHART_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          echo "Setting HelmRelease ${CHART_PATH} to ${CHART_VERSION}"
+          yq eval '.spec.chart.spec.version=env(CHART_VERSION)' -i ./clusters/${CHART_PATH}/helmrelease.yaml
+
+      - name: Import GPG Key
+        id: gpg_importer
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        with:
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          git_user_signingkey: true
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Open deployment PR
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
+        with:
+          author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
+          body: Deploy v${{ steps.release.outputs.version }} to ${{ github.event.client_payload.metadata.path }}
+          branch: deploy-${{ github.event.client_payload.metadata.path }}-${{ steps.release.outputs.version }}
+          commit-message: Deploy v${{ steps.release.outputs.version }} to ${{ github.event.client_payload.metadata.path }}
+          committer: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
+          delete-branch: true
+          signoff: true
+          title: Deploy v${{ steps.release.outputs.version }} to ${{ github.event.client_payload.metadata.path }}
+          token: ${{ secrets.HEDERA_BOT_TOKEN }}

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -191,11 +191,11 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         with:
-          body: ""
+          author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
+          body: Bump versions for v${{ env.NEXT_VERSION_SNAPSHOT }}
           branch: create-pull-request/${{ env.RELEASE_BRANCH }}
           commit-message: Bump versions for v${{ env.NEXT_VERSION_SNAPSHOT }}
           committer: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
-          author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
           delete-branch: true
           signoff: true
           title: ${{ needs.release.outputs.pr_title }}

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -105,6 +105,17 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: deploy
+          token: ${{ secrets.HEDERA_BOT_TOKEN }}
+
+      - name: Import GPG Key
+        id: gpg_importer
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        with:
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          git_user_signingkey: true
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Update integration deployment configuration
         run: 'sed -i "s/git.commit: .*/git.commit: ${GITHUB_SHA}/" clusters/preprod/integration/helmrelease.yaml'
@@ -112,4 +123,8 @@ jobs:
       - name: Auto-Commit
         uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
         with:
+          commit_author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
           commit_message: Upgrade integration to main ${{ github.sha }}
+          commit_options: "--no-verify --signoff"
+          commit_user_email: ${{ steps.gpg_importer.outputs.email }}
+          commit_user_name: ${{ steps.gpg_importer.outputs.name }}


### PR DESCRIPTION
**Description**:

* Add a deploy workflow that gets triggered via Flux repository dispatch alerts
* Add a PR body to bump version PR
* Change release integration committer from anonymous to the hedera-github-bot
* Change release integration to GPG sign and signoff commits

**Related issue(s)**:

Fixes #8514

**Notes for reviewer**:

Action run: https://github.com/steven-sheehy/hedera-mirror-node/actions/runs/9529128873
Deploy PR example: https://github.com/steven-sheehy/hedera-mirror-node/pull/755
Example of corresponding deploy branch changes: https://github.com/hashgraph/hedera-mirror-node/pull/8556

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
