### PR TITLE
Fix inconsistent balance results with tokens REST API (0.107)

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/balances/column-ordering.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/balances/column-ordering.json
@@ -1,0 +1,68 @@
+{
+  "description": "Tests the fix for v2 ordering is incorrect if column names collide",
+  "extendedDescription": [
+    "This demonstrates the fix for issue 8359. If `snapshot_timestamp` is reverted to `consensus_timestamp` the bug ",
+    "from 8359 will be recreated when testing against v2"
+  ],
+  "setup": {
+    "tokens": [
+      {
+        "token_id": "0.20.1",
+        "symbol": "TOKEN1",
+        "created_timestamp": "1234567890000000001",
+        "decimals": 1,
+        "type": "FUNGIBLE_COMMON"
+      }
+    ],
+    "balances": [
+      {
+        "timestamp": 1566560003000000000,
+        "id": 2,
+        "balance": 21
+      },
+      {
+        "timestamp": 1566560002000000999,
+        "id": 6,
+        "balance": 1,
+        "tokens": [
+          {
+            "token_realm": 20,
+            "token_num": 1,
+            "balance": 7
+          }
+        ]
+      },
+      {
+        "timestamp": 1566560003000000000,
+        "id": 6,
+        "balance": 1,
+        "tokens": [
+          {
+            "token_realm": 20,
+            "token_num": 1,
+            "balance": 6
+          }
+        ]
+      }
+    ]
+  },
+  "tests": [
+    {
+      "url": "/api/v1/tokens/0.20.1/balances?account.id=6&timestamp=1566560003.000000000",
+      "responseStatus": 200,
+      "responseJson": {
+        "timestamp": "1566560003.000000000",
+        "balances": [
+          {
+            "account": "0.0.6",
+            "balance": 6,
+            "decimals": 1
+          }
+        ],
+        "links": {
+          "next": null
+        }
+      }
+    }
+  ]
+}

--- a/hedera-mirror-rest/tokens.js
+++ b/hedera-mirror-rest/tokens.js
@@ -596,7 +596,7 @@ const extractSqlFromTokenBalancesRequest = async (tokenId, filters) => {
         distinct on (ti.account_id)
         ti.account_id,
         ti.balance,
-        $${params.length}::bigint as consensus_timestamp
+        $${params.length}::bigint as snapshot_timestamp
       from token_balance as ti
       ${joinEntityClause}
       where ${conditions.join(' and ')}
@@ -672,7 +672,8 @@ const getTokenBalances = async (req, res) => {
     const cachedTokens = await TokenService.getCachedTokens(new Set([tokenId]));
     const decimals = cachedTokens.get(tokenId)?.decimals ?? null;
     response.balances = rows.map((row) => formatTokenBalanceRow(row, decimals));
-    response.timestamp = utils.nsToSecNs(rows[0].consensus_timestamp);
+    const timestamp = rows[0].consensus_timestamp ?? rows[0].snapshot_timestamp;
+    response.timestamp = utils.nsToSecNs(timestamp);
 
     const anchorAccountId = response.balances[response.balances.length - 1].account;
     response.links.next = utils.getPaginationLink(


### PR DESCRIPTION
**Description**:
Fixes a token balances query that produced inconsistent balance results with Citus. (0.107)

**Related issue(s)**:

Fixes #8395 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
