### PR TITLE
8508 monitor api failures kubernetes

### DIFF
--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -105,6 +105,8 @@ monitor:
       "servers": [
         {
           "baseUrl": "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}",
+          "restJavaUrl": "http://{{ .Release.Name }}-restjava:{{ .Values.service.port }}",
+          "web3Url": "http://{{ .Release.Name }}-web3:{{ .Values.service.port }}",
           "name": "kubernetes"
         }
      ]

--- a/hedera-mirror-rest/monitoring/common.js
+++ b/hedera-mirror-rest/monitoring/common.js
@@ -85,10 +85,8 @@ const filterTestDetails = (result, resultType = TEST_RESULT_TYPES.FAILED) => {
  */
 const getStatus = (resultType) => {
   const results = Object.values(currentResults).map((result) => filterTestDetails(result, resultType));
-  const httpErrorCodes = results
-    .map((result) => result.httpCode)
-    .filter((httpCode) => httpCode < 200 || httpCode > 299);
-  const httpCode = httpErrorCodes.length === 0 ? 200 : 409;
+  const successfulTests = results.map((result) => result.results.success).filter((success) => success === true);
+  const httpCode = successfulTests.length === results.length ? 200 : 409;
 
   return {
     results,

--- a/hedera-mirror-rest/monitoring/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/config/default.serverlist.json
@@ -3,6 +3,8 @@
   "servers": [
     {
       "baseUrl": "http://127.0.0.1:5551",
+      "restJavaUrl": "http://127.0.0.1:8084",
+      "web3Url": "http://127.0.0.1:8545",
       "name": "local"
     }
   ],

--- a/hedera-mirror-rest/monitoring/contracts_tests.js
+++ b/hedera-mirror-rest/monitoring/contracts_tests.js
@@ -402,7 +402,7 @@ const runTests = async (server, testResult) => {
   const runTest = testRunner(server, testResult, resource);
   return Promise.all([
     runTest(getContractById),
-    contractCallEnabled ? runTest(postContractCall) : '',
+    contractCallEnabled ? runTest(postContractCall, 'WEB3') : '',
     runTest(getContractResults),
     runTest(getContractResultsLogs),
     runTest(getContractState),

--- a/hedera-mirror-rest/monitoring/token_tests.js
+++ b/hedera-mirror-rest/monitoring/token_tests.js
@@ -474,6 +474,14 @@ const getTokenNfts = async (server) => {
     return {url, ...nftsResult};
   }
 
+  if (!nfts.length) {
+    return {
+      url,
+      passed: true,
+      message: 'Successfully called token nfts with empty list',
+    };
+  }
+
   const serialNumber = nfts.response[0].serial_number;
   url = getUrl(server, tokenNftsPath + `/${serialNumber}`);
 

--- a/hedera-mirror-rest/monitoring/topic_tests.js
+++ b/hedera-mirror-rest/monitoring/topic_tests.js
@@ -354,7 +354,7 @@ const runTests = async (server, testResult) => {
 
   const runTest = testRunner(server, testResult, resource);
   return Promise.all([
-    runTest(getTopicById),
+    runTest(getTopicById, 'REST_JAVA'),
     runTest(getTopicMessages),
     runTest(getTopicMessagesBySequenceNumberFilter),
     runTest(getTopicMessagesByTopicIDAndSequenceNumberPath),

--- a/hedera-mirror-rest/monitoring/utils.js
+++ b/hedera-mirror-rest/monitoring/utils.js
@@ -283,6 +283,10 @@ const checkEntityId = (elements, option) => {
 };
 
 const checkMandatoryParams = (elements, option) => {
+  if (elements.length == 0) {
+    return {passed: true};
+  }
+
   const element = Array.isArray(elements) ? elements[0] : elements;
   const {params, message} = option;
   for (let index = 0; index < params.length; index += 1) {

--- a/hedera-mirror-rest/monitoring/utils.js
+++ b/hedera-mirror-rest/monitoring/utils.js
@@ -195,9 +195,22 @@ const hasEmptyList = (jsonRespKey) => (res) => !res.hasOwnProperty(jsonRespKey) 
  * @return {function(...[*]=)}
  */
 const testRunner = (server, testClassResult, resource) => {
-  return async (testFunc) => {
+  return async (testFunc, type = undefined) => {
     const start = Date.now();
-    const result = await testFunc(server.baseUrl);
+    // Default url here is the REST url
+    let url = server.baseUrl;
+    switch (type) {
+      case 'REST_JAVA':
+        url = server.restJavaUrl;
+        break;
+      case 'WEB3':
+        url = server.web3Url;
+        break;
+      default:
+        break;
+    }
+
+    const result = await testFunc(url);
     if (result.skipped) {
       return;
     }
@@ -283,7 +296,7 @@ const checkEntityId = (elements, option) => {
 };
 
 const checkMandatoryParams = (elements, option) => {
-  if (elements.length == 0) {
+  if (elements.length === 0) {
     return {passed: true};
   }
 


### PR DESCRIPTION
**Description**:
This PR fixes the JavaScript REST API monitor that has a number of persistent failures when ran inside Kubernetes.

This PR modifies 
* Add  a route to REST JAVA APIs
* Add a route to Web3 APIs
* Add automatic default account for some endpoints resulting in `/api/v1/accounts//`
* `/api/v1/status` returns 409 even when there are failures
* Fix token_tests to check for non_empty list returned by `tokens/{tokenId}/nfts` which is further used to get `serial_number`


**Related issue(s)**:

Fixes #8508

**Notes for reviewer**:
Testing in important clusters is still in progress.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
