### PR TITLE
Enable testnet-citus in testnet-eu cluster

### DIFF
--- a/clusters/testnet-eu/testnet-citus/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet-citus/helmrelease.yaml
@@ -37,7 +37,8 @@ spec:
     global:
       hostname: "*.mirrornode.hedera.com"
     grpc:
-      enabled: false
+      ingress:
+        enabled: false
     importer:
       env:
         HEDERA_MIRROR_IMPORTER_NETWORK: "TESTNET"
@@ -57,9 +58,11 @@ spec:
         MonitorSubscribeLatency:
           enabled: false
     rest:
-      enabled: false
+      ingress:
+        enabled: false
     restjava:
-      enabled: false
+      ingress:
+        enabled: false
     rosetta:
       env:
         HEDERA_MIRROR_ROSETTA_NETWORK: "testnet"
@@ -69,6 +72,6 @@ spec:
           size: 900Gi
     test:
       cucumberTags: "@acceptance and not @equivalence and not @historical and not @estimateprecompile"
-      enabled: false
     web3:
-      enabled: false
+      ingress:
+        enabled: false

--- a/clusters/testnet-eu/testnet-citus/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet-citus/helmrelease.yaml
@@ -72,6 +72,7 @@ spec:
           size: 900Gi
     test:
       cucumberTags: "@acceptance and not @equivalence and not @historical and not @estimateprecompile"
+      enabled: true
     web3:
       ingress:
         enabled: false


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR enables testnet-citus API modules and test. Note: ingresses and monitor are still disabled. Will enable them and disable `testnet` in testnet-eu in a follow-up PR once acceptance tests pass.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
