### PR TITLE
Route traffic to testnet-citus in testnet-eu

### DIFF
--- a/clusters/testnet-eu/testnet-citus/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet-citus/helmrelease.yaml
@@ -36,16 +36,12 @@ spec:
   values:
     global:
       hostname: "*.mirrornode.hedera.com"
-    grpc:
-      ingress:
-        enabled: false
     importer:
       env:
         HEDERA_MIRROR_IMPORTER_NETWORK: "TESTNET"
         HEDERA_MIRROR_IMPORTER_PARSER_RECORD_SIDECAR_ENABLED: "true"
         HEDERA_MIRROR_IMPORTER_START_DATE: "1970-01-01T00:00:00.000000000Z"
     monitor:
-      enabled: false
       env:
         HEDERA_MIRROR_MONITOR_HEALTH_RELEASE_ENABLED: "true"
         HEDERA_MIRROR_MONITOR_NETWORK: "TESTNET"
@@ -58,11 +54,17 @@ spec:
         MonitorSubscribeLatency:
           enabled: false
     rest:
-      ingress:
-        enabled: false
-    restjava:
-      ingress:
-        enabled: false
+      monitor:
+        config: |-
+          {
+            "servers": [
+              {
+                "baseUrl": "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}",
+                "name": "kubernetes"
+              }
+            ],
+            "stateproof": { "enabled": false }
+          }
     rosetta:
       env:
         HEDERA_MIRROR_ROSETTA_NETWORK: "testnet"
@@ -73,6 +75,3 @@ spec:
     test:
       cucumberTags: "@acceptance and not @equivalence and not @historical and not @estimateprecompile"
       enabled: true
-    web3:
-      ingress:
-        enabled: false

--- a/clusters/testnet-eu/testnet/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet/helmrelease.yaml
@@ -36,14 +36,14 @@ spec:
     global:
       hostname: "*.mirrornode.hedera.com"
     grpc:
-      enabled: true
+      enabled: false
     importer:
       env:
         HEDERA_MIRROR_IMPORTER_NETWORK: "TESTNET"
         HEDERA_MIRROR_IMPORTER_PARSER_RECORD_SIDECAR_ENABLED: "true"
         HEDERA_MIRROR_IMPORTER_START_DATE: "1970-01-01T00:00:00.000000000Z"
     monitor:
-      enabled: true
+      enabled: false
       env:
         HEDERA_MIRROR_MONITOR_HEALTH_RELEASE_ENABLED: "true"
         HEDERA_MIRROR_MONITOR_NETWORK: "TESTNET"
@@ -60,7 +60,7 @@ spec:
     redis:
       enabled: false
     rest:
-      enabled: true
+      enabled: false
       monitor:
         config: |-
           {
@@ -73,12 +73,12 @@ spec:
             "stateproof": { "enabled": false }
           }
     restjava:
-      enabled: true
+      enabled: false
     rosetta:
       env:
         HEDERA_MIRROR_ROSETTA_NETWORK: "testnet"
     test:
       cucumberTags: "@acceptance and not @equivalence and not @estimateprecompile"
-      enabled: true
+      enabled: false
     web3:
-      enabled: true
+      enabled: false


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR changes deployment for testnet-eu cluster to route traffic to testnet-citus API modules

- Disable monitor and all API components in `testnet` namespace
- Leave importer in `testnet` namespace up to switch back easily if needed
- Enable ingresses and monitor in `testnet-citus`
- Disable rest monitor stateproof test in `testnet-citus`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Acceptance tests passed in `testnet-citus`.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
