### PR TITLE
Increase delay duration to avoid pod scheduling issue

### DIFF
--- a/charts/hedera-mirror-common/templates/test-suite-rest.yaml
+++ b/charts/hedera-mirror-common/templates/test-suite-rest.yaml
@@ -23,19 +23,19 @@ spec:
   {{- end }}
   steps:
     - execute:
-        - delay: 10s
+        - delay: {{ eq $idx 0 | ternary "10s" $.Values.testkube.test.delay }}
       stopOnFailure: false
     - execute:
         - test: test-rest-{{ $target.namespace }}
       stopOnFailure: false
     - execute:
-        - delay: 60s
+        - delay: {{ $.Values.testkube.test.delay }}
       stopOnFailure: false
     - execute:
         - test: test-rest-java-{{ $target.namespace }}
       stopOnFailure: false
     - execute:
-        - delay: 60s
+        - delay: {{ $.Values.testkube.test.delay }}
       stopOnFailure: false
     - execute:
         - test: test-web3-{{ $target.namespace }}

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -385,6 +385,7 @@ testkube:
       rest: {}
       restjava: {}
       web3: {}
+    delay: 330s  # Delay duration between test suite steps
     extraExecutionRequestVariables: {}
     gitBranch: ""  # Default to .Chart.AppVersion
     schedule: ""  # Cron schedule of the test suite, default to no schedule


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR addresses the ramp up pod scheduling issue during k6 perf tests

- Increase delay duration between test steps 

**Related issue(s)**:

Fixes #8591 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
As mentioned in the ticket, the default HPA scale down stabilization window is 300s. Setting the delay to 330s would give enough time to completely scale down the deployment tested against in the previous test step to its min replicas.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
