### PR TITLE
Improve k6 perf test results consistency

### DIFF
--- a/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
@@ -64,6 +64,29 @@ spec:
       env:
         HEDERA_MIRROR_REST_STATEPROOF_ENABLED: "true"
         HEDERA_MIRROR_REST_STATEPROOF_STREAMS_NETWORK: MAINNET
+      hpa:
+        metrics:
+          - type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 40
+      resources:
+        requests:
+          cpu: 1100m  # same as limits
+    restjava:
+      hpa:
+        metrics:
+          - type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 40
+      resources:
+        requests:
+          cpu: 2  # same as limits
     rosetta:
       env:
         HEDERA_MIRROR_ROSETTA_NETWORK: "mainnet"
@@ -90,4 +113,14 @@ spec:
     web3:
       env:
         HEDERA_MIRROR_WEB3_EVM_NETWORK: MAINNET
-
+      hpa:
+        metrics:
+          - type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 40
+      resources:
+        requests:
+          cpu: 2  # same as limits

--- a/clusters/mainnet-staging-na/mainnet/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet/helmrelease.yaml
@@ -62,6 +62,29 @@ spec:
       env:
         HEDERA_MIRROR_REST_STATEPROOF_ENABLED: "true"
         HEDERA_MIRROR_REST_STATEPROOF_STREAMS_NETWORK: MAINNET
+      hpa:
+        metrics:
+          - type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 40
+      resources:
+        requests:
+          cpu: 1100m  # same as limits
+    restjava:
+      hpa:
+        metrics:
+          - type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 40
+      resources:
+        requests:
+          cpu: 2  # same as limits
     rosetta:
       env:
         HEDERA_MIRROR_ROSETTA_NETWORK: "mainnet"
@@ -78,4 +101,14 @@ spec:
       env:
         HEDERA_MIRROR_WEB3_EVM_NETWORK: MAINNET
         HEDERA_MIRROR_WEB3_THROTTLE_REQUESTSPERSECOND: "1500"
-
+      hpa:
+        metrics:
+          - type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 40
+      resources:
+        requests:
+          cpu: 2  # same as limits


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR makes k8s deployment resources changes for better k6 perf tests consistency

- Set cpu resources requests to limits for rest, restjava, and web3
- Set HPA target CPU utilization to 40% for rest, restjava, and web3 

**Related issue(s)**:

Fixes #8596 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The changes have been tested and the results are in notion for v0.107.0-rc1, the `#2` run. Note most RPS are better than that of v0.106.0-rc1, some web3 tests showed 3 times higher RPS.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
