### PR TITLE
Rest API redis error: wrong number of arguments for 'mget' command

### DIFF
--- a/hedera-mirror-rest/__tests__/cache.test.js
+++ b/hedera-mirror-rest/__tests__/cache.test.js
@@ -68,10 +68,10 @@ describe('get', () => {
     expect(newValues).toEqual(['v1', 'v2', 'v3']);
   });
 
-    test('No keys provided', async () => {
-      const values = await cache.get([], loader, keyMapper);
-      expect(values).toEqual([]);
-    });
+  test('No keys provided', async () => {
+    const values = await cache.get([], loader, keyMapper);
+    expect(values).toEqual([]);
+  });
 
   test('Disabled', async () => {
     config.redis.enabled = false;

--- a/hedera-mirror-rest/__tests__/cache.test.js
+++ b/hedera-mirror-rest/__tests__/cache.test.js
@@ -68,6 +68,11 @@ describe('get', () => {
     expect(newValues).toEqual(['v1', 'v2', 'v3']);
   });
 
+    test('No keys provided', async () => {
+      const values = await cache.get([], loader, keyMapper);
+      expect(values).toEqual([]);
+    });
+
   test('Disabled', async () => {
     config.redis.enabled = false;
     const values = await cache.get(['1', '2', '3'], loader, keyMapper);

--- a/hedera-mirror-rest/cache.js
+++ b/hedera-mirror-rest/cache.js
@@ -74,17 +74,17 @@ export class Cache {
   }
 
   async get(keys, loader, keyMapper = (k) => (k ? k.toString() : k)) {
+    if (_.isEmpty(keys)) {
+        return [];
+    }
     if (!this.ready) {
       return loader(keys);
     }
 
-    const mappedKeys = _.map(keys, keyMapper);
-    const buffers = mappedKeys.length === 0 ? [] :
+    const buffers =
       (await this.redis
-        .mgetBuffer(mappedKeys)
-        .catch((err) => {
-          logger.warn(`Redis error during mget: ${err.message}`)
-        })) || new Array(keys.length);
+        .mgetBuffer(_.map(keys, keyMapper))
+        .catch((err) => logger.warn(`Redis error during mget: ${err.message}`))) || new Array(keys.length);
     const values = buffers.map((t) => JSONParse(t));
 
     let i = 0;

--- a/hedera-mirror-rest/cache.js
+++ b/hedera-mirror-rest/cache.js
@@ -78,10 +78,13 @@ export class Cache {
       return loader(keys);
     }
 
-    const buffers =
+    const mappedKeys = _.map(keys, keyMapper);
+    const buffers = mappedKeys.length === 0 ? [] :
       (await this.redis
-        .mgetBuffer(_.map(keys, keyMapper))
-        .catch((err) => logger.warn(`Redis error during mget: ${err.message}`))) || new Array(keys.length);
+        .mgetBuffer(mappedKeys)
+        .catch((err) => {
+          logger.warn(`Redis error during mget: ${err.message}`)
+        })) || new Array(keys.length);
     const values = buffers.map((t) => JSONParse(t));
 
     let i = 0;


### PR DESCRIPTION
**Description**:

It appears the following redis error happens quite frequently in `testnet`:

```
2024-06-18T19:40:31.232Z WARN e2b77dc8 Redis error during mget: ERR wrong number of arguments for 'mget' command
2024-06-18T19:40:31.233Z WARN e2b77dc8 x.x.x.x GET /api/v1/accounts/0.0.5897416?&limit=999 in 40 ms: 404 Not found NotFoundError Not found
```

If the keys provided to `mget()`, `mgetBuffer()` etc are empty, then the behavior is to throw this error. There are a few opportunities for `transactions.getTransactionTimestamps()` to return empty rows.  It seems reasonable for `cache.get()` to look for this condition.

**Related issue(s)**:

Fixes #8587

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
