### PR TITLE
Enabling contract and token tests

### DIFF
--- a/hedera-mirror-rest/monitoring/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/config/default.serverlist.json
@@ -75,7 +75,7 @@
   },
   "token": {
     "enabled": true,
-    "freshnessThreshold": 1000,
+    "freshnessThreshold": 0,
     "intervalMultiplier": 1,
     "tokenId": "",
     "nftTokenId": "",

--- a/hedera-mirror-rest/monitoring/config/default.serverlist.json
+++ b/hedera-mirror-rest/monitoring/config/default.serverlist.json
@@ -41,8 +41,8 @@
   },
   "contract": {
     "contractId": "",
-    "enabled": false,
-    "contractCallEnabled": false,
+    "enabled": true,
+    "contractCallEnabled": true,
     "intervalMultiplier": 1,
     "limit": 2
   },
@@ -74,7 +74,7 @@
     "topicId": ""
   },
   "token": {
-    "enabled": false,
+    "enabled": true,
     "freshnessThreshold": 1000,
     "intervalMultiplier": 1,
     "tokenId": "",

--- a/hedera-mirror-rest/monitoring/token_tests.js
+++ b/hedera-mirror-rest/monitoring/token_tests.js
@@ -533,6 +533,10 @@ const checkTokenBalanceFreshness = async (server) => {
  * @param {ServerTestResult} testResult shared server test result object capturing tests for given endpoint
  */
 const runTests = async (server, testResult) => {
+  if (!tokenIdFromConfig) {
+    return Promise.resolve();
+  }
+
   const runTest = testRunner(server, testResult, resource);
   return Promise.all([
     runTest(getTokensCheck),


### PR DESCRIPTION
**Description**:
Enabling contract and token tests in config.

This PR modifies
* Enables contracts tests for monitor.
* Enables token tests for monitor, which will run if tokenId is set in the config.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Testing in progress on all user facing environments.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
