### PR TITLE
Optimize topic message lookup migration

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigration.java
@@ -163,6 +163,7 @@ public class TopicMessageLookupMigration extends AsyncJavaMigration<String> {
     private Collection<Set<Long>> topicByShard;
 
     @Lazy
+    @SuppressWarnings("java:S107")
     protected TopicMessageLookupMigration(
             EntityProperties entityProperties,
             JdbcTemplate jdbcTemplate,

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigration.java
@@ -141,8 +141,8 @@ public class TopicMessageLookupMigration extends AsyncJavaMigration<String> {
     private static final String PARTITION_NEEDS_MIGRATION_SQL =
             """
                     select
-                      not exists(select 1 from topic_message_lookup where partition = ?) and
-                      exists(select 1 from %s)
+                      not exists(select 1 from topic_message_lookup where partition = ? limit 1) and
+                      exists(select 1 from %s limit 1)
                     """;
     private static final RowMapper<ShardCount> SHARD_COUNT_ROW_MAPPER = new DataClassRowMapper<>(ShardCount.class);
     private static final String TOPIC_MESSAGE_TABLE_NAME = "topic_message";

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/TopicMessageLookupMigration.java
@@ -16,6 +16,15 @@
 
 package com.hedera.mirror.importer.migration;
 
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toSet;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.importer.ImporterProperties;
 import com.hedera.mirror.importer.db.DBProperties;
@@ -25,53 +34,140 @@ import com.hedera.mirror.importer.exception.ParserException;
 import com.hedera.mirror.importer.parser.record.entity.EntityProperties;
 import com.hedera.mirror.importer.repository.RecordFileRepository;
 import jakarta.inject.Named;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import org.apache.commons.lang3.BooleanUtils;
 import org.flywaydb.core.api.MigrationVersion;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.DataClassRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.transaction.support.TransactionOperations;
 
 @Named
+@Profile("v2")
 public class TopicMessageLookupMigration extends AsyncJavaMigration<String> {
 
-    private static final String TOPIC_MESSAGE_TABLE_NAME = "topic_message";
-
-    private static final String UPDATE_PARTITION_SQL =
+    private static final int BATCH_SIZE = 10_000;
+    private static final String GET_SHARD_COUNT_SQL =
             """
-                    insert into topic_message_lookup (partition, sequence_number_range, timestamp_range, topic_id)
-                    select
-                      '%1$s',
-                      int8range(min(sequence_number), max(sequence_number), '[]'),
-                      int8range(min(consensus_timestamp), max(consensus_timestamp), '[]'),
-                      topic_id
-                    from %1$s
-                    group by topic_id;
-                    """;
+            select shardid as shard_id, result as count
+            from run_command_on_shards(
+              '%s',
+              $cmd$
+              select reltuples::bigint
+              from pg_class
+              where relname::text = '%%s'
+              $cmd$)
+            """;
+    private static final String GET_TOPIC_SHARD_SQL =
+            """
+            select id as topic_id, get_shard_id_for_distribution_column('topic_message', id) as shard_id
+            from entity
+            where type = 'TOPIC'
+            """;
+    private static final String GET_TOPIC_STAT_SQL =
+            """
+            select jsonb_object_agg(shardid, result::jsonb)
+            from run_command_on_shards(
+              '%s',
+              $cmd$
+              with most_common_topic as (
+                select
+                  unnest(most_common_vals::text::bigint[]) as topic_id,
+                  unnest(most_common_freqs) as freq
+                from pg_stats
+                where tablename::text = '%%s' and attname = 'topic_id'
+              )
+              select coalesce(jsonb_agg(jsonb_build_object('topicId', topic_id, 'freq', freq)), '[]'::jsonb)
+              from most_common_topic
+              $cmd$)
+            """;
+    private static final String INSERT_BATCH_TOPIC_MESSAGE_LOOKUP_SQL =
+            """
+            with sequence_number as (
+              select
+                int8range(min(sequence_number), max(sequence_number), '[]') as sequence_number_range,
+                topic_id
+              from %1$s
+              where topic_id = any(?)
+              group by topic_id
+            ), timestamp as (
+              select
+                int8range(min(consensus_timestamp), max(consensus_timestamp), '[]') as timestamp_range,
+                topic_id
+              from %1$s
+              where topic_id = any(?)
+              group by topic_id
+            )
+            insert into topic_message_lookup (partition, sequence_number_range, timestamp_range, topic_id)
+            select
+              '%1$s',
+              sn.sequence_number_range,
+              ts.timestamp_range,
+              sn.topic_id
+            from sequence_number as sn
+            join timestamp as ts using (topic_id)
+            """;
+    private static final String INSERT_SINGLE_TOPIC_MESSAGE_LOOKUP_SQL =
+            """
+            with lookup as (
+              select
+                int8range(min(sequence_number), max(sequence_number), '[]') as sequence_number_range,
+                int8range(min(consensus_timestamp), max(consensus_timestamp), '[]') as timestamp_range
+              from %1$s
+              where topic_id = :id
+            )
+            insert into topic_message_lookup (partition, sequence_number_range, timestamp_range, topic_id)
+            select
+              '%1$s',
+              sequence_number_range,
+              timestamp_range,
+              :id
+            from lookup
+            where sequence_number_range <> '(,)'::int8range
+            """;
     private static final String PARTITION_NEEDS_MIGRATION_SQL =
             """
-                    select exists (select 1 from topic_message_lookup where partition = ?)
+                    select
+                      not exists(select 1 from topic_message_lookup where partition = ?) and
+                      exists(select 1 from %s)
                     """;
+    private static final RowMapper<ShardCount> SHARD_COUNT_ROW_MAPPER = new DataClassRowMapper<>(ShardCount.class);
+    private static final String TOPIC_MESSAGE_TABLE_NAME = "topic_message";
+    private static final long TOPIC_MESSAGE_THRESHOLD = 1_000_000L;
+    private static final RowMapper<TopicShard> TOPIC_SHARD_ROW_MAPPER = new DataClassRowMapper<>(TopicShard.class);
+    private static final TypeReference<Map<Long, List<TopicStat>>> TOPIC_STAT_MAP_TYPE = new TypeReference<>() {};
 
     private final EntityProperties entityProperties;
     private final JdbcTemplate jdbcTemplate;
     private final List<String> partitions = new LinkedList<>();
-
+    private final ObjectMapper objectMapper;
     private final RecordFileRepository recordFileRepository;
     private final TimePartitionService timePartitionService;
 
     @Getter
     private final TransactionOperations transactionOperations;
 
+    private Collection<Set<Long>> topicByShard;
+
     @Lazy
     protected TopicMessageLookupMigration(
             EntityProperties entityProperties,
             JdbcTemplate jdbcTemplate,
             ImporterProperties importerProperties,
+            ObjectMapper objectMapper,
             RecordFileRepository recordFileRepository,
             DBProperties dbProperties,
             TimePartitionService timePartitionService,
@@ -82,6 +178,7 @@ public class TopicMessageLookupMigration extends AsyncJavaMigration<String> {
                 dbProperties.getSchema());
         this.entityProperties = entityProperties;
         this.jdbcTemplate = jdbcTemplate;
+        this.objectMapper = objectMapper;
         this.recordFileRepository = recordFileRepository;
         this.timePartitionService = timePartitionService;
         this.transactionOperations = transactionOperations;
@@ -121,32 +218,14 @@ public class TopicMessageLookupMigration extends AsyncJavaMigration<String> {
                 .map(TimePartition::getName)
                 .toList());
 
+        topicByShard = jdbcTemplate.query(GET_TOPIC_SHARD_SQL, TOPIC_SHARD_ROW_MAPPER).stream()
+                .collect(Collectors.groupingBy(TopicShard::shardId, mapping(TopicShard::topicId, toSet())))
+                .values();
+
         log.info("Migrating topic_message_lookup for partition {} synchronously", activePartition);
         getTransactionOperations().executeWithoutResult(status -> migratePartition(activePartition));
 
         return !partitions.isEmpty();
-    }
-
-    @Override
-    protected String getInitial() {
-        return partitions.isEmpty() ? null : partitions.removeLast();
-    }
-
-    @Override
-    protected Optional<String> migratePartial(String partitionName) {
-        migratePartition(partitionName);
-        return Optional.ofNullable(getInitial());
-    }
-
-    private void migratePartition(String partitionName) {
-        var alreadyMigrated = jdbcTemplate.queryForObject(PARTITION_NEEDS_MIGRATION_SQL, Boolean.class, partitionName);
-        if (BooleanUtils.isFalse(alreadyMigrated)) {
-            var sql = String.format(UPDATE_PARTITION_SQL, partitionName);
-            jdbcTemplate.update(sql);
-            log.info("Migrated topic_message_lookup for partition {}", partitionName);
-        } else {
-            log.info("Partition {} already migrated", partitionName);
-        }
     }
 
     @Override
@@ -155,8 +234,107 @@ public class TopicMessageLookupMigration extends AsyncJavaMigration<String> {
     }
 
     @Override
+    protected String getInitial() {
+        return partitions.isEmpty() ? null : partitions.removeLast();
+    }
+
+    @Override
     protected MigrationVersion getMinimumVersion() {
         // The version where topic_message_lookup table was added
         return MigrationVersion.fromVersion("1.80.1");
     }
+
+    @Override
+    protected Optional<String> migratePartial(String partitionName) {
+        migratePartition(partitionName);
+        return Optional.ofNullable(getInitial());
+    }
+
+    private Set<Long> getTopTopics(String partitionName) {
+        var sql = String.format(GET_SHARD_COUNT_SQL, partitionName);
+        var shardCount = jdbcTemplate.query(sql, SHARD_COUNT_ROW_MAPPER).stream()
+                .collect(Collectors.toMap(ShardCount::shardId, ShardCount::count));
+
+        sql = String.format(GET_TOPIC_STAT_SQL, partitionName);
+        var topicStats = Objects.requireNonNull(jdbcTemplate.query(sql, rs -> {
+            try {
+                rs.next();
+                return objectMapper.readValue(rs.getString(1), TOPIC_STAT_MAP_TYPE);
+            } catch (JsonProcessingException e) {
+                throw new ParserException(e);
+            }
+        }));
+
+        var topTopics = new HashSet<Long>();
+        for (var entry : topicStats.entrySet()) {
+            long count = shardCount.getOrDefault(entry.getKey(), 0L);
+            if (count < TOPIC_MESSAGE_THRESHOLD) {
+                continue;
+            }
+
+            for (var topicStat : entry.getValue()) {
+                if (count * topicStat.freq >= TOPIC_MESSAGE_THRESHOLD) {
+                    topTopics.add(topicStat.topicId());
+                }
+            }
+        }
+
+        return topTopics;
+    }
+
+    private void migratePartition(String partitionName) {
+        var stopwatch = Stopwatch.createStarted();
+
+        var sql = String.format(PARTITION_NEEDS_MIGRATION_SQL, partitionName);
+        var needsMigration = jdbcTemplate.queryForObject(sql, Boolean.class, partitionName);
+        if (BooleanUtils.isFalse(needsMigration)) {
+            log.info("Partition {} doesn't need migration", partitionName);
+            return;
+        }
+
+        var topTopics = getTopTopics(partitionName);
+        int count = migrateBatch(partitionName, topTopics) + migrateSingle(partitionName, topTopics);
+
+        log.info("Migrated topic_message_lookup with {} rows for partition {} in {}", count, partitionName, stopwatch);
+    }
+
+    private int migrateBatch(String partitionName, Set<Long> topTopics) {
+        int count = 0;
+        var sql = String.format(INSERT_BATCH_TOPIC_MESSAGE_LOOKUP_SQL, partitionName);
+
+        for (var topicShard : topicByShard) {
+            if (topicShard.isEmpty()) {
+                continue;
+            }
+
+            var batches = Lists.partition(Lists.newArrayList(Sets.difference(topicShard, topTopics)), BATCH_SIZE);
+            for (var batch : batches) {
+                count += jdbcTemplate.update(sql, ps -> {
+                    var topicArray = ps.getConnection().createArrayOf("BIGINT", batch.toArray());
+                    ps.setArray(1, topicArray);
+                    ps.setArray(2, topicArray);
+                });
+            }
+        }
+
+        return count;
+    }
+
+    private int migrateSingle(String partitionName, Set<Long> topTopics) {
+        int count = 0;
+        var sql = String.format(INSERT_SINGLE_TOPIC_MESSAGE_LOOKUP_SQL, partitionName);
+
+        for (var topicId : topTopics) {
+            var paramSource = new MapSqlParameterSource("id", topicId);
+            count += namedParameterJdbcTemplate.update(sql, paramSource);
+        }
+
+        return count;
+    }
+
+    private record ShardCount(long shardId, long count) {}
+
+    private record TopicShard(long shardId, long topicId) {}
+
+    private record TopicStat(long topicId, float freq) {}
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR optimizes the topic message lookup migration.

- Add functionality to group topic ids by citus shard
- Add functionality to find top topics with more than 1 million messages in a partition
- Insert topic message lookups for non-top topics in batches by shard for each partition
- Insert topic message lookups for top topics one at a time for each partition
- Fix slow query to determine whether to skip partition

**Related issue(s)**:

Fixes #8512 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
The previous optimized version with a fixed 12 top topics from mainnet db took about 52 minutes to complete.

The enhanced version in this PR is supposed to take less time, however I just ran it for the last several partitions:

```
2024-06-24T20:43:52.415Z  INFO main c.h.m.i.m.TopicMessageLookupMigration Migrated topic_message_lookup with 10159 rows for partition topic_message_p2024_06 in 22.56 s
2024-06-24T20:43:52.485Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Starting asynchronous migration
2024-06-24T20:43:52.485Z  INFO main c.h.m.i.m.TopicMessageLookupMigration Ran migration Backfill topic_message_lookup table in 28.17 s.
2024-06-24T20:44:31.221Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Migrated topic_message_lookup with 15408 rows for partition topic_message_p2024_05 in 37.15 s
2024-06-24T20:44:58.636Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Migrated topic_message_lookup with 34514 rows for partition topic_message_p2024_04 in 27.38 s
2024-06-24T20:44:58.677Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Completed iteration 2 with last value: topic_message_p2024_03
2024-06-24T20:45:43.501Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Migrated topic_message_lookup with 67023 rows for partition topic_message_p2024_03 in 44.82 s
2024-06-24T20:46:47.627Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Migrated topic_message_lookup with 4825 rows for partition topic_message_p2024_02 in 1.068 min
2024-06-24T20:46:47.668Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Completed iteration 4 with last value: topic_message_p2024_01
2024-06-24T20:47:43.565Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Migrated topic_message_lookup with 2846 rows for partition topic_message_p2024_01 in 55.90 s
2024-06-24T20:47:43.602Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Completed iteration 5 with last value: topic_message_p2023_12
2024-06-24T20:48:39.752Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Migrated topic_message_lookup with 1122 rows for partition topic_message_p2023_12 in 56.15 s
2024-06-24T20:48:39.792Z  INFO single-1 c.h.m.i.m.TopicMessageLookupMigration Completed iteration 6 with last value: topic_message_p2023_11
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
