### PR TITLE
Make rest monitor config in chart mergeable

### DIFF
--- a/charts/hedera-mirror-rest/templates/monitor/secret.yaml
+++ b/charts/hedera-mirror-rest/templates/monitor/secret.yaml
@@ -8,5 +8,5 @@ metadata:
 type: Opaque
 stringData:
   serverlist.json: |
-    {{- tpl .Values.monitor.config $ | fromYaml | toJson | nindent 4 }}
+    {{- tpl (.Values.monitor.config | toPrettyJson) $ | nindent 4 }}
 {{- end }}

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -100,17 +100,12 @@ middleware:
       initialInterval: 100ms
 
 monitor:
-  config: |-
-    {
-      "servers": [
-        {
-          "baseUrl": "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}",
-          "name": "kubernetes",
-          "restJavaUrl": "http://{{ .Release.Name }}-restjava:{{ .Values.service.port }}",
-          "web3Url": "http://{{ .Release.Name }}-web3:{{ .Values.service.port }}"
-        }
-     ]
-    }
+  config:
+    servers:
+    - baseUrl: "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}"
+      name: kubernetes
+      restJavaUrl: "http://{{ .Release.Name }}-restjava:{{ .Values.service.port }}"
+      web3Url: "http://{{ .Release.Name }}-web3:{{ .Values.service.port }}"
   enabled: true
   image:
     pullPolicy: IfNotPresent

--- a/charts/hedera-mirror/ci/v1-values.yaml
+++ b/charts/hedera-mirror/ci/v1-values.yaml
@@ -19,18 +19,12 @@ postgresql:
   fullnameOverride: db
 rest:
   monitor:
-    config: |-
-      {
-        "freshness": false,
-        "network": { "enabled": false },
-        "servers": [
-          {
-            "baseUrl": "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}",
-            "name": "kubernetes"
-          }
-        ],
-        "stateproof": { "enabled": false }
-      }
+    config:
+      freshness: false
+      network:
+        enabled: false
+      stateproof:
+        enabled: false
   resources:
     requests:
       cpu: 200m

--- a/charts/hedera-mirror/ci/v2-values.yaml
+++ b/charts/hedera-mirror/ci/v2-values.yaml
@@ -23,18 +23,12 @@ postgresql:
   enabled: false
 rest:
   monitor:
-    config: |-
-      {
-        "freshness": false,
-        "network": { "enabled": false },
-        "servers": [
-          {
-            "baseUrl": "http://{{ .Release.Name }}-rest:{{ .Values.service.port }}",
-            "name": "kubernetes"
-          }
-        ],
-        "stateproof": { "enabled": false }
-      }
+    config:
+      freshness: false
+      network:
+        enabled: false
+      stateproof:
+        enabled: false
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR makes the rest monitor config in chart mergable

- Change rest monitor config to use yaml syntax
- Change the default values and secret template accordingly
 
**Related issue(s)**:

Fixes #8657

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
This is the output:

```shell
$ helm template  -s templates/monitor/secret.yaml --set monitor.config.stateproof.enabled=false  mirror hedera-mirror-rest
---
# Source: hedera-mirror-rest/templates/monitor/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  labels:
    app.kubernetes.io/component: rest-monitor
    app.kubernetes.io/name: hedera-mirror-rest-monitor
    app.kubernetes.io/instance: mirror
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: hedera-mirror-node
    app.kubernetes.io/version: "0.109.0-SNAPSHOT"
    helm.sh/chart: hedera-mirror-rest-0.109.0-SNAPSHOT
  name: mirror-hedera-mirror-rest-monitor
  namespace: mainnet
type: Opaque
stringData:
  serverlist.json: |
    {
      "servers": [
        {
          "baseUrl": "http://mirror-rest:80",
          "name": "kubernetes",
          "restJavaUrl": "http://mirror-restjava:80",
          "web3Url": "http://mirror-web3:80"
        }
      ],
      "stateproof": {
        "enabled": false
      }
    }
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
