### PR TITLE
Modifying dynamic address book design to add admin_key and node table.

### DIFF
--- a/docs/design/dynamic-addressbook.md
+++ b/docs/design/dynamic-addressbook.md
@@ -68,6 +68,11 @@ Update the `AddressBookServiceImpl` to persist the `domain_name` in `address_boo
 #### Domain
 
 - Modify `AddressBookServiceEndpoint` domain object to add `domain_name`.
+- Add `AbstractNode`,`Node` and `NodeHistory` domain objects in the common module.
+
+#### EntityListener
+
+- Add `EntityListener.onNode` method and `CompositeEntityListener.onNode`
 
 #### Transaction Handlers
 

--- a/docs/design/dynamic-addressbook.md
+++ b/docs/design/dynamic-addressbook.md
@@ -63,14 +63,14 @@ create index if not exists node_history__node_id_lower_timestamp
 When parsing node transactions,
 
 - Persist `transaction_bytes` and `transaction_record_bytes` to the `transaction` table for `NodeUpdate`,`NodeCreate` and `NodeDelete`.
-- Persist `Node` and `NodeHistory` domain objects.
+- Persist `Node` domain objects.
 
 Update the `AddressBookServiceImpl` to persist the `domain_name` in `address_book_service_endpoint`
 
 #### Domain
 
 - Modify `AddressBookServiceEndpoint` domain object to add `domain_name`.
-- Add `AbstractNode`,`Node` and `NodeHistory` domain objects in the common module.
+- Add `AbstractNode`, `Node` and `NodeHistory` domain objects in the common module.
 
 #### EntityListener
 
@@ -136,12 +136,6 @@ Response:
   }
 }
 ```
-
-## Acceptance Tests
-
-Add acceptance tests for the node feature that use an existing set of accounts from the existing acceptance tests and performs the following:
-
-- Send Node create, update and delete transactions and verify that the `admin_key` is updated on the (`/network/nodes`) API.
 
 ## Non-Functional Requirements
 

--- a/docs/design/dynamic-addressbook.md
+++ b/docs/design/dynamic-addressbook.md
@@ -36,8 +36,7 @@ create table if not exists node
 (
     admin_key              bytea           not null,
     created_timestamp      bigint          not null,
-    description            varchar(100)    null,
-    node_account_id        bigint          not null,
+    deleted                boolean         default false not null,
     node_id                bigint          primary key,
     timestamp_range        int8range       not null
 );
@@ -46,8 +45,7 @@ create table if not exists node_history
 (
   admin_key              bytea           not null,
   created_timestamp      bigint          not null,
-  description            varchar(100)    null,
-  node_account_id        bigint          not null,
+  deleted                boolean         default false not null,
   node_id                bigint          not null,
   timestamp_range        int8range       not null
 );

--- a/docs/design/dynamic-addressbook.md
+++ b/docs/design/dynamic-addressbook.md
@@ -52,8 +52,8 @@ create table if not exists node_history
   timestamp_range        int8range       not null
 );
 
-create index if not exists node_history__timestamp_node_id
-  on node_history (created_timestamp , node_id);
+create index if not exists node_history__node_id_lower_timestamp
+  on node_history (node_id, lower(timestamp_range));
 
 ```
 

--- a/docs/design/dynamic-addressbook.md
+++ b/docs/design/dynamic-addressbook.md
@@ -34,32 +34,26 @@ create index if not exists address_book_service_endpoint__timestamp_node_id
 
 create table if not exists node
 (
-    admin_key              varchar(1024)   null,
-    consensus_timestamp    nanos_timestamp references address_book (start_consensus_timestamp),
+    admin_key              bytea           not null,
+    created_timestamp      bigint          not null,
     description            varchar(100)    null,
-    memo                   varchar(128)    null,
-    node_account_id        entity_id       null,
-    node_cert_hash         bytea           null,
+    node_account_id        bigint          not null,
     node_id                bigint          primary key,
-    public_key             varchar(1024)   null,
-    stake                  bigint          null
+    timestamp_range        int8range       not null
 );
 
 create table if not exists node_history
 (
-  admin_key              varchar(1024)   null,
-  consensus_timestamp    nanos_timestamp references address_book (start_consensus_timestamp),
+  admin_key              bytea           not null,
+  created_timestamp      bigint          not null,
   description            varchar(100)    null,
-  memo                   varchar(128)    null,
-  node_account_id        entity_id       null,
-  node_cert_hash         bytea           null,
+  node_account_id        bigint          not null,
   node_id                bigint          not null,
-  public_key             varchar(1024)   null,
-  stake                  bigint          null
+  timestamp_range        int8range       not null
 );
 
 create index if not exists node_history__timestamp_node_id
-  on node_history (consensus_timestamp , node_id);
+  on node_history (created_timestamp , node_id);
 
 ```
 

--- a/docs/design/dynamic-addressbook.md
+++ b/docs/design/dynamic-addressbook.md
@@ -101,6 +101,7 @@ Response:
 {
   "nodes": [
     {
+      "admin_key": "0x565fd764f0957fa170a676210c9bdbddf3bc9519702cf927fa6767a40463b96f",
       "description": "address book 1",
       "file_id": "0.0.102",
       "max_stake": 50000,

--- a/docs/design/dynamic-addressbook.md
+++ b/docs/design/dynamic-addressbook.md
@@ -63,6 +63,7 @@ create index if not exists node_history__node_id_lower_timestamp
 When parsing node transactions,
 
 - Persist `transaction_bytes` and `transaction_record_bytes` to the `transaction` table for `NodeUpdate`,`NodeCreate` and `NodeDelete`.
+- Persist `Node` and `NodeHistory` domain objects.
 
 Update the `AddressBookServiceImpl` to persist the `domain_name` in `address_book_service_endpoint`
 
@@ -73,7 +74,7 @@ Update the `AddressBookServiceImpl` to persist the `domain_name` in `address_boo
 
 #### EntityListener
 
-- Add `EntityListener.onNode` method and `CompositeEntityListener.onNode`
+- Add `EntityListener.onNode` method and `CompositeEntityListener.onNode` to handle inserts to the `node` table.
 
 #### Transaction Handlers
 
@@ -135,6 +136,12 @@ Response:
   }
 }
 ```
+
+## Acceptance Tests
+
+Add acceptance tests for the node feature that use an existing set of accounts from the existing acceptance tests and performs the following:
+
+- Send Node create, update and delete transactions and verify that the `admin_key` is updated on the (`/network/nodes`) API.
 
 ## Non-Functional Requirements
 

--- a/docs/design/dynamic-addressbook.md
+++ b/docs/design/dynamic-addressbook.md
@@ -34,21 +34,22 @@ create index if not exists address_book_service_endpoint__timestamp_node_id
 
 create table if not exists node
 (
-    admin_key              bytea           not null,
-    created_timestamp      bigint          not null,
-    deleted                boolean         default false not null,
-    node_id                bigint          primary key,
-    timestamp_range        int8range       not null
-);
-
-create table if not exists node_history
-(
   admin_key              bytea           not null,
   created_timestamp      bigint          not null,
   deleted                boolean         default false not null,
   node_id                bigint          not null,
   timestamp_range        int8range       not null
 );
+
+-- add node index
+alter table if exists node
+  add constraint node__pk primary key (node_id);
+
+create table if not exists node_history
+(
+  like node including defaults
+);
+
 
 create index if not exists node_history__node_id_lower_timestamp
   on node_history (node_id, lower(timestamp_range));


### PR DESCRIPTION
**Description**:
This PR includes the design for the node and node_history table.

This PR modifies
* Adds the `node` and `node_history` table design.

**Related issue(s)**:

Fixes #8720 

**Notes for reviewer**:
* The `admin_key` addition to the rest API and gRPC API will not be added now.
`Questions:`
* Since we are adding a node table, all node information from address_book_entry should be in that table right?

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
