### PR TITLE
Increase prometheus default memory limits to 4GB

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -308,7 +308,7 @@ prometheus:
       resources:
         limits:
           cpu: 750m
-          memory: 2750Mi
+          memory: 4Gi
         requests:
           cpu: 250m
           memory: 1Gi


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR increases the default prometheus memory limits to 4GB.

**Related issue(s)**:

Fixes #8734 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Observed in previewnet, the peak used memory is around 3.5GB; in testnet-eu, it's 3.26GB. It's higher than what we saw before. Potentially it needs more memory to scrape and clean up all the accumulated data after a short period of service disruption, for instance, upgrade. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
