### PR TITLE
Reorder monitor helm test (0.109)

### DIFF
--- a/charts/hedera-mirror-rest/templates/monitor/tests/pod.yaml
+++ b/charts/hedera-mirror-rest/templates/monitor/tests/pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations: {{- toYaml .Values.test.annotations | nindent 4 }}
+  annotations: {{- toYaml .Values.monitor.test.annotations | nindent 4 }}
   labels: {{- include "hedera-mirror-rest-monitor.labels" . | nindent 4 }}
   name: {{ include "hedera-mirror-rest.fullname" . }}-monitor-test
   namespace: {{ include "hedera-mirror-rest.namespace" . }}

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -125,6 +125,10 @@ monitor:
   service:
     type: ClusterIP
   test:
+    annotations:
+      helm.sh/hook: test-success
+      helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+      helm.sh/hook-weight: "20"
     enabled: true
     image:
       pullPolicy: IfNotPresent


### PR DESCRIPTION
**Description**:

Reorder monitor helm test so that it runs after acceptance tests to ensure sufficient entities are created on reset networks first.

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
