### PR TITLE
Set web3 network to OTHER in stagings

### DIFF
--- a/clusters/preprod/staging-lg/helmrelease.yaml
+++ b/clusters/preprod/staging-lg/helmrelease.yaml
@@ -51,4 +51,11 @@ spec:
           enabled: false
     postgresql:
       enabled: false
+    rest:
+      monitor:
+        test:
+          enabled: false
+    web3:
+      env:
+        HEDERA_MIRROR_WEB3_EVM_NETWORK: OTHER
 

--- a/clusters/preprod/staging-sm/helmrelease.yaml
+++ b/clusters/preprod/staging-sm/helmrelease.yaml
@@ -51,6 +51,10 @@ spec:
           enabled: false
     postgresql:
       enabled: false
+    rest:
+      monitor:
+        test:
+          enabled: false
     test:
       config:
         hedera:
@@ -60,4 +64,7 @@ spec:
                 network: OTHER
       cucumberTags: "@acceptance and not @contractbase"
       enabled: true
+    web3:
+      env:
+        HEDERA_MIRROR_WEB3_EVM_NETWORK: OTHER
 


### PR DESCRIPTION
**Description**:

For both staging-lg and staging-sm:

* Disable rest monitor test due to missing sufficient data caused by mismatched state
* Set web3 network to OTHER in stagings to match other components

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
