### PR TITLE
Fix Initial address book bootstrap failure

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -16,9 +16,6 @@
 
 package com.hedera.mirror.importer.addressbook;
 
-import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_ADDRESS_BOOK;
-import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_NAME;
-
 import com.hedera.mirror.common.domain.addressbook.AddressBook;
 import com.hedera.mirror.common.domain.addressbook.AddressBookEntry;
 import com.hedera.mirror.common.domain.addressbook.AddressBookServiceEndpoint;
@@ -38,6 +35,18 @@ import com.hederahashgraph.api.proto.java.NodeAddress;
 import com.hederahashgraph.api.proto.java.NodeAddressBook;
 import com.hederahashgraph.api.proto.java.ServiceEndpoint;
 import jakarta.inject.Named;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.CollectionUtils;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -57,17 +66,9 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import lombok.CustomLog;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.cache.annotation.CacheConfig;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.springframework.transaction.support.TransactionTemplate;
-import org.springframework.util.CollectionUtils;
+
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_ADDRESS_BOOK;
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_NAME;
 
 @CustomLog
 @Named
@@ -497,6 +498,9 @@ public class AddressBookServiceImpl implements AddressBookService {
 
         if (entityProperties.getPersist().isNodes()) {
             addressBookServiceEndpoint.setDomainName(serviceEndpoint.getDomainName());
+        } else {
+            // Setting domain_name to empty string here only until HIP 869 goes to mainnet
+            addressBookServiceEndpoint.setDomainName("");
         }
 
         return addressBookServiceEndpoint;

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -16,6 +16,9 @@
 
 package com.hedera.mirror.importer.addressbook;
 
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_ADDRESS_BOOK;
+import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_NAME;
+
 import com.hedera.mirror.common.domain.addressbook.AddressBook;
 import com.hedera.mirror.common.domain.addressbook.AddressBookEntry;
 import com.hedera.mirror.common.domain.addressbook.AddressBookServiceEndpoint;
@@ -35,18 +38,6 @@ import com.hederahashgraph.api.proto.java.NodeAddress;
 import com.hederahashgraph.api.proto.java.NodeAddressBook;
 import com.hederahashgraph.api.proto.java.ServiceEndpoint;
 import jakarta.inject.Named;
-import lombok.CustomLog;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.cache.annotation.CacheConfig;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.springframework.transaction.support.TransactionTemplate;
-import org.springframework.util.CollectionUtils;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -66,9 +57,17 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-
-import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_ADDRESS_BOOK;
-import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_NAME;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.CollectionUtils;
 
 @CustomLog
 @Named

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImplTest.java
@@ -60,9 +60,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.ListAssert;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -143,16 +141,6 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
         Path addressBookPath =
                 ResourceUtils.getFile("classpath:addressbook/testnet").toPath();
         initialAddressBookBytes = Files.readAllBytes(addressBookPath);
-    }
-
-    @BeforeEach
-    void setup() {
-        entityProperties.getPersist().setNodes(true);
-    }
-
-    @AfterEach
-    void after() {
-        entityProperties.getPersist().setNodes(false);
     }
 
     private FileData createFileData(
@@ -670,6 +658,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
 
     @Test
     void verifyAddressBookWithServiceEndpointsOnly() throws UnknownHostException {
+        entityProperties.getPersist().setNodes(true);
 
         List<NodeAddress> nodeAddressList = new ArrayList<>();
         int nodeAccountStart = 3;
@@ -700,6 +689,7 @@ class AddressBookServiceImplTest extends ImporterIntegrationTest {
         assertEquals(2, addressBookRepository.count()); // bootstrap and new address book with service endpoints
         assertEquals(TEST_INITIAL_ADDRESS_BOOK_NODE_COUNT + addressBookEntries, addressBookEntryRepository.count());
         assertEquals(addressBookEntries * numEndpointsPerNode, addressBookServiceEndpointRepository.count());
+        entityProperties.getPersist().setNodes(false);
     }
 
     @Test


### PR DESCRIPTION
**Description**:
This PR fixes the initial address book bootstrap failure due to domain_name not null constraint.

This PR
* Sets `domain_name` to empty string when the persistProperty on it is false.

**Related issue(s)**:

Fixes #8796

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
