### PR TITLE
Optimize accounts rest api to avoid full entity_stake index scan

### DIFF
--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -70,6 +70,7 @@
         "qs": "^6.12.3",
         "quick-lru": "^6.1.2",
         "rfc4648": "^1.5.3",
+        "sql-formatter": "^15.3.2",
         "swagger-stats": "^0.99.7",
         "swagger-ui-express": "^5.0.1",
         "word-wrap": "npm:@aashutoshrathi/word-wrap@^1.2.6"
@@ -5355,6 +5356,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
+    },
     "node_modules/docker-compose": {
       "version": "0.24.8",
       "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
@@ -6774,6 +6780,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8855,6 +8872,11 @@
         "node": "*"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -8903,6 +8925,32 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -9923,6 +9971,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -10156,6 +10221,14 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/retry": {
@@ -10537,6 +10610,19 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.3.2.tgz",
+      "integrity": "sha512-pNxSMf5DtwhpZ8gUcOGCGZIWtCcyAUx9oLgAtlO4ag7DvlfnETL0BGqXaISc84pNrXvTWmt8Wal1FWKxdTsL3Q==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "get-stdin": "=8.0.0",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
+      }
     },
     "node_modules/ssh-remote-port-forward": {
       "version": "1.0.4",

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -46,12 +46,14 @@
     "qs": "^6.12.3",
     "quick-lru": "^6.1.2",
     "rfc4648": "^1.5.3",
+    "sql-formatter": "^15.3.2",
     "swagger-stats": "^0.99.7",
     "swagger-ui-express": "^5.0.1",
     "word-wrap": "npm:@aashutoshrathi/word-wrap@^1.2.6"
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^10.10.3",
+    "@testcontainers/redis": "^10.10.3",
     "app-root-path": "^3.1.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^9.1.0",
@@ -67,8 +69,7 @@
     "pg-format": "^1.0.4",
     "rewire": "^7.0.0",
     "sinon": "^18.0.0",
-    "supertest": "^7.0.0",
-    "@testcontainers/redis": "^10.10.3"
+    "supertest": "^7.0.0"
   },
   "jest-junit": {
     "outputDirectory": "build/test-results/test",
@@ -78,5 +79,37 @@
   "overrides": {
     "protobufjs": "^7.2.4"
   },
-  "bundleDependencies": true
+  "bundleDependencies": [
+    "@awaitjs/express",
+    "@aws-sdk/client-s3",
+    "@godaddy/terminus",
+    "@hashgraph/proto",
+    "@trufflesuite/bigint-buffer",
+    "asn1js",
+    "body-parser",
+    "compression",
+    "cors",
+    "express",
+    "express-http-context",
+    "express-openapi-validator",
+    "extend",
+    "ioredis",
+    "ip-anonymize",
+    "js-yaml",
+    "json-bigint",
+    "lodash",
+    "log4js",
+    "long",
+    "mathjs",
+    "parse-duration",
+    "pg",
+    "pg-range",
+    "prom-client",
+    "qs",
+    "quick-lru",
+    "rfc4648",
+    "swagger-stats",
+    "swagger-ui-express",
+    "word-wrap"
+  ]
 }

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -22,6 +22,7 @@ import long from 'long';
 import * as math from 'mathjs';
 import pg from 'pg';
 import pgRange, {Range} from 'pg-range';
+import {format} from 'sql-formatter';
 import util from 'util';
 
 import * as constants from './constants';
@@ -1389,8 +1390,11 @@ const getPoolClass = () => {
           const result = entry.match(/^\s*at\s+(\S+).*\/(.*\.js):(\d+):.*/);
           return result && result.length === 4 && {function: result[1], file: result[2], line: result[3]};
         })[0];
+      const prettyQuery = format(query, {language: 'postgresql'});
       logger.trace(
-        `${callerInfo.function} (${callerInfo.file}:${callerInfo.line}) query: ${query} ${JSONStringify(params)}`
+        `${callerInfo.function} (${callerInfo.file}:${callerInfo.line})\nquery: ${prettyQuery}\nparams: ${JSONStringify(
+          params
+        )}`
       );
     }
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR optimizes the query for accounts rest api to avoid full entity_stake index scan

- Add account id condition to `entity_stake` left join
- Prettify SQL query logging at trace level

**Related issue(s)**:

Fixes #8804 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The SQL query time with `limit 100` is reduced from 58ms to 3ms.

Output of `explain analyze` shows huge difference in actual number of rows.

```
         ->  Index Scan using entity_stake_pkey on entity_stake es  (cost=0.42..7221.88 rows=103484 width=24) (actual time=0.005..41.461 rows=102204 loops=1)
``` 
v.s.

```
         ->  Index Scan using entity_stake_pkey on entity_stake es  (cost=0.42..1350.68 rows=1386 width=24) (actual time=0.015..0.015 rows=1 loops=1)
               Index Cond: (id > 6205393)
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
