### PR TITLE
Fix address book bootstrap failing with null `ip_address_v4`

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -19,6 +19,7 @@ package com.hedera.mirror.importer.addressbook;
 import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_ADDRESS_BOOK;
 import static com.hedera.mirror.importer.config.CacheConfiguration.CACHE_NAME;
 
+import com.google.protobuf.ByteString;
 import com.hedera.mirror.common.domain.addressbook.AddressBook;
 import com.hedera.mirror.common.domain.addressbook.AddressBookEntry;
 import com.hedera.mirror.common.domain.addressbook.AddressBookServiceEndpoint;
@@ -484,11 +485,13 @@ public class AddressBookServiceImpl implements AddressBookService {
 
     private AddressBookServiceEndpoint getAddressBookServiceEndpoint(
             ServiceEndpoint serviceEndpoint, long consensusTimestamp, long nodeId) throws UnknownHostException {
-        var ipAddressByteString = serviceEndpoint.getIpAddressV4();
-        String ip = StringUtils.EMPTY;
-        if (ipAddressByteString != null && ipAddressByteString.size() == 4) {
-            ip = InetAddress.getByAddress(ipAddressByteString.toByteArray()).getHostAddress();
+        var ipAddressByteString =
+                serviceEndpoint.getIpAddressV4() != null ? serviceEndpoint.getIpAddressV4() : ByteString.EMPTY;
+        if (ipAddressByteString.size() != 4) {
+            throw new IllegalStateException(String.format("Invalid IpAddressV4: %s", ipAddressByteString));
         }
+
+        var ip = InetAddress.getByAddress(ipAddressByteString.toByteArray()).getHostAddress();
         AddressBookServiceEndpoint addressBookServiceEndpoint = new AddressBookServiceEndpoint();
         addressBookServiceEndpoint.setConsensusTimestamp(consensusTimestamp);
         addressBookServiceEndpoint.setIpAddressV4(ip);

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/addressbook/AddressBookServiceImpl.java
@@ -485,7 +485,7 @@ public class AddressBookServiceImpl implements AddressBookService {
     private AddressBookServiceEndpoint getAddressBookServiceEndpoint(
             ServiceEndpoint serviceEndpoint, long consensusTimestamp, long nodeId) throws UnknownHostException {
         var ipAddressByteString = serviceEndpoint.getIpAddressV4();
-        String ip = null;
+        String ip = StringUtils.EMPTY;
         if (ipAddressByteString != null && ipAddressByteString.size() == 4) {
             ip = InetAddress.getByAddress(ipAddressByteString.toByteArray()).getHostAddress();
         }
@@ -499,7 +499,7 @@ public class AddressBookServiceImpl implements AddressBookService {
             addressBookServiceEndpoint.setDomainName(serviceEndpoint.getDomainName());
         } else {
             // Setting domain_name to empty string here only until HIP 869 goes to mainnet
-            addressBookServiceEndpoint.setDomainName("");
+            addressBookServiceEndpoint.setDomainName(StringUtils.EMPTY);
         }
 
         return addressBookServiceEndpoint;


### PR DESCRIPTION
**Description**:
This PR sets ip_address_v4 to an empty string.

This PR
* Sets  ip_address_v4 to an empty string instead of null


**Related issue(s)**:

Fixes #8844

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
