### PR TITLE
Fix case sensitive query parameters

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/contracts/results/logs/pagination-index-timestamp-range.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/logs/pagination-index-timestamp-range.json
@@ -206,7 +206,11 @@
       }
     },
     {
-      "url": "/api/v1/contracts/results/logs?timestamp=gte:1639010151.000000000&timestamp=lte:1639010161.000000000&limit=3&order=desc&index=lte:1",
+      "urls": [
+        "/api/v1/contracts/results/logs?timestamp=gte:1639010151.000000000&timestamp=lte:1639010161.000000000&limit=3&order=desc&index=lte:1",
+        "/api/v1/contracts/results/logs?timestamp=gte:1639010151.000000000&timestamp=lte:1639010161.000000000&limit=3&order=DESC&index=lte:1",
+        "/api/v1/contracts/results/logs?timestamp=gte:1639010151.000000000&timestamp=lte:1639010161.000000000&limit=3&order=DeSc&index=lte:1"
+      ],
       "responseStatus": 200,
       "responseJson": {
         "logs": [
@@ -324,7 +328,9 @@
     },
     {
       "urls": [
-        "/api/v1/contracts/results/logs?index=gte:0&timestamp=gte:1639010141.000000000&index=lte:1&timestamp=lte:1639010141.000000000&limit=1&order=asc"
+        "/api/v1/contracts/results/logs?index=gte:0&timestamp=gte:1639010141.000000000&index=lte:1&timestamp=lte:1639010141.000000000&limit=1&order=asc",
+        "/api/v1/contracts/results/logs?index=gte:0&timestamp=gte:1639010141.000000000&index=lte:1&timestamp=lte:1639010141.000000000&limit=1&order=ASC",
+        "/api/v1/contracts/results/logs?index=gte:0&timestamp=gte:1639010141.000000000&index=lte:1&timestamp=lte:1639010141.000000000&limit=1&order=Asc"
       ],
       "responseStatus": 200,
       "responseJson": {

--- a/hedera-mirror-rest/__tests__/specs/transactions/all-params.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions/all-params.json
@@ -72,7 +72,11 @@
   },
   "tests": [
     {
-      "url": "/api/v1/transactions?timestamp=1565779209.711927001&account.id=0.0.9&type=credit&result=success",
+      "urls": [
+        "/api/v1/transactions?timestamp=1565779209.711927001&account.id=0.0.9&type=credit&result=success&order=asc",
+        "/api/v1/transactions?timestamp=1565779209.711927001&account.id=0.0.9&type=credit&result=SUCCESS&order=ASC",
+        "/api/v1/transactions?timestamp=1565779209.711927001&account.id=0.0.9&type=credit&result=SucCess&order=AsC"
+      ],
       "responseStatus": 200,
       "responseJson": {
         "transactions": [

--- a/hedera-mirror-rest/__tests__/utils.test.js
+++ b/hedera-mirror-rest/__tests__/utils.test.js
@@ -2039,3 +2039,15 @@ describe('bigIntMin', () => {
     expect(utils.bigIntMin(a, b)).toEqual(expected);
   });
 });
+
+describe('lowerCaseQueryValue', () => {
+  test.each`
+    input        | expected
+    ${'success'} | ${'success'}
+    ${'SUCCESS'} | ${'success'}
+    ${'SUCCess'} | ${'success'}
+    ${100}       | ${100}
+  `('$input', ({input, expected}) => {
+    expect(utils.lowerCaseQueryValue(input)).toEqual(expected);
+  });
+});

--- a/hedera-mirror-rest/middleware/requestHandler.js
+++ b/hedera-mirror-rest/middleware/requestHandler.js
@@ -18,14 +18,7 @@ import httpContext from 'express-http-context';
 import qs from 'qs';
 
 import {httpStatusCodes, requestIdLabel, requestStartTime} from '../constants';
-import {randomString} from '../utils';
-
-const lowerCaseQueryValue = (queryValue) => {
-  if (typeof queryValue === 'string') {
-    return queryValue.toLowerCase();
-  }
-  return queryValue;
-};
+import {lowerCaseQueryValue, randomString} from '../utils';
 
 const queryCanonicalizationMap = {
   order: lowerCaseQueryValue,
@@ -70,12 +63,12 @@ const requestQueryParser = (queryString) => {
   for (const [key, value] of Object.entries(parsedQueryString)) {
     const lowerKey = key.toLowerCase();
     const canonicalizationFunc = queryCanonicalizationMap[lowerKey];
-    const canonicalizedValue = canonicalizationFunc ? canonicalizationFunc(value) : value;
+    const canonicalValue = canonicalizationFunc ? canonicalizationFunc(value) : value;
     if (lowerKey in caseInsensitiveQueryString) {
       // handle repeated values, merge into an array
-      caseInsensitiveQueryString[lowerKey] = merge(caseInsensitiveQueryString[lowerKey], canonicalizedValue);
+      caseInsensitiveQueryString[lowerKey] = merge(caseInsensitiveQueryString[lowerKey], canonicalValue);
     } else {
-      caseInsensitiveQueryString[lowerKey] = canonicalizedValue;
+      caseInsensitiveQueryString[lowerKey] = canonicalValue;
     }
   }
 

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -211,6 +211,8 @@ const isValidAddressBookFileIdPattern = (fileId) => {
   return addressBookFileIdPattern.includes(fileId);
 };
 
+const lowerCaseQueryValue = (queryValue) => (typeof queryValue === 'string' ? queryValue.toLowerCase() : queryValue);
+
 /**
  * Validate input parameters for the rest apis
  * @param {String} param Parameter to be validated
@@ -1743,6 +1745,7 @@ export {
   isValidSlot,
   isValidTimestampParam,
   isValidValueIgnoreCase,
+  lowerCaseQueryValue,
   ltLte,
   mergeParams,
   nowInNs,


### PR DESCRIPTION
**Description**:

Some rest api endpoints return 500 with `order=ASC` /  `order=DESC`, examples:

- `https://mainnet-public.mirrornode.hedera.com/api/v1/contracts/results/logs?order=ASC`
- `https://mainnet-public.mirrornode.hedera.com/api/v1/accounts/0.0.1274288/nfts?limit=100&order=ASC`

The transactions REST API misinterprets query filter `result=SUCCESS` to look for transactions with response code not equal to 22. The issue is only all lower case `success` is interpreted as response code equal to 22. On top of the inverted interpretation, this may also cause query timeout, e.g., when combined with `account.id` for which there's very few failed transactions.

This PR, in the `requestHander.js` middleware Express query parser, ensures the query parameter values to selected parameters (currently just `order` and `result`) are forced to lowercase before the request is routed to the request handler code.

**Related issue(s)**:

Fixes #8790
Fixes #8801

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
