### PR TITLE
HIP-540 Update REST API to return correct value for empty KeyLists

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/custom-fees.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/custom-fees.json
@@ -104,7 +104,8 @@
         "fee_schedule_key": [1, 2, 3],
         "type": "FUNGIBLE_COMMON",
         "pause_key": "4a5ad514f0957fa170a676210c9bdbddf3bc9519702cf915fa6767a40463b96x",
-        "pause_status": "UNPAUSED"
+        "pause_status": "UNPAUSED",
+        "supply_key": "2\\000"
       },
       {
         "token_id": "0.7.25301",
@@ -151,7 +152,10 @@
       "key": "34613561643531346630393537666131373061363736323130633962646264646633626339353139373032636639313566613637363761343034363362393678"
     },
     "pause_status": "UNPAUSED",
-    "supply_key": null,
+    "supply_key": {
+      "_type": "ProtobufEncoded",
+      "key": null
+    },
     "supply_type": "INFINITE",
     "total_supply": "1000000",
     "treasury_account_id": "0.0.98",

--- a/hedera-mirror-rest/__tests__/specs/tokens/{id}/custom-fees.json
+++ b/hedera-mirror-rest/__tests__/specs/tokens/{id}/custom-fees.json
@@ -152,10 +152,7 @@
       "key": "34613561643531346630393537666131373061363736323130633962646264646633626339353139373032636639313566613637363761343034363362393678"
     },
     "pause_status": "UNPAUSED",
-    "supply_key": {
-      "_type": "ProtobufEncoded",
-      "key": null
-    },
+    "supply_key": null,
     "supply_type": "INFINITE",
     "total_supply": "1000000",
     "treasury_account_id": "0.0.98",

--- a/hedera-mirror-rest/__tests__/utils.test.js
+++ b/hedera-mirror-rest/__tests__/utils.test.js
@@ -217,6 +217,14 @@ describe('Utils encodeKey', () => {
       },
     },
     {
+      name: 'Immutable Sentinel',
+      input: Buffer.from('3200', 'hex'),
+      expected: {
+        _type: constants.keyTypes.PROTOBUF,
+        key: null,
+      },
+    },
+    {
       name: 'Protobuf',
       input: Buffer.from('abcdef', 'hex'),
       expected: {
@@ -282,7 +290,7 @@ describe('Utils.isByteRange', () => {
   test('Single byte chars gt max size', () => expect(utils.isByteRange('abcde', 5, 4)).toBeFalse());
   test('Single byte chars lt max size', () => expect(utils.isByteRange('abcde', 5, 6)).toBeTrue());
   test('Multi byte chars eq max size', () => expect(utils.isByteRange('ℏℏℏ', 5, 9)).toBeTrue());
-  test('Multi byte chars gt max size', () => expect(utils.isByteRange('ℏℏℏ', 5,8)).toBeFalse());
+  test('Multi byte chars gt max size', () => expect(utils.isByteRange('ℏℏℏ', 5, 8)).toBeFalse());
   test('Multi byte chars lt max size', () => expect(utils.isByteRange('ℏℏℏ', 5, 10)).toBeTrue());
   test('Multi byte chars eq max size', () => expect(utils.isByteRange('abcdeℏℏℏ', 5, 14)).toBeTrue());
   test('Multi byte chars gt max size', () => expect(utils.isByteRange('abcdeℏℏℏ', 5, 13)).toBeFalse());

--- a/hedera-mirror-rest/__tests__/utils.test.js
+++ b/hedera-mirror-rest/__tests__/utils.test.js
@@ -219,10 +219,7 @@ describe('Utils encodeKey', () => {
     {
       name: 'Immutable Sentinel',
       input: Buffer.from('3200', 'hex'),
-      expected: {
-        _type: constants.keyTypes.PROTOBUF,
-        key: null,
-      },
+      expected: null,
     },
     {
       name: 'Protobuf',

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -1040,7 +1040,11 @@ const encodeKey = (key) => {
   }
 
   // check for empty case to support differentiation between empty and null keys
-  let keyHex = _.isEmpty(key) ? '' : toHexString(key);
+  const keyHex = _.isEmpty(key) ? '' : toHexString(key);
+  if (keyHex === IMMUTABLE_SENTINEL_KEY) {
+    return null;
+  }
+
   const ed25519Key = keyHex.match(PATTERN_ED25519);
   if (ed25519Key) {
     return {
@@ -1055,10 +1059,6 @@ const encodeKey = (key) => {
       _type: constants.keyTypes.ECDSA_SECP256K1,
       key: ecdsa[2],
     };
-  }
-
-  if (keyHex === IMMUTABLE_SENTINEL_KEY) {
-    keyHex = null;
   }
 
   return {

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -134,9 +134,9 @@ const isHexPositiveInt = (num, allowZero = false) => {
 };
 
 const isByteRange = (str, minSize, maxSize) => {
-  const length = Buffer.from(str).length
+  const length = Buffer.from(str).length;
   return length >= minSize && length <= maxSize;
-}
+};
 
 const nonNegativeInt32Regex = /^\d{1,10}$/;
 
@@ -1026,6 +1026,9 @@ const toHexStringNonQuantity = (byteArray) => {
 const PATTERN_ECDSA = /^(3a21|32250a233a21|2a29080112250a233a21)([A-Fa-f0-9]{66})$/;
 const PATTERN_ED25519 = /^(1220|32240a221220|2a28080112240a221220)([A-Fa-f0-9]{64})$/;
 
+// An empty or default key list appears as the sentinel value /x3200
+const IMMUTABLE_SENTINEL_KEY = '3200';
+
 /**
  * Converts a key for returning in JSON output
  * @param {Array} key Byte array representing the key
@@ -1037,7 +1040,7 @@ const encodeKey = (key) => {
   }
 
   // check for empty case to support differentiation between empty and null keys
-  const keyHex = _.isEmpty(key) ? '' : toHexString(key);
+  let keyHex = _.isEmpty(key) ? '' : toHexString(key);
   const ed25519Key = keyHex.match(PATTERN_ED25519);
   if (ed25519Key) {
     return {
@@ -1052,6 +1055,10 @@ const encodeKey = (key) => {
       _type: constants.keyTypes.ECDSA_SECP256K1,
       key: ecdsa[2],
     };
+  }
+
+  if (keyHex === IMMUTABLE_SENTINEL_KEY) {
+    keyHex = null;
   }
 
   return {
@@ -1118,7 +1125,7 @@ const buildAndValidateFilters = (
   acceptedParameters,
   filterValidator = filterValidityChecks,
   filterDependencyChecker = filterDependencyCheck,
-  excludedCombinatons= [[]],
+  excludedCombinatons = [[]]
 ) => {
   const {badParams, filters} = buildFilters(query);
   const {invalidParams, unknownParams} = validateAndParseFilters(filters, filterValidator, acceptedParameters);


### PR DESCRIPTION
**Description**:
Updates the REST API to display the empty KeyList/Immutable Sentinel value as null instead of the byte representation of the sentinel value (`3200`).

**Related issue(s)**:

Fixes #8845 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
