### PR TITLE
Downgrade go btcd btsec to v2.3.3

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "release/**"
+      - "go-btcd-btsec-2.3.3"
     tags:
       - "v*"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - "main"
       - "release/**"
-      - "go-btcd-btsec-2.3.3"
     tags:
       - "v*"
 

--- a/hedera-mirror-rosetta/go.mod
+++ b/hedera-mirror-rosetta/go.mod
@@ -134,4 +134,6 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
+replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
+
 replace golang.org/x/image/tiff => golang.org/x/image/tiff v0.16.0

--- a/hedera-mirror-rosetta/go.mod
+++ b/hedera-mirror-rosetta/go.mod
@@ -134,6 +134,5 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
-
+replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3 // remove when go-ethereum upgrades to be compatible with >= v2.3.4
 replace golang.org/x/image/tiff => golang.org/x/image/tiff v0.16.0

--- a/hedera-mirror-rosetta/go.sum
+++ b/hedera-mirror-rosetta/go.sum
@@ -427,8 +427,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bits-and-blooms/bitset v1.13.0 h1:bAQ9OPNFYbGHV6Nez0tmNI0RiEu7/hxlYJRUA0wFAVE=
 github.com/bits-and-blooms/bitset v1.13.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/btcsuite/btcd v0.22.1 h1:CnwP9LM/M9xuRrGSCGeMVs9iv09uMqwsVX7EeIpgV2c=
-github.com/btcsuite/btcd/btcec/v2 v2.3.4 h1:3EJjcN70HCu/mwqlUsGK8GcNVyLVxFDlWurTXGPFfiQ=
-github.com/btcsuite/btcd/btcec/v2 v2.3.4/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
+github.com/btcsuite/btcd/btcec/v2 v2.3.3 h1:6+iXlDKE8RMtKsvK0gshlXIuPbyWM/h84Ensb7o3sC0=
+github.com/btcsuite/btcd/btcec/v2 v2.3.3/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes rosetta compile error in SonarCloud github workflow job

- downgrade go btcd btsec to v2.3.3

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The compile failure only happens in CI `SonarCloud` job. The problem is btcd btsec v2.3.4 has a breaking change on a function's signature go-ethereum depends on. However go-thereum hasn't released the version to accommodate the breaking change so far.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
