### PR TITLE
filter ethereum transaction with empty hash

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigration.java
@@ -47,7 +47,7 @@ public class BackfillTransactionHashMigration extends RepeatableMigration {
             insert into transaction_hash (consensus_timestamp, hash, payer_account_id)
             select consensus_timestamp, hash, payer_account_id
             from ethereum_transaction
-            where consensus_timestamp >= :startTimestamp;
+            where length(hash) > 0 and consensus_timestamp >= :startTimestamp;
             """;
     private static final String START_TIMESTAMP_KEY = "startTimestamp";
     private static final String STRATEGY_KEY = "strategy";

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -70,6 +70,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.core.annotation.Order;
 import org.springframework.util.CollectionUtils;
 
@@ -201,7 +202,8 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
     public void onEthereumTransaction(EthereumTransaction ethereumTransaction) throws ImporterException {
         context.add(ethereumTransaction);
 
-        if (entityProperties.getPersist().shouldPersistTransactionHash(TransactionType.ETHEREUMTRANSACTION)) {
+        if (entityProperties.getPersist().shouldPersistTransactionHash(TransactionType.ETHEREUMTRANSACTION)
+                && ArrayUtils.isNotEmpty(ethereumTransaction.getHash())) {
             context.add(ethereumTransaction.toTransactionHash());
         }
     }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillTransactionHashMigrationTest.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.importer.migration;
 
 import static com.hedera.mirror.common.domain.transaction.TransactionType.CONSENSUSSUBMITMESSAGE;
 import static com.hedera.mirror.common.domain.transaction.TransactionType.ETHEREUMTRANSACTION;
+import static com.hedera.mirror.common.util.DomainUtils.EMPTY_BYTE_ARRAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -127,6 +128,7 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
                 .filter(t -> persistTransactionHash)
                 .toList();
         entityProperties.getPersist().setTransactionHash(persistTransactionHash);
+        persistEthereumTransactionWithEmptyHash(DEFAULT_START_TIMESTAMP + 3);
 
         // when
         runMigration();
@@ -151,6 +153,7 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
                                 .persist())
                 .map(Transaction::toTransactionHash)
                 .toList();
+        persistEthereumTransactionWithEmptyHash(DEFAULT_START_TIMESTAMP + 2);
 
         // when
         runMigration();
@@ -255,6 +258,7 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
         // For auto (or the default, since it's just auto) strategy with existing data in the database, only ethereum
         // transaction info should be backfilled
         expected.addAll(persistEthereumTransaction(DEFAULT_START_TIMESTAMP + 1, SkipTransaction.NATIVE));
+        persistEthereumTransactionWithEmptyHash(DEFAULT_START_TIMESTAMP + 2);
 
         // when
         runMigration();
@@ -292,6 +296,7 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
                 .persist()
                 .toTransactionHash());
         expected.addAll(persistEthereumTransaction(DEFAULT_START_TIMESTAMP + 1, SkipTransaction.NOTHING));
+        persistEthereumTransactionWithEmptyHash(DEFAULT_START_TIMESTAMP + 2);
 
         // when
         runMigration();
@@ -331,6 +336,7 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
                 .persist()
                 .toTransactionHash();
         expected.addAll(persistEthereumTransaction(DEFAULT_START_TIMESTAMP + 1, SkipTransaction.NATIVE));
+        persistEthereumTransactionWithEmptyHash(DEFAULT_START_TIMESTAMP + 2);
 
         // when
         runMigration();
@@ -405,6 +411,13 @@ class BackfillTransactionHashMigrationTest extends ImporterIntegrationTest {
         }
 
         return transactionHashList;
+    }
+
+    private void persistEthereumTransactionWithEmptyHash(long consensusTimestamp) {
+        domainBuilder
+                .ethereumTransaction(false)
+                .customize(t -> t.consensusTimestamp(consensusTimestamp).hash(EMPTY_BYTE_ARRAY))
+                .persist();
     }
 
     private void assertTransactionHashes(Collection<TransactionHash> expected) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.importer.parser.record.entity.sql;
 
 import static com.hedera.mirror.common.domain.entity.EntityType.ACCOUNT;
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
+import static com.hedera.mirror.common.util.DomainUtils.EMPTY_BYTE_ARRAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -2937,6 +2938,23 @@ class SqlEntityListenerTest extends ImporterIntegrationTest {
         // then
         assertThat(ethereumTransactionRepository.findAll()).containsExactly(ethereumTransaction);
         assertThat(transactionHashRepository.findAll()).containsExactlyInAnyOrderElementsOf(expectedTransactionHash);
+    }
+
+    @Test
+    void onEthereumTransactionWithEmptyHash() {
+        entityProperties.getPersist().setTransactionHash(true);
+        var ethereumTransaction = domainBuilder
+                .ethereumTransaction(false)
+                .customize(e -> e.hash(EMPTY_BYTE_ARRAY))
+                .get();
+        sqlEntityListener.onEthereumTransaction(ethereumTransaction);
+
+        // when
+        completeFileAndCommit();
+
+        // then
+        assertThat(ethereumTransactionRepository.findAll()).containsExactly(ethereumTransaction);
+        assertThat(transactionHashRepository.findAll()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes issue caused by inserting transaction hash from an ethereum transaction with empty hash

- Filter ethereum transaction with empty hash in `SqlEntityListener`
- Filter ethereum transaction with empty hash in `BackfillTransactionHashMigration`

**Related issue(s)**:

Fixes #8925

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
