### PR TITLE
Enable cluster state reconciliation in testnet-eu

### DIFF
--- a/clusters/testnet-eu/common/helmrelease.yaml
+++ b/clusters/testnet-eu/common/helmrelease.yaml
@@ -12,7 +12,7 @@ spec:
         name: hedera-mirror-node
       version: '0.110.1'
   driftDetection:
-    mode: warn
+    mode: enabled
     ignore:
       - paths: [""]
         target:

--- a/clusters/testnet-eu/testnet-citus/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet-citus/helmrelease.yaml
@@ -19,7 +19,12 @@ spec:
     - name: mirror
       namespace: common
   driftDetection:
-    mode: warn
+    ignore:
+    - paths:
+      - /spec/scripts
+      target:
+        kind: SGScript
+    mode: enabled
   install:
     crds: CreateReplace
   interval: 90s

--- a/clusters/testnet-eu/testnet/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
     - name: mirror
       namespace: common
   driftDetection:
-    mode: warn
+    mode: enabled
   install:
     crds: CreateReplace
   interval: 90s


### PR DESCRIPTION
**Description**:

* Enable cluster state reconciliation in testnet-eu
* Fix alerts by ignoring `SGScript.spec.scripts` since the operator updates it with a version number

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
