### PR TITLE
Disable NFT Acceptance Tests for Mainnet Staging In V1 and V2

### DIFF
--- a/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
@@ -105,7 +105,7 @@ spec:
                 network: MAINNET
                 feature:
                   rejectToken: false
-      cucumberTags: "@critical"
+      cucumberTags: "@critical and not @nft"
       enabled: true
     web3:
       env:

--- a/clusters/mainnet-staging-na/mainnet/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
                 network: MAINNET
                 feature:
                   rejectToken: false
-      cucumberTags: "@critical"
+      cucumberTags: "@critical and not @nft"
       enabled: true
     web3:
       env:


### PR DESCRIPTION
* disable nft acceptance tests to work around environments without tokenReject