### PR TITLE
Fix case sensitive array query parameters

### DIFF
--- a/hedera-mirror-rest/__tests__/requestHandler.test.js
+++ b/hedera-mirror-rest/__tests__/requestHandler.test.js
@@ -51,4 +51,15 @@ describe('qs tests', () => {
       'token.id': ['2', '8', 'gt:4', 'gte:6', '10'],
     });
   });
+
+  test('requestQueryParser for single lowercased query param values', () => {
+    const val = requestQueryParser('order=ASC&result=SUCCESS');
+    expect(val.order).toStrictEqual('asc');
+    expect(val.result).toStrictEqual('success');
+  });
+
+  test('requestQueryParser for multiple lowercased query param keys and values', () => {
+    const val = requestQueryParser('order=ASC&ORder=ASC');
+    expect(val.order).toStrictEqual(['asc', 'asc']);
+  });
 });

--- a/hedera-mirror-rest/__tests__/specs/transactions/all-params.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions/all-params.json
@@ -74,8 +74,8 @@
     {
       "urls": [
         "/api/v1/transactions?timestamp=1565779209.711927001&account.id=0.0.9&type=credit&result=success&order=asc",
-        "/api/v1/transactions?timestamp=1565779209.711927001&account.id=0.0.9&type=credit&result=SUCCESS&order=ASC",
-        "/api/v1/transactions?timestamp=1565779209.711927001&account.id=0.0.9&type=credit&result=SucCess&order=AsC"
+        "/api/v1/transactions?timestamp=1565779209.711927001&account.id=0.0.9&type=credit&result=SUCCESS&order=ASC&result=SUCCESS&order=ASC",
+        "/api/v1/transactions?timestamp=1565779209.711927001&account.id=0.0.9&type=credit&result=SucCess&order=AsC&Result=SUCCESS&oRder=ASC"
       ],
       "responseStatus": 200,
       "responseJson": {


### PR DESCRIPTION
**Description**:
My first attempt (#8852) at fixing this issue did not accommodate the scenario where a query parameter is provided more than once. When that happens, the Express query parser aggregates the values for the key into an array. Thus, when the `order=ASC` parameter is specified a single time,  the value is simply a string. However `order=ASC&order=ASC` results in the single `order` key, but this time with a value of `[ ASC, ASC]`.

The solution is to accommodate the possibility of the array, and in that case to canonicalize each element individually.

**Related issue(s)**:

Fixes #8790

**Notes for reviewer**:
Beyond the fact this scenario was not tested for previously, my assumption was that the process of merging multiple values within `requestQueryParser()` was handling this possibility. And, it was in the sense that the original code could handle whether the request parameter was a single value or an array, and that it was also merging to support case-insensitive keys.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
