### PR TITLE
Refactor ContractCallSystemPrecompileTest

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -125,13 +125,12 @@ abstract class AbstractContractCallServiceTest extends Web3IntegrationTest {
 
     protected <T extends Exception> void verifyEstimateGasRevertExecution(
             final RemoteFunctionCall<TransactionReceipt> functionCall,
-            final String exceptionMessage, Class<T> exceptionClass) {
+            final String exceptionMessage,
+            Class<T> exceptionClass) {
 
         testWeb3jService.setEstimateGas(true);
         // Verify estimate reverts with proper message
-        assertThatThrownBy(functionCall::send)
-                .isInstanceOf(exceptionClass)
-                .hasMessage(exceptionMessage);
+        assertThatThrownBy(functionCall::send).isInstanceOf(exceptionClass).hasMessage(exceptionMessage);
     }
 
     protected void verifyEthCallAndEstimateGasWithValue(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -21,6 +21,7 @@ import static com.hedera.mirror.web3.utils.ContractCallTestUtil.TRANSACTION_GAS_
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.isWithinExpectedGasRange;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.longValueOf;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.hedera.mirror.web3.Web3IntegrationTest;
@@ -120,6 +121,17 @@ abstract class AbstractContractCallServiceTest extends Web3IntegrationTest {
         assertThat(isWithinExpectedGasRange(estimateGasUsedResult.get(), actualGasUsed))
                 .withFailMessage(ESTIMATE_GAS_ERROR_MESSAGE, estimateGasUsedResult.get(), actualGasUsed)
                 .isTrue();
+    }
+
+    protected <T extends Exception> void verifyEstimateGasRevertExecution(
+            final RemoteFunctionCall<TransactionReceipt> functionCall,
+            final String exceptionMessage, Class<T> exceptionClass) {
+
+        testWeb3jService.setEstimateGas(true);
+        // Verify estimate reverts with proper message
+        assertThatThrownBy(functionCall::send)
+                .isInstanceOf(exceptionClass)
+                .hasMessage(exceptionMessage);
     }
 
     protected void verifyEthCallAndEstimateGasWithValue(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileHistoricalTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.mirror.web3.service;
 
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_CALL;
@@ -63,8 +79,8 @@ public class ContractCallSystemPrecompileHistoricalTest extends ContractCallTest
     @Getter
     @RequiredArgsConstructor
     enum ExchangeRateFunctions implements ContractFunctionProviderEnum {
-        TINYCENTS_TO_TINYBARS("tinycentsToTinybars", new Object[]{100L}, new Long[]{8L}),
-        TINYBARS_TO_TINYCENTS("tinybarsToTinycents", new Object[]{100L}, new Object[]{1200L});
+        TINYCENTS_TO_TINYBARS("tinycentsToTinybars", new Object[] {100L}, new Long[] {8L}),
+        TINYBARS_TO_TINYCENTS("tinybarsToTinycents", new Object[] {100L}, new Object[] {1200L});
 
         private final String name;
         private final Object[] functionParameters;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileHistoricalTest.java
@@ -1,0 +1,73 @@
+package com.hedera.mirror.web3.service;
+
+import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_CALL;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.mirror.web3.utils.ContractFunctionProviderEnum;
+import com.hedera.mirror.web3.viewmodel.BlockType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ContractCallSystemPrecompileHistoricalTest extends ContractCallTestSetup {
+
+    private static final List<BlockType> BLOCK_NUMBERS_FOR_EVM_VERSION = List.of(
+            BlockType.of(String.valueOf(EVM_V_46_BLOCK)),
+            BlockType.of(String.valueOf(EVM_V_38_BLOCK)),
+            BlockType.of(String.valueOf(EVM_V_34_BLOCK)),
+            BlockType.of(String.valueOf(EVM_V_34_BLOCK - 1)));
+
+    private static Stream<Arguments> exchangeRateFunctionsProviderHistorical() {
+        return Arrays.stream(ExchangeRateFunctions.values())
+                .flatMap(exchangeRateFunction -> BLOCK_NUMBERS_FOR_EVM_VERSION.stream()
+                        .map(blockNumber -> Arguments.of(exchangeRateFunction, blockNumber)));
+    }
+
+    private static Stream<Arguments> blockNumberForDifferentEvmVersionsProviderHistorical() {
+        return BLOCK_NUMBERS_FOR_EVM_VERSION.stream().map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("exchangeRateFunctionsProviderHistorical")
+    void exchangeRateFunctionsTestEthCallHistorical(final ExchangeRateFunctions contractFunc, BlockType blockNumber) {
+        final var functionHash = functionEncodeDecoder.functionHashFor(
+                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.functionParameters);
+        final var serviceParameters = serviceParametersForExecution(
+                functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_CALL, 0L, blockNumber);
+        final var successfulResponse = functionEncodeDecoder.encodedResultFor(
+                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.expectedResultFields);
+
+        assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);
+    }
+
+    @ParameterizedTest
+    @MethodSource("blockNumberForDifferentEvmVersionsProviderHistorical")
+    void pseudoRandomGeneratorPrecompileFunctionsTestEthCallHistorical(BlockType blockNumber) {
+        final var functionName = "getPseudorandomSeed";
+        final var functionHash = functionEncodeDecoder.functionHashFor(functionName, PRNG_PRECOMPILE_ABI_PATH);
+        final var serviceParameters =
+                serviceParametersForExecution(functionHash, PRNG_CONTRACT_ADDRESS, ETH_CALL, 0L, blockNumber);
+
+        final var result = contractCallService.processCall(serviceParameters);
+
+        // Length of "0x" + 64 hex characters (2 per byte * 32 bytes)
+        assertEquals(66, result.length(), "The string should represent a 32-byte long array");
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    enum ExchangeRateFunctions implements ContractFunctionProviderEnum {
+        TINYCENTS_TO_TINYBARS("tinycentsToTinybars", new Object[]{100L}, new Long[]{8L}),
+        TINYBARS_TO_TINYCENTS("tinybarsToTinycents", new Object[]{100L}, new Object[]{1200L});
+
+        private final String name;
+        private final Object[] functionParameters;
+        private final Object[] expectedResultFields;
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileTest.java
@@ -16,188 +16,87 @@
 
 package com.hedera.mirror.web3.service;
 
-import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_CALL;
-import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_ESTIMATE_GAS;
-import static com.hedera.mirror.web3.utils.ContractCallTestUtil.isWithinExpectedGasRange;
-import static com.hedera.mirror.web3.utils.ContractCallTestUtil.longValueOf;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
-import com.hedera.mirror.web3.utils.ContractFunctionProviderEnum;
-import com.hedera.mirror.web3.viewmodel.BlockType;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Stream;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import com.hedera.mirror.web3.web3j.generated.ExchangeRatePrecompile;
+import com.hedera.mirror.web3.web3j.generated.PrngSystemContract;
+import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.MethodSource;
 
-class ContractCallSystemPrecompileTest extends ContractCallTestSetup {
+class ContractCallSystemPrecompileTest extends AbstractContractCallServiceTest {
 
-    private static final List<BlockType> BLOCK_NUMBERS_FOR_EVM_VERSION = List.of(
-            BlockType.of(String.valueOf(EVM_V_46_BLOCK)),
-            BlockType.of(String.valueOf(EVM_V_38_BLOCK)),
-            BlockType.of(String.valueOf(EVM_V_34_BLOCK)),
-            BlockType.of(String.valueOf(EVM_V_34_BLOCK - 1)));
-
-    private static Stream<Arguments> exchangeRateFunctionsProviderHistorical() {
-        return Arrays.stream(ExchangeRateFunctions.values())
-                .flatMap(exchangeRateFunction -> BLOCK_NUMBERS_FOR_EVM_VERSION.stream()
-                        .map(blockNumber -> Arguments.of(exchangeRateFunction, blockNumber)));
+    @Test
+    void exchangeRatePrecompileTinycentsToTinybarsTestEthCall() throws Exception {
+        final var contract = testWeb3jService.deploy(ExchangeRatePrecompile::deploy);
+        final var result = contract.call_tinycentsToTinybars(BigInteger.valueOf(100L)).send();
+        final var functionCall = contract.send_tinycentsToTinybars(BigInteger.valueOf(100L), BigInteger.ZERO);
+        assertThat(result).isEqualTo(BigInteger.valueOf(8L));
+        verifyEthCallAndEstimateGas(functionCall, contract);
     }
 
-    private static Stream<Arguments> blockNumberForDifferentEvmVersionsProviderHistorical() {
-        return BLOCK_NUMBERS_FOR_EVM_VERSION.stream().map(Arguments::of);
+    @Test
+    void exchangeRatePrecompileTinybarsToTinycentsTestEthCall() throws Exception {
+        final var contract = testWeb3jService.deploy(ExchangeRatePrecompile::deploy);
+        final var result = contract.call_tinybarsToTinycents(BigInteger.valueOf(100L)).send();
+        final var functionCall = contract.send_tinybarsToTinycents(BigInteger.valueOf(100L), BigInteger.ZERO);
+        assertThat(result).isEqualTo(BigInteger.valueOf(1200L));
+        verifyEthCallAndEstimateGas(functionCall, contract);
     }
 
-    @ParameterizedTest
-    @EnumSource(ExchangeRateFunctions.class)
-    void exchangeRatePrecompileFunctionsTestEthCall(final ExchangeRateFunctions contractFunc) {
-        final var functionHash = functionEncodeDecoder.functionHashFor(
-                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.functionParameters);
-        final var serviceParameters = serviceParametersForExecution(
-                functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
-        final var successfulResponse = functionEncodeDecoder.encodedResultFor(
-                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.expectedResultFields);
-
-        assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);
-    }
-
-    @ParameterizedTest
-    @EnumSource(ExchangeRateFunctions.class)
-    void exchangeRatePrecompileFunctionsTestEthCallWithValueRevertExecution(final ExchangeRateFunctions contractFunc) {
-        final var functionHash = functionEncodeDecoder.functionHashFor(
-                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.functionParameters);
-        final var serviceParameters = serviceParametersForExecution(
-                functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_CALL, 100L, BlockType.LATEST);
-
-        assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
+    @Test
+    void exchangeRatePrecompileTinycentsToTinybarsTestEthCallAndEstimateWithValueRevertExecution() {
+        final var contract = testWeb3jService.deploy(ExchangeRatePrecompile::deploy);
+        final var functionCall = contract.send_tinycentsToTinybars(BigInteger.valueOf(100L), BigInteger.valueOf(100L));
+        String expectedErrorMessage = CONTRACT_REVERT_EXECUTED.name();
+        assertThatThrownBy(functionCall::send)
                 .isInstanceOf(MirrorEvmTransactionException.class)
-                .hasMessage(CONTRACT_REVERT_EXECUTED.name());
+                .hasMessage(expectedErrorMessage);
+        verifyEstimateGasRevertExecution(functionCall, expectedErrorMessage, MirrorEvmTransactionException.class);
     }
 
-    @ParameterizedTest
-    @MethodSource("exchangeRateFunctionsProviderHistorical")
-    void exchangeRateFunctionsTestEthCallHistorical(final ExchangeRateFunctions contractFunc, BlockType blockNumber) {
-        final var functionHash = functionEncodeDecoder.functionHashFor(
-                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.functionParameters);
-        final var serviceParameters = serviceParametersForExecution(
-                functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_CALL, 0L, blockNumber);
-        final var successfulResponse = functionEncodeDecoder.encodedResultFor(
-                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.expectedResultFields);
-
-        assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);
-    }
-
-    @ParameterizedTest
-    @EnumSource(ExchangeRateFunctions.class)
-    void exchangeRatePrecompileFunctionsTestEthEstimateGas(final ExchangeRateFunctions contractFunc) {
-        final var functionHash = functionEncodeDecoder.functionHashFor(
-                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.functionParameters);
-        final var serviceParameters = serviceParametersForExecution(
-                functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
-
-        final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
-
-        assertThat(isWithinExpectedGasRange(
-                        longValueOf.applyAsLong(contractCallService.processCall(serviceParameters)), expectedGasUsed))
-                .isTrue();
-    }
-
-    @ParameterizedTest
-    @EnumSource(ExchangeRateFunctions.class)
-    void exchangeRatePrecompileFunctionsTestEthEstimateGasWithValueRevertExecution(
-            final ExchangeRateFunctions contractFunc) {
-        final var functionHash = functionEncodeDecoder.functionHashFor(
-                contractFunc.name, EXCHANGE_RATE_PRECOMPILE_ABI_PATH, contractFunc.functionParameters);
-        final var serviceParameters = serviceParametersForExecution(
-                functionHash, EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 100L, BlockType.LATEST);
-
-        assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
+    @Test
+    void exchangeRatePrecompileTinybarsToTinycentsTestEthCallAndEstimateWithValueRevertExecution() {
+        final var contract = testWeb3jService.deploy(ExchangeRatePrecompile::deploy);
+        final var functionCall = contract.send_tinybarsToTinycents(BigInteger.valueOf(100L), BigInteger.valueOf(100L));
+        String expectedErrorMessage = CONTRACT_REVERT_EXECUTED.name();
+        assertThatThrownBy(functionCall::send)
                 .isInstanceOf(MirrorEvmTransactionException.class)
-                .hasMessage(CONTRACT_REVERT_EXECUTED.name());
+                .hasMessage(expectedErrorMessage);
+        verifyEstimateGasRevertExecution(functionCall, expectedErrorMessage, MirrorEvmTransactionException.class);
     }
 
     @Test
     void pseudoRandomGeneratorPrecompileFunctionsTestEthEstimateGas() {
-        final var functionName = "getPseudorandomSeed";
-        final var functionHash = functionEncodeDecoder.functionHashFor(functionName, PRNG_PRECOMPILE_ABI_PATH);
-        final var serviceParameters = serviceParametersForExecution(
-                functionHash, PRNG_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
-
-        final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
-
-        assertThat(isWithinExpectedGasRange(
-                        longValueOf.applyAsLong(contractCallService.processCall(serviceParameters)), expectedGasUsed))
-                .isTrue();
+        final var contract = testWeb3jService.deploy(PrngSystemContract::deploy);
+        final var functionCall = contract.send_getPseudorandomSeed(BigInteger.ZERO);
+        verifyEthCallAndEstimateGas(functionCall, contract);
     }
 
     @Test
     void pseudoRandomGeneratorPrecompileFunctionsTestEthEstimateGasWithValueRevertExecution() {
-        final var functionName = "getPseudorandomSeed";
-        final var functionHash = functionEncodeDecoder.functionHashFor(functionName, PRNG_PRECOMPILE_ABI_PATH);
-        final var serviceParameters = serviceParametersForExecution(
-                functionHash, PRNG_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 100L, BlockType.LATEST);
-
-        assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
-                .isInstanceOf(MirrorEvmTransactionException.class)
-                .hasMessage(CONTRACT_REVERT_EXECUTED.name());
+        final var contract = testWeb3jService.deploy(PrngSystemContract::deploy);
+        final var functionCall = contract.send_getPseudorandomSeed(BigInteger.valueOf(100));
+        verifyEstimateGasRevertExecution(functionCall, CONTRACT_REVERT_EXECUTED.name(),
+                MirrorEvmTransactionException.class);
     }
 
     @Test
-    void pseudoRandomGeneratorPrecompileFunctionsTestEthCall() {
-        final var functionName = "getPseudorandomSeed";
-        final var functionHash = functionEncodeDecoder.functionHashFor(functionName, PRNG_PRECOMPILE_ABI_PATH);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, PRNG_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
-
-        final var result = contractCallService.processCall(serviceParameters);
-
-        // Length of "0x" + 64 hex characters (2 per byte * 32 bytes)
-        assertEquals(66, result.length(), "The string should represent a 32-byte long array");
+    void pseudoRandomGeneratorPrecompileFunctionsTestEthCall() throws Exception {
+        final var contract = testWeb3jService.deploy(PrngSystemContract::deploy);
+        final var result = contract.call_getPseudorandomSeed().send();
+        assertEquals(32, result.length, "The string should represent a 32-byte long array");
     }
 
     @Test
     void pseudoRandomGeneratorPrecompileFunctionsTestEthCallWithValueRevertExecution() {
-        final var functionName = "getPseudorandomSeed";
-        final var functionHash = functionEncodeDecoder.functionHashFor(functionName, PRNG_PRECOMPILE_ABI_PATH);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, PRNG_CONTRACT_ADDRESS, ETH_CALL, 100L, BlockType.LATEST);
-
-        assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
+        final var contract = testWeb3jService.deploy(PrngSystemContract::deploy);
+        final var functionCall = contract.send_getPseudorandomSeed(BigInteger.valueOf(100));
+        assertThatThrownBy(functionCall::send)
                 .isInstanceOf(MirrorEvmTransactionException.class)
                 .hasMessage(CONTRACT_REVERT_EXECUTED.name());
-    }
-
-    @ParameterizedTest
-    @MethodSource("blockNumberForDifferentEvmVersionsProviderHistorical")
-    void pseudoRandomGeneratorPrecompileFunctionsTestEthCallHistorical(BlockType blockNumber) {
-        final var functionName = "getPseudorandomSeed";
-        final var functionHash = functionEncodeDecoder.functionHashFor(functionName, PRNG_PRECOMPILE_ABI_PATH);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, PRNG_CONTRACT_ADDRESS, ETH_CALL, 0L, blockNumber);
-
-        final var result = contractCallService.processCall(serviceParameters);
-
-        // Length of "0x" + 64 hex characters (2 per byte * 32 bytes)
-        assertEquals(66, result.length(), "The string should represent a 32-byte long array");
-    }
-
-    @Getter
-    @RequiredArgsConstructor
-    enum ExchangeRateFunctions implements ContractFunctionProviderEnum {
-        TINYCENTS_TO_TINYBARS("tinycentsToTinybars", new Object[] {100L}, new Long[] {8L}),
-        TINYBARS_TO_TINYCENTS("tinybarsToTinycents", new Object[] {100L}, new Object[] {1200L});
-
-        private final String name;
-        private final Object[] functionParameters;
-        private final Object[] expectedResultFields;
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileTest.java
@@ -32,7 +32,8 @@ class ContractCallSystemPrecompileTest extends AbstractContractCallServiceTest {
     @Test
     void exchangeRatePrecompileTinycentsToTinybarsTestEthCall() throws Exception {
         final var contract = testWeb3jService.deploy(ExchangeRatePrecompile::deploy);
-        final var result = contract.call_tinycentsToTinybars(BigInteger.valueOf(100L)).send();
+        final var result =
+                contract.call_tinycentsToTinybars(BigInteger.valueOf(100L)).send();
         final var functionCall = contract.send_tinycentsToTinybars(BigInteger.valueOf(100L), BigInteger.ZERO);
         assertThat(result).isEqualTo(BigInteger.valueOf(8L));
         verifyEthCallAndEstimateGas(functionCall, contract);
@@ -41,7 +42,8 @@ class ContractCallSystemPrecompileTest extends AbstractContractCallServiceTest {
     @Test
     void exchangeRatePrecompileTinybarsToTinycentsTestEthCall() throws Exception {
         final var contract = testWeb3jService.deploy(ExchangeRatePrecompile::deploy);
-        final var result = contract.call_tinybarsToTinycents(BigInteger.valueOf(100L)).send();
+        final var result =
+                contract.call_tinybarsToTinycents(BigInteger.valueOf(100L)).send();
         final var functionCall = contract.send_tinybarsToTinycents(BigInteger.valueOf(100L), BigInteger.ZERO);
         assertThat(result).isEqualTo(BigInteger.valueOf(1200L));
         verifyEthCallAndEstimateGas(functionCall, contract);
@@ -80,8 +82,8 @@ class ContractCallSystemPrecompileTest extends AbstractContractCallServiceTest {
     void pseudoRandomGeneratorPrecompileFunctionsTestEthEstimateGasWithValueRevertExecution() {
         final var contract = testWeb3jService.deploy(PrngSystemContract::deploy);
         final var functionCall = contract.send_getPseudorandomSeed(BigInteger.valueOf(100));
-        verifyEstimateGasRevertExecution(functionCall, CONTRACT_REVERT_EXECUTED.name(),
-                MirrorEvmTransactionException.class);
+        verifyEstimateGasRevertExecution(
+                functionCall, CONTRACT_REVERT_EXECUTED.name(), MirrorEvmTransactionException.class);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/OpcodeServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/OpcodeServiceTest.java
@@ -80,6 +80,865 @@ class OpcodeServiceTest extends ContractCallTestSetup {
     private final OpcodeService opcodeService;
     private final EntityDatabaseAccessor entityDatabaseAccessor;
 
+    @Getter
+    @RequiredArgsConstructor
+    private enum NestedEthCallContractFunctions implements ContractFunctionProviderEnum {
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        1,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        1L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{1,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                        },
+                        1L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{1,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        1L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        1,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        1L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        2,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        2L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{2,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                        },
+                        2L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{2,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        2L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        2,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        2L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        4,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        4L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{4,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                        },
+                        4L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{4,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        4L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        4,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        4L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        8,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        8L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{8,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                        },
+                        8L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{8,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        8L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        8,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        8L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        16,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        16L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{16,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                                }
+                        },
+                        16L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{16,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        16L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        16,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        16L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        32,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        32L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{32,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                                }
+                        },
+                        32L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{32,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        32L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        32,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        32L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        64,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        64L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{64,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                                }
+                        },
+                        64L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{64,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        64L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        64,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        64L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        1,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        1L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{1,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                        },
+                        1L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{1,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        1L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        1,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        1L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        2,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        2L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{2,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                        },
+                        2L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{2,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        2L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        2,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        2L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        4,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        4L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{4,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                        },
+                        4L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{4,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        4L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        4,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        4L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        8,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        8L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{8,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                        },
+                        8L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{8,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        8L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        8,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        8L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        16,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        16L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{16,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                                }
+                        },
+                        16L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{16,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        16L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        16,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        16L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        32,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        32L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{32,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                                }
+                        },
+                        32L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{32,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        32L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        32,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        32L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_CONTRACT_ADDRESS(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        64,
+                                        new Object[]{
+                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
+                                                Address.ZERO
+                                        }
+                                }
+                        },
+                        64L
+                },
+                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ED25519_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{64,
+                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                                }
+                        },
+                        64L
+                },
+                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ECDSA_KEY(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{64,
+                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                        },
+                        64L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_DELEGATE_CONTRACT_ID(
+                "updateTokenKeysAndGetUpdatedTokenKey",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new Object[]{
+                                new Object[]{
+                                        64,
+                                        new Object[]{
+                                                false, Address.ZERO, new byte[0], new byte[0],
+                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
+                                        }
+                                }
+                        },
+                        64L
+                },
+                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+        UPDATE_TOKEN_EXPIRY_AND_GET_TOKEN_EXPIRY(
+                "updateTokenExpiryAndGetUpdatedTokenExpiry",
+                new Object[]{
+                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                        new TokenExpiryWrapper(
+                                4_000_000_000L,
+                                EntityIdUtils.accountIdFromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS),
+                                8_000_000L)
+                },
+                new Object[]{4_000_000_000L, AUTO_RENEW_ACCOUNT_ADDRESS, 8_000_000L
+                }), // 4_000_000_000L in order to fit in uint32 until there is a support for int64 in EvmEncodingFacade
+        // to match the Expiry struct in IHederaTokenService
+        UPDATE_NFT_TOKEN_EXPIRY_AND_GET_TOKEN_EXPIRY(
+                "updateTokenExpiryAndGetUpdatedTokenExpiry",
+                new Object[]{
+                        NFT_TRANSFER_ADDRESS,
+                        new TokenExpiryWrapper(
+                                4_000_000_000L,
+                                EntityIdUtils.accountIdFromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS),
+                                8_000_000L)
+                },
+                new Object[]{4_000_000_000L, AUTO_RENEW_ACCOUNT_ADDRESS, 8_000_000L
+                }), // 4_000_000_000L in order to fit in uint32 until there is a support for int64 in EvmEncodingFacade
+        // to match the Expiry struct in IHederaTokenService
+        UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_SYMBOL(
+                "updateTokenInfoAndGetUpdatedTokenInfoSymbol",
+                new Object[]{UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[]{FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getSymbol()}),
+        UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_SYMBOL(
+                "updateTokenInfoAndGetUpdatedTokenInfoSymbol",
+                new Object[]{NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[]{NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getSymbol()}),
+        UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_NAME(
+                "updateTokenInfoAndGetUpdatedTokenInfoName",
+                new Object[]{UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[]{FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getName()}),
+        UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_NAME(
+                "updateTokenInfoAndGetUpdatedTokenInfoName",
+                new Object[]{NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[]{NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getName()}),
+        UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_MEMO(
+                "updateTokenInfoAndGetUpdatedTokenInfoMemo",
+                new Object[]{UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[]{FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getMemo()}),
+        UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_MEMO(
+                "updateTokenInfoAndGetUpdatedTokenInfoMemo",
+                new Object[]{NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[]{NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getMemo()}),
+        UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_AUTO_RENEW_PERIOD(
+                "updateTokenInfoAndGetUpdatedTokenInfoAutoRenewPeriod",
+                new Object[]{UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[]{FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getExpiry().autoRenewPeriod()}),
+        UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_AUTO_RENEW_PERIOD(
+                "updateTokenInfoAndGetUpdatedTokenInfoAutoRenewPeriod",
+                new Object[]{NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[]{
+                        NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getExpiry().autoRenewPeriod()
+                }),
+        DELETE_TOKEN_AND_GET_TOKEN_INFO_IS_DELETED(
+                "deleteTokenAndGetTokenInfoIsDeleted",
+                new Object[]{UNPAUSED_FUNGIBLE_TOKEN_ADDRESS},
+                new Object[]{true}),
+        DELETE_NFT_TOKEN_AND_GET_TOKEN_INFO_IS_DELETED(
+                "deleteTokenAndGetTokenInfoIsDeleted", new Object[]{NFT_TRANSFER_ADDRESS}, new Object[]{true}),
+        CREATE_FUNGIBLE_TOKEN_WITH_KEYS(
+                "createFungibleTokenAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
+                new Object[]{FUNGIBLE_TOKEN_WITH_KEYS, 10L, 10},
+                new Object[]{true, true, true}),
+        CREATE_FUNGIBLE_TOKEN_INHERIT_KEYS(
+                "createFungibleTokenAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
+                new Object[]{FUNGIBLE_TOKEN_INHERIT_KEYS, 10L, 10},
+                new Object[]{true, true, true}),
+        CREATE_FUNGIBLE_TOKEN_NO_KEYS(
+                "createFungibleTokenAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
+                new Object[]{FUNGIBLE_TOKEN, 10L, 10},
+                new Object[]{false, false, true}),
+        CREATE_NON_FUNGIBLE_TOKEN_WITH_KEYS(
+                "createNFTAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
+                new Object[]{NON_FUNGIBLE_TOKEN_WITH_KEYS, 10L, 10},
+                new Object[]{true, true, true}),
+        CREATE_NON_FUNGIBLE_TOKEN_INHERIT_KEYS(
+                "createNFTAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
+                new Object[]{NON_FUNGIBLE_TOKEN_INHERIT_KEYS, 10L, 10},
+                new Object[]{true, true, true}),
+        CREATE_NON_FUNGIBLE_TOKEN_NO_KEYS(
+                "createNFTAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
+                new Object[]{NON_FUNGIBLE_TOKEN, 10L, 10},
+                new Object[]{false, false, true});
+
+        private final String name;
+        private final Object[] functionParameters;
+        private final Object[] expectedResultFields;
+    }
+
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @DisplayName("processOpcodeCall")
@@ -144,12 +1003,12 @@ class OpcodeServiceTest extends ContractCallTestSetup {
         @BeforeEach
         void setUpArgumentCaptors() {
             doAnswer(invocation -> {
-                        final var transactionProcessingResult =
-                                (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
-                        resultCaptor = transactionProcessingResult;
-                        contextCaptor = ContractCallContext.get();
-                        return transactionProcessingResult;
-                    })
+                final var transactionProcessingResult =
+                        (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
+                resultCaptor = transactionProcessingResult;
+                contextCaptor = ContractCallContext.get();
+                return transactionProcessingResult;
+            })
                     .when(processor)
                     .execute(serviceParametersCaptor.capture(), gasCaptor.capture());
         }
@@ -210,8 +1069,8 @@ class OpcodeServiceTest extends ContractCallTestSetup {
 
             final var expectedResult = provider.getExpectedResultFields() != null
                     ? Bytes.fromHexString(functionEncodeDecoder.encodedResultFor(
-                                    provider.getName(), contractAbiPath, provider.getExpectedResultFields()))
-                            .toArray()
+                            provider.getName(), contractAbiPath, provider.getExpectedResultFields()))
+                    .toArray()
                     : null;
             final var expectedError = provider.getExpectedErrorMessage() != null
                     ? provider.getExpectedErrorMessage().getBytes()
@@ -265,20 +1124,6 @@ class OpcodeServiceTest extends ContractCallTestSetup {
             }
         }
 
-        @Getter
-        @RequiredArgsConstructor
-        private enum DynamicCallsContractFunctions implements ContractFunctionProviderEnum {
-            MINT_NFT("mintTokenGetTotalSupplyAndBalanceOfTreasury", new Object[] {
-                NFT_ADDRESS,
-                0L,
-                new byte[][] {ByteString.copyFromUtf8("firstMeta").toByteArray()},
-                OWNER_ADDRESS
-            });
-
-            private final String name;
-            private final Object[] functionParameters;
-        }
-
         @ParameterizedTest
         @MethodSource("tracerOptions")
         void callWithDifferentCombinationsOfTracerOptions(final OpcodeTracerOptions options) {
@@ -322,7 +1167,7 @@ class OpcodeServiceTest extends ContractCallTestSetup {
             contractEntityId = systemExchangeRateContractPersist();
 
             final TransactionIdOrHashParameter transactionIdOrHash = setUp(
-                    ContractCallSystemPrecompileTest.ExchangeRateFunctions.TINYBARS_TO_TINYCENTS,
+                    ContractCallSystemPrecompileHistoricalTest.ExchangeRateFunctions.TINYBARS_TO_TINYCENTS,
                     TransactionType.CONTRACTCALL,
                     EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS,
                     EXCHANGE_RATE_PRECOMPILE_ABI_PATH,
@@ -340,7 +1185,7 @@ class OpcodeServiceTest extends ContractCallTestSetup {
             contractEntityId = systemExchangeRateContractPersist();
 
             final TransactionIdOrHashParameter transactionIdOrHash = setUp(
-                    ContractCallSystemPrecompileTest.ExchangeRateFunctions.TINYCENTS_TO_TINYBARS,
+                    ContractCallSystemPrecompileHistoricalTest.ExchangeRateFunctions.TINYCENTS_TO_TINYBARS,
                     TransactionType.CONTRACTCALL,
                     EXCHANGE_RATE_PRECOMPILE_CONTRACT_ADDRESS,
                     EXCHANGE_RATE_PRECOMPILE_ABI_PATH,
@@ -448,808 +1293,19 @@ class OpcodeServiceTest extends ContractCallTestSetup {
             }
             return toAddress(entity.toEntityId());
         }
-    }
 
-    @Getter
-    @RequiredArgsConstructor
-    private enum NestedEthCallContractFunctions implements ContractFunctionProviderEnum {
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            1,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    1L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {1, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                    },
-                    1L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {1, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    1L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            1,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    1L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            2,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    2L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {2, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                    },
-                    2L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {2, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    2L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            2,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    2L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            4,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    4L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {4, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                    },
-                    4L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {4, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    4L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            4,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    4L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            8,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    8L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {8, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                    },
-                    8L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {8, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    8L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            8,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    8L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            16,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    16L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {16, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                        }
-                    },
-                    16L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {16, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    16L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            16,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    16L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            32,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    32L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {32, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                        }
-                    },
-                    32L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {32, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    32L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            32,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    32L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            64,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    64L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {64, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                        }
-                    },
-                    64L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {64, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    64L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            64,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    64L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            1,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    1L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {1, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                    },
-                    1L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {1, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    1L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            1,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    1L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            2,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    2L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {2, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                    },
-                    2L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {2, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    2L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            2,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    2L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            4,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    4L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {4, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                    },
-                    4L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {4, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    4L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            4,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    4L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            8,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    8L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {8, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                    },
-                    8L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {8, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    8L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            8,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    8L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            16,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    16L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {16, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                        }
-                    },
-                    16L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {16, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    16L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            16,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    16L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            32,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    32L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {32, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                        }
-                    },
-                    32L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {32, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    32L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            32,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    32L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_CONTRACT_ADDRESS(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            64,
-                            new Object[] {
-                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
-                            }
-                        }
-                    },
-                    64L
-                },
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ED25519_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {64, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                        }
-                    },
-                    64L
-                },
-                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ECDSA_KEY(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {64, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                    },
-                    64L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
-        UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_DELEGATE_CONTRACT_ID(
-                "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new Object[] {
-                        new Object[] {
-                            64,
-                            new Object[] {
-                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
-                            }
-                        }
-                    },
-                    64L
-                },
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        UPDATE_TOKEN_EXPIRY_AND_GET_TOKEN_EXPIRY(
-                "updateTokenExpiryAndGetUpdatedTokenExpiry",
-                new Object[] {
-                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                    new TokenExpiryWrapper(
-                            4_000_000_000L,
-                            EntityIdUtils.accountIdFromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS),
-                            8_000_000L)
-                },
-                new Object[] {4_000_000_000L, AUTO_RENEW_ACCOUNT_ADDRESS, 8_000_000L
-                }), // 4_000_000_000L in order to fit in uint32 until there is a support for int64 in EvmEncodingFacade
-        // to match the Expiry struct in IHederaTokenService
-        UPDATE_NFT_TOKEN_EXPIRY_AND_GET_TOKEN_EXPIRY(
-                "updateTokenExpiryAndGetUpdatedTokenExpiry",
-                new Object[] {
-                    NFT_TRANSFER_ADDRESS,
-                    new TokenExpiryWrapper(
-                            4_000_000_000L,
-                            EntityIdUtils.accountIdFromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS),
-                            8_000_000L)
-                },
-                new Object[] {4_000_000_000L, AUTO_RENEW_ACCOUNT_ADDRESS, 8_000_000L
-                }), // 4_000_000_000L in order to fit in uint32 until there is a support for int64 in EvmEncodingFacade
-        // to match the Expiry struct in IHederaTokenService
-        UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_SYMBOL(
-                "updateTokenInfoAndGetUpdatedTokenInfoSymbol",
-                new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[] {FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getSymbol()}),
-        UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_SYMBOL(
-                "updateTokenInfoAndGetUpdatedTokenInfoSymbol",
-                new Object[] {NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[] {NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getSymbol()}),
-        UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_NAME(
-                "updateTokenInfoAndGetUpdatedTokenInfoName",
-                new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[] {FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getName()}),
-        UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_NAME(
-                "updateTokenInfoAndGetUpdatedTokenInfoName",
-                new Object[] {NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[] {NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getName()}),
-        UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_MEMO(
-                "updateTokenInfoAndGetUpdatedTokenInfoMemo",
-                new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[] {FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getMemo()}),
-        UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_MEMO(
-                "updateTokenInfoAndGetUpdatedTokenInfoMemo",
-                new Object[] {NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[] {NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getMemo()}),
-        UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_AUTO_RENEW_PERIOD(
-                "updateTokenInfoAndGetUpdatedTokenInfoAutoRenewPeriod",
-                new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[] {FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getExpiry().autoRenewPeriod()}),
-        UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_AUTO_RENEW_PERIOD(
-                "updateTokenInfoAndGetUpdatedTokenInfoAutoRenewPeriod",
-                new Object[] {NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[] {
-                    NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getExpiry().autoRenewPeriod()
-                }),
-        DELETE_TOKEN_AND_GET_TOKEN_INFO_IS_DELETED(
-                "deleteTokenAndGetTokenInfoIsDeleted",
-                new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS},
-                new Object[] {true}),
-        DELETE_NFT_TOKEN_AND_GET_TOKEN_INFO_IS_DELETED(
-                "deleteTokenAndGetTokenInfoIsDeleted", new Object[] {NFT_TRANSFER_ADDRESS}, new Object[] {true}),
-        CREATE_FUNGIBLE_TOKEN_WITH_KEYS(
-                "createFungibleTokenAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[] {FUNGIBLE_TOKEN_WITH_KEYS, 10L, 10},
-                new Object[] {true, true, true}),
-        CREATE_FUNGIBLE_TOKEN_INHERIT_KEYS(
-                "createFungibleTokenAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[] {FUNGIBLE_TOKEN_INHERIT_KEYS, 10L, 10},
-                new Object[] {true, true, true}),
-        CREATE_FUNGIBLE_TOKEN_NO_KEYS(
-                "createFungibleTokenAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[] {FUNGIBLE_TOKEN, 10L, 10},
-                new Object[] {false, false, true}),
-        CREATE_NON_FUNGIBLE_TOKEN_WITH_KEYS(
-                "createNFTAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[] {NON_FUNGIBLE_TOKEN_WITH_KEYS, 10L, 10},
-                new Object[] {true, true, true}),
-        CREATE_NON_FUNGIBLE_TOKEN_INHERIT_KEYS(
-                "createNFTAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[] {NON_FUNGIBLE_TOKEN_INHERIT_KEYS, 10L, 10},
-                new Object[] {true, true, true}),
-        CREATE_NON_FUNGIBLE_TOKEN_NO_KEYS(
-                "createNFTAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[] {NON_FUNGIBLE_TOKEN, 10L, 10},
-                new Object[] {false, false, true});
+        @Getter
+        @RequiredArgsConstructor
+        private enum DynamicCallsContractFunctions implements ContractFunctionProviderEnum {
+            MINT_NFT("mintTokenGetTotalSupplyAndBalanceOfTreasury", new Object[]{
+                    NFT_ADDRESS,
+                    0L,
+                    new byte[][]{ByteString.copyFromUtf8("firstMeta").toByteArray()},
+                    OWNER_ADDRESS
+            });
 
-        private final String name;
-        private final Object[] functionParameters;
-        private final Object[] expectedResultFields;
+            private final String name;
+            private final Object[] functionParameters;
+        }
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/OpcodeServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/OpcodeServiceTest.java
@@ -85,854 +85,798 @@ class OpcodeServiceTest extends ContractCallTestSetup {
     private enum NestedEthCallContractFunctions implements ContractFunctionProviderEnum {
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        1,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        1L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            1,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    1L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{1,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                        },
-                        1L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {1, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                    },
+                    1L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{1,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        1L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {1, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    1L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        1,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        1L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            1,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    1L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        2,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        2L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            2,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    2L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{2,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                        },
-                        2L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {2, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                    },
+                    2L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{2,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        2L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {2, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    2L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        2,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        2L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            2,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    2L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        4,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        4L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            4,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    4L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{4,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                        },
-                        4L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {4, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                    },
+                    4L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{4,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        4L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {4, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    4L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        4,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        4L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            4,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    4L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        8,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        8L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            8,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    8L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{8,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                        },
-                        8L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {8, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                    },
+                    8L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{8,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        8L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {8, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    8L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        8,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        8L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            8,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    8L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        16,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        16L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            16,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    16L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{16,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                                }
-                        },
-                        16L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {16, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                        }
+                    },
+                    16L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{16,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        16L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {16, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    16L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        16,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        16L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            16,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    16L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        32,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        32L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            32,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    32L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{32,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                                }
-                        },
-                        32L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {32, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                        }
+                    },
+                    32L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{32,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        32L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {32, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    32L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        32,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        32L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            32,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    32L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        64,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        64L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            64,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    64L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{64,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                                }
-                        },
-                        64L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {64, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                        }
+                    },
+                    64L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{64,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        64L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {64, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    64L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        64,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        64L
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            64,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    64L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        1,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        1L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            1,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    1L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{1,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                        },
-                        1L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {1, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                    },
+                    1L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{1,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        1L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {1, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    1L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_ADMIN_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        1,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        1L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            1,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    1L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        2,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        2L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            2,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    2L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{2,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                        },
-                        2L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {2, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                    },
+                    2L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{2,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        2L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {2, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    2L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_KYC_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        2,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        2L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            2,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    2L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        4,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        4L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            4,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    4L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{4,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                        },
-                        4L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {4, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                    },
+                    4L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{4,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        4L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {4, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    4L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FREEZE_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        4,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        4L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            4,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    4L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        8,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        8L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            8,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    8L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{8,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
-                        },
-                        8L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {8, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}}
+                    },
+                    8L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{8,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        8L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {8, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    8L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_WIPE_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        8,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        8L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            8,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    8L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        16,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        16L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            16,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    16L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{16,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                                }
-                        },
-                        16L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {16, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                        }
+                    },
+                    16L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{16,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        16L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {16, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    16L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_SUPPLY_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        16,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        16L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            16,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    16L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        32,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        32L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            32,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    32L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{32,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                                }
-                        },
-                        32L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {32, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                        }
+                    },
+                    32L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{32,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        32L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {32, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    32L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_FEE_SCHEDULE_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        32,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        32L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            32,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    32L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_CONTRACT_ADDRESS(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        64,
-                                        new Object[]{
-                                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0],
-                                                Address.ZERO
-                                        }
-                                }
-                        },
-                        64L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            64,
+                            new Object[] {
+                                false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO
+                            }
+                        }
+                    },
+                    64L
                 },
-                new Object[]{false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
+                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ED25519_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{64,
-                                        new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
-                                }
-                        },
-                        64L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {64, new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}
+                        }
+                    },
+                    64L
                 },
-                new Object[]{false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
+                new Object[] {false, Address.ZERO, NEW_ED25519_KEY, new byte[0], Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_ECDSA_KEY(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{64,
-                                        new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
-                        },
-                        64L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {64, new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}}
+                    },
+                    64L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
+                new Object[] {false, Address.ZERO, new byte[0], NEW_ECDSA_KEY, Address.ZERO}),
         UPDATE_NFT_TOKEN_KEYS_AND_GET_TOKEN_KEY_PAUSE_KEY_DELEGATE_CONTRACT_ID(
                 "updateTokenKeysAndGetUpdatedTokenKey",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new Object[]{
-                                new Object[]{
-                                        64,
-                                        new Object[]{
-                                                false, Address.ZERO, new byte[0], new byte[0],
-                                                PRECOMPILE_TEST_CONTRACT_ADDRESS
-                                        }
-                                }
-                        },
-                        64L
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new Object[] {
+                        new Object[] {
+                            64,
+                            new Object[] {
+                                false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS
+                            }
+                        }
+                    },
+                    64L
                 },
-                new Object[]{false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
+                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
         UPDATE_TOKEN_EXPIRY_AND_GET_TOKEN_EXPIRY(
                 "updateTokenExpiryAndGetUpdatedTokenExpiry",
-                new Object[]{
-                        UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
-                        new TokenExpiryWrapper(
-                                4_000_000_000L,
-                                EntityIdUtils.accountIdFromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS),
-                                8_000_000L)
+                new Object[] {
+                    UNPAUSED_FUNGIBLE_TOKEN_ADDRESS,
+                    new TokenExpiryWrapper(
+                            4_000_000_000L,
+                            EntityIdUtils.accountIdFromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS),
+                            8_000_000L)
                 },
-                new Object[]{4_000_000_000L, AUTO_RENEW_ACCOUNT_ADDRESS, 8_000_000L
+                new Object[] {4_000_000_000L, AUTO_RENEW_ACCOUNT_ADDRESS, 8_000_000L
                 }), // 4_000_000_000L in order to fit in uint32 until there is a support for int64 in EvmEncodingFacade
         // to match the Expiry struct in IHederaTokenService
         UPDATE_NFT_TOKEN_EXPIRY_AND_GET_TOKEN_EXPIRY(
                 "updateTokenExpiryAndGetUpdatedTokenExpiry",
-                new Object[]{
-                        NFT_TRANSFER_ADDRESS,
-                        new TokenExpiryWrapper(
-                                4_000_000_000L,
-                                EntityIdUtils.accountIdFromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS),
-                                8_000_000L)
+                new Object[] {
+                    NFT_TRANSFER_ADDRESS,
+                    new TokenExpiryWrapper(
+                            4_000_000_000L,
+                            EntityIdUtils.accountIdFromEvmAddress(AUTO_RENEW_ACCOUNT_ADDRESS),
+                            8_000_000L)
                 },
-                new Object[]{4_000_000_000L, AUTO_RENEW_ACCOUNT_ADDRESS, 8_000_000L
+                new Object[] {4_000_000_000L, AUTO_RENEW_ACCOUNT_ADDRESS, 8_000_000L
                 }), // 4_000_000_000L in order to fit in uint32 until there is a support for int64 in EvmEncodingFacade
         // to match the Expiry struct in IHederaTokenService
         UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_SYMBOL(
                 "updateTokenInfoAndGetUpdatedTokenInfoSymbol",
-                new Object[]{UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[]{FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getSymbol()}),
+                new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[] {FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getSymbol()}),
         UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_SYMBOL(
                 "updateTokenInfoAndGetUpdatedTokenInfoSymbol",
-                new Object[]{NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[]{NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getSymbol()}),
+                new Object[] {NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[] {NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getSymbol()}),
         UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_NAME(
                 "updateTokenInfoAndGetUpdatedTokenInfoName",
-                new Object[]{UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[]{FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getName()}),
+                new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[] {FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getName()}),
         UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_NAME(
                 "updateTokenInfoAndGetUpdatedTokenInfoName",
-                new Object[]{NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[]{NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getName()}),
+                new Object[] {NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[] {NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getName()}),
         UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_MEMO(
                 "updateTokenInfoAndGetUpdatedTokenInfoMemo",
-                new Object[]{UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[]{FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getMemo()}),
+                new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[] {FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getMemo()}),
         UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_MEMO(
                 "updateTokenInfoAndGetUpdatedTokenInfoMemo",
-                new Object[]{NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[]{NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getMemo()}),
+                new Object[] {NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[] {NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getMemo()}),
         UPDATE_TOKEN_INFO_AND_GET_TOKEN_INFO_AUTO_RENEW_PERIOD(
                 "updateTokenInfoAndGetUpdatedTokenInfoAutoRenewPeriod",
-                new Object[]{UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[]{FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getExpiry().autoRenewPeriod()}),
+                new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS, FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[] {FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getExpiry().autoRenewPeriod()}),
         UPDATE_NFT_TOKEN_INFO_AND_GET_TOKEN_INFO_AUTO_RENEW_PERIOD(
                 "updateTokenInfoAndGetUpdatedTokenInfoAutoRenewPeriod",
-                new Object[]{NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
-                new Object[]{
-                        NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getExpiry().autoRenewPeriod()
+                new Object[] {NFT_TRANSFER_ADDRESS, NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE},
+                new Object[] {
+                    NON_FUNGIBLE_TOKEN_EXPIRY_IN_UINT32_RANGE.getExpiry().autoRenewPeriod()
                 }),
         DELETE_TOKEN_AND_GET_TOKEN_INFO_IS_DELETED(
                 "deleteTokenAndGetTokenInfoIsDeleted",
-                new Object[]{UNPAUSED_FUNGIBLE_TOKEN_ADDRESS},
-                new Object[]{true}),
+                new Object[] {UNPAUSED_FUNGIBLE_TOKEN_ADDRESS},
+                new Object[] {true}),
         DELETE_NFT_TOKEN_AND_GET_TOKEN_INFO_IS_DELETED(
-                "deleteTokenAndGetTokenInfoIsDeleted", new Object[]{NFT_TRANSFER_ADDRESS}, new Object[]{true}),
+                "deleteTokenAndGetTokenInfoIsDeleted", new Object[] {NFT_TRANSFER_ADDRESS}, new Object[] {true}),
         CREATE_FUNGIBLE_TOKEN_WITH_KEYS(
                 "createFungibleTokenAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[]{FUNGIBLE_TOKEN_WITH_KEYS, 10L, 10},
-                new Object[]{true, true, true}),
+                new Object[] {FUNGIBLE_TOKEN_WITH_KEYS, 10L, 10},
+                new Object[] {true, true, true}),
         CREATE_FUNGIBLE_TOKEN_INHERIT_KEYS(
                 "createFungibleTokenAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[]{FUNGIBLE_TOKEN_INHERIT_KEYS, 10L, 10},
-                new Object[]{true, true, true}),
+                new Object[] {FUNGIBLE_TOKEN_INHERIT_KEYS, 10L, 10},
+                new Object[] {true, true, true}),
         CREATE_FUNGIBLE_TOKEN_NO_KEYS(
                 "createFungibleTokenAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[]{FUNGIBLE_TOKEN, 10L, 10},
-                new Object[]{false, false, true}),
+                new Object[] {FUNGIBLE_TOKEN, 10L, 10},
+                new Object[] {false, false, true}),
         CREATE_NON_FUNGIBLE_TOKEN_WITH_KEYS(
                 "createNFTAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[]{NON_FUNGIBLE_TOKEN_WITH_KEYS, 10L, 10},
-                new Object[]{true, true, true}),
+                new Object[] {NON_FUNGIBLE_TOKEN_WITH_KEYS, 10L, 10},
+                new Object[] {true, true, true}),
         CREATE_NON_FUNGIBLE_TOKEN_INHERIT_KEYS(
                 "createNFTAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[]{NON_FUNGIBLE_TOKEN_INHERIT_KEYS, 10L, 10},
-                new Object[]{true, true, true}),
+                new Object[] {NON_FUNGIBLE_TOKEN_INHERIT_KEYS, 10L, 10},
+                new Object[] {true, true, true}),
         CREATE_NON_FUNGIBLE_TOKEN_NO_KEYS(
                 "createNFTAndGetIsTokenAndGetDefaultFreezeStatusAndGetDefaultKycStatus",
-                new Object[]{NON_FUNGIBLE_TOKEN, 10L, 10},
-                new Object[]{false, false, true});
+                new Object[] {NON_FUNGIBLE_TOKEN, 10L, 10},
+                new Object[] {false, false, true});
 
         private final String name;
         private final Object[] functionParameters;
@@ -1003,12 +947,12 @@ class OpcodeServiceTest extends ContractCallTestSetup {
         @BeforeEach
         void setUpArgumentCaptors() {
             doAnswer(invocation -> {
-                final var transactionProcessingResult =
-                        (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
-                resultCaptor = transactionProcessingResult;
-                contextCaptor = ContractCallContext.get();
-                return transactionProcessingResult;
-            })
+                        final var transactionProcessingResult =
+                                (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
+                        resultCaptor = transactionProcessingResult;
+                        contextCaptor = ContractCallContext.get();
+                        return transactionProcessingResult;
+                    })
                     .when(processor)
                     .execute(serviceParametersCaptor.capture(), gasCaptor.capture());
         }
@@ -1069,8 +1013,8 @@ class OpcodeServiceTest extends ContractCallTestSetup {
 
             final var expectedResult = provider.getExpectedResultFields() != null
                     ? Bytes.fromHexString(functionEncodeDecoder.encodedResultFor(
-                            provider.getName(), contractAbiPath, provider.getExpectedResultFields()))
-                    .toArray()
+                                    provider.getName(), contractAbiPath, provider.getExpectedResultFields()))
+                            .toArray()
                     : null;
             final var expectedError = provider.getExpectedErrorMessage() != null
                     ? provider.getExpectedErrorMessage().getBytes()
@@ -1297,11 +1241,11 @@ class OpcodeServiceTest extends ContractCallTestSetup {
         @Getter
         @RequiredArgsConstructor
         private enum DynamicCallsContractFunctions implements ContractFunctionProviderEnum {
-            MINT_NFT("mintTokenGetTotalSupplyAndBalanceOfTreasury", new Object[]{
-                    NFT_ADDRESS,
-                    0L,
-                    new byte[][]{ByteString.copyFromUtf8("firstMeta").toByteArray()},
-                    OWNER_ADDRESS
+            MINT_NFT("mintTokenGetTotalSupplyAndBalanceOfTreasury", new Object[] {
+                NFT_ADDRESS,
+                0L,
+                new byte[][] {ByteString.copyFromUtf8("firstMeta").toByteArray()},
+                OWNER_ADDRESS
             });
 
             private final String name;

--- a/hedera-mirror-web3/src/test/solidity/ExchangeRatePrecompile.sol
+++ b/hedera-mirror-web3/src/test/solidity/ExchangeRatePrecompile.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+
+contract ExchangeRatePrecompile {
+
+    uint256 constant TINY_PARTS_PER_WHOLE = 100_000_000;
+    address constant PRECOMPILE_ADDRESS = address(0x168);
+    bytes4 constant TINYCENTS_TO_TINYBARS = bytes4(keccak256("tinycentsToTinybars(uint256)"));
+    bytes4 constant TINYBARS_TO_TINYCENTS = bytes4(keccak256("tinybarsToTinycents(uint256)"));
+
+    function tinycentsToTinybars(uint256 tinycents) external payable returns (uint256 tinybars) {
+        (bool success, bytes memory result) = PRECOMPILE_ADDRESS.call{value: msg.value}(
+            abi.encodeWithSelector(TINYCENTS_TO_TINYBARS, tinycents));
+        require(success);
+        tinybars = abi.decode(result, (uint256));
+    }
+
+    function tinybarsToTinycents(uint256 tinybars) external payable returns (uint256 tinycents) {
+        (bool success, bytes memory result) = PRECOMPILE_ADDRESS.call{value: msg.value}(
+            abi.encodeWithSelector(TINYBARS_TO_TINYCENTS, tinybars));
+        require(success);
+        tinycents = abi.decode(result, (uint256));
+    }
+}

--- a/hedera-mirror-web3/src/test/solidity/IPrngSystemContract.sol
+++ b/hedera-mirror-web3/src/test/solidity/IPrngSystemContract.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+
+interface IPrngSystemContract {
+    // Generates a 256-bit pseudorandom seed using the first 256-bits of running hash from the latest RecordFile in the database.
+    // Users can generate a pseudorandom number in a specified range using the seed by (integer value of seed % range)
+    function getPseudorandomSeed() external returns (bytes32);
+}

--- a/hedera-mirror-web3/src/test/solidity/PrngSystemContract.sol
+++ b/hedera-mirror-web3/src/test/solidity/PrngSystemContract.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+
+import "./IPrngSystemContract.sol";
+
+contract PrngSystemContract {
+    address constant PRECOMPILE_ADDRESS = address(0x169);
+
+    function getPseudorandomSeed() external payable returns (bytes32 randomBytes) {
+        (bool success, bytes memory result) = PRECOMPILE_ADDRESS.call{value: msg.value}(
+            abi.encodeWithSelector(IPrngSystemContract.getPseudorandomSeed.selector));
+        require(success);
+        randomBytes = abi.decode(result, (bytes32));
+    }
+}


### PR DESCRIPTION
**Description**:
This PR refactors ContractCallSystemPrecompileTest to use the web3j plugin.
Historical test are moved into a new class ContractCallSystemPrecompileHistoricalTest.

This PR modifies;
Refactored ContractCallSystemPrecompileTest to use the web3j approach
Moved historical tests into ContractCallSystemPrecompileHistoricalTest.
Added a new method in AbstractContractCallServiceTest that asserts that estimate gas fails with expected 
exception and error message.

Fixes #8453 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
