### PR TITLE
8456 Refactor ContractCallServiceERCTokenTest readonly redirect functions

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenReadOnlyFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenReadOnlyFunctionsTest.java
@@ -716,7 +716,6 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
         verifyEthCallAndEstimateGas(functionCall, contract);
     }
 
-
     @Test
     void ethCallIsApprovedForAllWithAliasRedirect() throws Exception {
         final var spender = spenderEntityPersistWithAlias();
@@ -738,7 +737,6 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
                 toAddress(spender).toHexString());
         verifyEthCallAndEstimateGas(functionCall, contract);
     }
-
 
     @Test
     void ethCallAllowanceRedirect() throws Exception {
@@ -762,7 +760,6 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
                 toAddress(spender).toHexString());
         verifyEthCallAndEstimateGas(functionCall, contract);
     }
-
 
     @Test
     void ethCallAllowanceWithAliasRedirect() throws Exception {
@@ -874,7 +871,8 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
                 .persist();
         final var tokenAddress = toAddress(tokenEntity.getTokenId());
         final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
-        final var functionCall = contract.send_balanceOfRedirect(tokenAddress.toHexString(), SENDER_ALIAS.toHexString());
+        final var functionCall =
+                contract.send_balanceOfRedirect(tokenAddress.toHexString(), SENDER_ALIAS.toHexString());
         verifyEthCallAndEstimateGas(functionCall, contract);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenReadOnlyFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenReadOnlyFunctionsTest.java
@@ -31,6 +31,7 @@ import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.web3.web3j.generated.ERCTestContract;
+import com.hedera.mirror.web3.web3j.generated.RedirectTestContract;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityIdUtils;
 import java.math.BigInteger;
@@ -669,6 +670,273 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
                 .send();
         final var functionCall = contract.send_tokenURINonStatic(tokenAddress.toHexString(), BigInteger.valueOf(1));
         assertThat(result).isEqualTo(metadata);
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallGetApprovedEmptySpenderRedirect() throws Exception {
+        final var treasuryEntityId = accountPersist();
+        final var tokenEntity = persistTokenEntity();
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                        .treasuryAccountId(treasuryEntityId))
+                .persist();
+        domainBuilder
+                .nft()
+                .customize(n -> n.tokenId(tokenEntity.getId()).serialNumber(1L).accountId(treasuryEntityId))
+                .persist();
+
+        final var tokenAddress = getAddressFromEntity(tokenEntity);
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_getApprovedRedirect(tokenAddress, BigInteger.valueOf(1));
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallIsApprovedForAllRedirect() throws Exception {
+        final var owner = accountPersist();
+        final var spender = accountPersist();
+        final var tokenEntity = nftPersist(owner);
+        domainBuilder
+                .nftAllowance()
+                .customize(a -> a.tokenId(tokenEntity.getTokenId())
+                        .spender(spender.getId())
+                        .owner(owner.getId())
+                        .payerAccountId(owner)
+                        .approvedForAll(true))
+                .persist();
+        final var tokenAddress = toAddress(tokenEntity.getTokenId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_isApprovedForAllRedirect(
+                tokenAddress.toHexString(),
+                toAddress(owner).toHexString(),
+                toAddress(spender).toHexString());
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+
+    @Test
+    void ethCallIsApprovedForAllWithAliasRedirect() throws Exception {
+        final var spender = spenderEntityPersistWithAlias();
+        final var owner = senderEntityPersistWithAlias();
+        final var tokenEntity = nftPersist(owner);
+        domainBuilder
+                .nftAllowance()
+                .customize(a -> a.tokenId(tokenEntity.getTokenId())
+                        .spender(spender.getId())
+                        .owner(owner.getId())
+                        .payerAccountId(owner)
+                        .approvedForAll(true))
+                .persist();
+        final var tokenAddress = toAddress(tokenEntity.getTokenId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_isApprovedForAllRedirect(
+                tokenAddress.toHexString(),
+                toAddress(owner).toHexString(),
+                toAddress(spender).toHexString());
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+
+    @Test
+    void ethCallAllowanceRedirect() throws Exception {
+        final var owner = accountPersist();
+        final var spender = accountPersist();
+        final var tokenEntity = fungibleTokenPersist();
+        final var amountGranted = 50L;
+        domainBuilder
+                .tokenAllowance()
+                .customize(a -> a.tokenId(tokenEntity.getTokenId())
+                        .owner(owner.getNum())
+                        .spender(spender.getNum())
+                        .amount(amountGranted)
+                        .amountGranted(amountGranted))
+                .persist();
+        final var tokenAddress = toAddress(tokenEntity.getTokenId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_allowanceRedirect(
+                tokenAddress.toHexString(),
+                toAddress(owner).toHexString(),
+                toAddress(spender).toHexString());
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+
+    @Test
+    void ethCallAllowanceWithAliasRedirect() throws Exception {
+        final var spender = spenderEntityPersistWithAlias();
+        final var owner = senderEntityPersistWithAlias();
+        final var tokenEntity = fungibleTokenPersist();
+        final var amountGranted = 50L;
+        domainBuilder
+                .tokenAllowance()
+                .customize(a -> a.tokenId(tokenEntity.getTokenId())
+                        .owner(owner.getNum())
+                        .spender(spender.getNum())
+                        .amount(amountGranted)
+                        .amountGranted(amountGranted))
+                .persist();
+        final var tokenAddress = toAddress(tokenEntity.getTokenId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_allowanceRedirect(
+                tokenAddress.toHexString(), SENDER_ALIAS.toHexString(), SPENDER_ALIAS.toHexString());
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallGetApprovedRedirect() throws Exception {
+        final var owner = accountPersist();
+        final var spender = accountPersist();
+        final var tokenEntity = nftPersist(owner, owner, spender);
+        final var tokenAddress = toAddress(tokenEntity.getTokenId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_getApprovedRedirect(tokenAddress.toHexString(), BigInteger.valueOf(1));
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallGetDecimalsRedirect() throws Exception {
+        final var decimals = 12;
+        final var tokenEntity = persistTokenEntity();
+        domainBuilder
+                .token()
+                .customize(ta -> ta.tokenId(tokenEntity.getId()).decimals(decimals))
+                .persist();
+        final var tokenAddress = toAddress(tokenEntity.getId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_decimalsRedirect(tokenAddress.toHexString());
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallGetTotalSupplyRedirect() throws Exception {
+        final var totalSupply = 12345L;
+        final var tokenEntity = persistTokenEntity();
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .totalSupply(totalSupply))
+                .persist();
+
+        final var tokenAddress = getAddressFromEntity(tokenEntity);
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_totalSupplyRedirect(tokenAddress);
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallSymbolRedirect() throws Exception {
+        final var symbol = "HBAR";
+        final var tokenEntity = persistTokenEntity();
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .symbol(symbol))
+                .persist();
+        final var tokenAddress = getAddressFromEntity(tokenEntity);
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_symbolRedirect(tokenAddress);
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallBalanceOfRedirect() throws Exception {
+        final var owner = accountPersist();
+        final var tokenEntity = fungibleTokenPersist(owner);
+        final var balance = 12L;
+        domainBuilder
+                .tokenAccount()
+                .customize(e -> e.accountId(owner.getId())
+                        .tokenId(tokenEntity.getTokenId())
+                        .balance(balance))
+                .persist();
+        final var tokenAddress = toAddress(tokenEntity.getTokenId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_balanceOfRedirect(
+                tokenAddress.toHexString(), toAddress(owner).toHexString());
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallBalanceOfWithAliasRedirect() throws Exception {
+        final var owner = senderEntityPersistWithAlias();
+        final var tokenEntity = fungibleTokenPersist(owner);
+        final var balance = 12L;
+        domainBuilder
+                .tokenAccount()
+                .customize(e -> e.accountId(owner.getId())
+                        .tokenId(tokenEntity.getTokenId())
+                        .balance(balance))
+                .persist();
+        final var tokenAddress = toAddress(tokenEntity.getTokenId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_balanceOfRedirect(tokenAddress.toHexString(), SENDER_ALIAS.toHexString());
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallNameRedirect() throws Exception {
+        final var tokenName = "Hbars";
+        final var tokenEntity = persistTokenEntity();
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .name(tokenName))
+                .persist();
+        final var tokenAddress = toAddress(tokenEntity.getId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_nameRedirect(tokenAddress.toHexString());
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallGetOwnerOfRedirect() throws Exception {
+        final var owner = accountPersist();
+        final var tokenEntity = nftPersist(owner);
+        final var tokenAddress = toAddress(tokenEntity.getTokenId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_getOwnerOfRedirect(tokenAddress.toHexString(), BigInteger.valueOf(1));
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallGetOwnerOfEmptyOwnerRedirect() throws Exception {
+        final var tokenEntity = nftPersist();
+        final var tokenAddress = toAddress(tokenEntity.getTokenId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_getOwnerOfRedirect(tokenAddress.toHexString(), BigInteger.valueOf(1));
+        verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void ethCallTokenURIRedirect() throws Exception {
+        final var ownerEntity = accountPersist();
+        final byte[] kycKey = domainBuilder.key();
+        final var metadata = "NFT_METADATA_URI";
+        final var tokenEntity = persistTokenEntity();
+
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                        .treasuryAccountId(ownerEntity)
+                        .kycKey(kycKey))
+                .persist();
+        domainBuilder
+                .nft()
+                .customize(n -> n.tokenId(tokenEntity.getId())
+                        .metadata(metadata.getBytes())
+                        .serialNumber(1))
+                .persist();
+
+        final var tokenAddress = toAddress(tokenEntity.getId());
+        final var contract = testWeb3jService.deploy(RedirectTestContract::deploy);
+        final var functionCall = contract.send_tokenURIRedirect(tokenAddress.toHexString(), BigInteger.valueOf(1));
         verifyEthCallAndEstimateGas(functionCall, contract);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -122,22 +122,6 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
     }
 
     @ParameterizedTest
-    @EnumSource(ErcContractReadOnlyFunctions.class)
-    void supportedErcReadOnlyRedirectPrecompileOperationsTest(final ErcContractReadOnlyFunctions ercFunction) {
-        final var functionName = ercFunction.name + REDIRECT_SUFFIX;
-        final var functionHash = functionEncodeDecoder.functionHashFor(
-                functionName, REDIRECT_CONTRACT_ABI_PATH, ercFunction.functionParameters);
-        final var serviceParameters = serviceParametersForExecution(
-                functionHash, REDIRECT_CONTRACT_ADDRESS, ETH_ESTIMATE_GAS, 0L, BlockType.LATEST);
-
-        final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);
-
-        assertThat(isWithinExpectedGasRange(
-                        longValueOf.applyAsLong(contractCallService.processCall(serviceParameters)), expectedGasUsed))
-                .isTrue();
-    }
-
-    @ParameterizedTest
     @EnumSource(ErcContractReadOnlyFunctionsNegative.class)
     void supportedErcReadOnlyRedirectPrecompileNegativeOperationsTest(
             final ErcContractReadOnlyFunctionsNegative ercFunction) {
@@ -174,38 +158,6 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
         final var serviceParameters =
                 serviceParametersForExecution(functionHash, ERC_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
         assertThat(contractCallService.processCall(serviceParameters)).isEqualTo("0x");
-    }
-
-    @Getter
-    @RequiredArgsConstructor
-    public enum ErcContractReadOnlyFunctions implements ContractFunctionProviderEnum {
-        GET_APPROVED_EMPTY_SPENDER("getApproved", new Object[] {NFT_ADDRESS, 2L}, new Address[] {Address.ZERO}),
-        IS_APPROVE_FOR_ALL(
-                "isApprovedForAll", new Address[] {NFT_ADDRESS, SENDER_ADDRESS, SPENDER_ADDRESS}, new Boolean[] {true}),
-        IS_APPROVE_FOR_ALL_WITH_ALIAS(
-                "isApprovedForAll", new Address[] {NFT_ADDRESS, SENDER_ALIAS, SPENDER_ALIAS}, new Boolean[] {true}),
-        ALLOWANCE_OF(
-                "allowance", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS, SPENDER_ADDRESS}, new Long[] {13L}),
-        ALLOWANCE_OF_WITH_ALIAS(
-                "allowance", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS, SPENDER_ALIAS}, new Long[] {13L}),
-        GET_APPROVED("getApproved", new Object[] {NFT_ADDRESS, 1L}, new Address[] {SPENDER_ALIAS}),
-        ERC_DECIMALS("decimals", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Integer[] {12}),
-        TOTAL_SUPPLY("totalSupply", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new Long[] {12345L}),
-        ERC_SYMBOL("symbol", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new String[] {"HBAR"}),
-        BALANCE_OF("balanceOf", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ADDRESS}, new Long[] {12L}),
-        BALANCE_OF_WITH_ALIAS("balanceOf", new Address[] {FUNGIBLE_TOKEN_ADDRESS, SENDER_ALIAS}, new Long[] {12L}),
-        ERC_NAME("name", new Address[] {FUNGIBLE_TOKEN_ADDRESS}, new String[] {"Hbars"}),
-        OWNER_OF("getOwnerOf", new Object[] {NFT_ADDRESS, 1L}, new Address[] {OWNER_ADDRESS}),
-        EMPTY_OWNER_OF("getOwnerOf", new Object[] {NFT_ADDRESS, 2L}, new Address[] {Address.ZERO}),
-        TOKEN_URI("tokenURI", new Object[] {NFT_ADDRESS, 1L}, new String[] {"NFT_METADATA_URI"});
-
-        private final String name;
-        private final Object[] functionParameters;
-        private final Object[] expectedResultFields;
-
-        public String getName(final boolean isStatic) {
-            return isStatic ? name : name + NON_STATIC_SUFFIX;
-        }
     }
 
     @Getter

--- a/hedera-mirror-web3/src/test/solidity/RedirectTestContract.sol
+++ b/hedera-mirror-web3/src/test/solidity/RedirectTestContract.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "./HederaTokenService.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+
+
+contract RedirectTestContract is HederaTokenService {
+
+    function nameRedirect(address token) public returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC20Metadata.name.selector));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token name redirect failed");
+        }
+        return responseResult;
+    }
+
+    function symbolRedirect(address token) public returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC20Metadata.symbol.selector));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token symbol redirect failed");
+        }
+        return responseResult;
+    }
+
+    function decimalsRedirect(address token) public returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC20Metadata.decimals.selector));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token decimals() redirect failed");
+        }
+        return responseResult;
+    }
+
+    function totalSupplyRedirect(address token) external returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC20.totalSupply.selector));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token totalSupply redirect failed");
+        }
+        return responseResult;
+    }
+
+    function balanceOfRedirect(address token, address account) public returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC20.balanceOf.selector, account));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token balanceOf redirect failed");
+        }
+        return responseResult;
+    }
+
+    function allowanceRedirect(address token, address owner, address spender) external returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC20.allowance.selector, owner, spender));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token allowance redirect failed");
+        }
+        return responseResult;
+    }
+
+    function getApprovedRedirect(address token, uint256 tokenId) external returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC721.getApproved.selector, tokenId));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token getApproved redirect failed");
+        }
+        return responseResult;
+    }
+
+    function getOwnerOfRedirect(address token, uint256 serialNo) external returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC721.ownerOf.selector, serialNo));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token getOwnerOf redirect failed");
+        }
+        return responseResult;
+    }
+
+    function tokenURIRedirect(address token, uint256 tokenId) public returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC721Metadata.tokenURI.selector, tokenId));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token tokenURI redirect failed");
+        }
+        return responseResult;
+    }
+
+    function isApprovedForAllRedirect(address token, address owner, address operator) public returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC721.isApprovedForAll.selector, owner, operator));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token isApprovedForAll redirect failed");
+        }
+        return responseResult;
+    }
+
+    //Modification operations
+
+    function transferRedirect(address token, address recipient, uint256 amount) public returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC20.transfer.selector, recipient, amount));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token transfer redirect failed");
+        }
+        return responseResult;
+    }
+
+    function transferFromRedirect(address token, address sender, address recipient, uint256 amount) public returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC20.transferFrom.selector, sender, recipient, amount));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token transferFrom redirect failed");
+        }
+        return responseResult;
+    }
+
+    function approveRedirect(address token, address spender, uint256 amount) public returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC20.approve.selector, spender, amount));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token approve redirect failed");
+        }
+        return responseResult;
+    }
+
+    function transferFromNFTRedirect(address token, address from, address to, uint256 tokenId) public returns (bytes memory result) {
+        (int response, bytes memory responseResult) = this.redirectForToken(token, abi.encodeWithSelector(IERC721.transferFrom.selector, from, to, tokenId));
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token transferFromNFT redirect failed");
+        }
+        return responseResult;
+    }
+
+}


### PR DESCRIPTION
**Description**:
With this PR the ContractCallServiceERCTokenTest integration test file is partially refactored using the web3j plugin and the big enum is now replaced with multiple junit tests so that it is easier to debug a particular scenario. This way also the number of persisted entities per test is reduced significantly and now we persist only the ones that are needed in the particular test.

This PR refactors the read only redirect functions tests 

**Related issue(s)**:
Related and partially fixes: #8456 
Fixes #

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
