### PR TITLE
Standardize rest-java error response

### DIFF
--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/controller/GenericControllerAdvice.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/controller/GenericControllerAdvice.java
@@ -20,6 +20,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
 import com.hedera.mirror.common.exception.InvalidEntityException;
 import com.hedera.mirror.rest.model.Error;
@@ -29,16 +30,30 @@ import com.hedera.mirror.restjava.RestJavaProperties;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Locale;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.context.properties.bind.BindException;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.context.support.StaticMessageSource;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.dao.QueryTimeoutException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.lang.Nullable;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.validation.method.MethodValidationResult;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -46,6 +61,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.util.WebUtils;
 
 @ControllerAdvice
 @CustomLog
@@ -53,6 +69,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @RequiredArgsConstructor
 class GenericControllerAdvice extends ResponseEntityExceptionHandler {
 
+    private final MessageSource messageSource = new ErrorMessageSource();
     private final RestJavaProperties properties;
 
     @ModelAttribute
@@ -62,64 +79,122 @@ class GenericControllerAdvice extends ResponseEntityExceptionHandler {
         responseHeaders.forEach(response::setHeader);
     }
 
-    @ExceptionHandler
-    private ResponseEntity<Error> notFound(final EntityNotFoundException e) {
-        return errorResponse(e.getMessage(), NOT_FOUND);
+    @ExceptionHandler({
+        HttpMessageConversionException.class,
+        IllegalArgumentException.class,
+        InvalidEntityException.class
+    })
+    private ResponseEntity<Object> badRequest(final Exception e, final WebRequest request) {
+        return handleExceptionInternal(e, null, null, BAD_REQUEST, request);
     }
 
     @ExceptionHandler
-    private ResponseEntity<Error> inputValidationError(final InvalidEntityException e) {
-        return errorResponse(e.getMessage(), BAD_REQUEST);
-    }
-
-    @ExceptionHandler
-    private ResponseEntity<Error> inputValidationError(final IllegalArgumentException e) {
-        return errorResponse(e.getMessage(), BAD_REQUEST);
-    }
-
-    @ExceptionHandler
-    private ResponseEntity<Error> bindError(final BindException e) {
-        return errorResponse(e.getMessage(), BAD_REQUEST);
-    }
-
-    @ExceptionHandler
-    private ResponseEntity<Error> queryTimeout(final QueryTimeoutException e) {
-        log.error("Query timed out: {}", e.getMessage());
-        return errorResponse(SERVICE_UNAVAILABLE.getReasonPhrase(), SERVICE_UNAVAILABLE);
-    }
-
-    @ExceptionHandler
-    private ResponseEntity<Error> genericError(final Exception e) {
+    private ResponseEntity<Object> defaultExceptionHandler(final Exception e, final WebRequest request) {
         log.error("Generic error: ", e);
-        return errorResponse(SERVICE_UNAVAILABLE.getReasonPhrase(), INTERNAL_SERVER_ERROR);
+        var headers = e instanceof ErrorResponse er ? er.getHeaders() : null;
+        return handleExceptionInternal(e, null, headers, INTERNAL_SERVER_ERROR, request);
+    }
+
+    @ExceptionHandler
+    private ResponseEntity<Object> notFound(final EntityNotFoundException e, final WebRequest request) {
+        return handleExceptionInternal(e, null, null, NOT_FOUND, request);
+    }
+
+    @ExceptionHandler
+    private ResponseEntity<Object> queryTimeout(final QueryTimeoutException e, final WebRequest request) {
+        log.error("Query timed out: {}", e.getMessage());
+        return handleExceptionInternal(e, null, null, SERVICE_UNAVAILABLE, request);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    protected ResponseEntity<Object> createResponseEntity(
-            Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
-        var message = statusCode instanceof HttpStatus hs ? hs.getReasonPhrase() : statusCode.toString();
-        ResponseEntity<?> responseEntity = errorResponse(message, statusCode);
-        return (ResponseEntity<Object>) responseEntity;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
     protected ResponseEntity<Object> handleMissingPathVariable(
             MissingPathVariableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         if (ex.isMissingAfterConversion()) {
-            var message = "Invalid value for path variable '" + ex.getVariableName() + "'";
-            ResponseEntity<?> response = errorResponse(message, status);
-            return (ResponseEntity<Object>) response;
+            var detail = "Invalid value for path variable '" + ex.getVariableName() + "'";
+            var problem = ProblemDetail.forStatusAndDetail(status, detail);
+            return handleExceptionInternal(ex, problem, ex.getHeaders(), BAD_REQUEST, request);
         }
-        return super.handleMissingPathVariable(ex, headers, status, request);
+        return handleExceptionInternal(ex, ex.getBody(), ex.getHeaders(), BAD_REQUEST, request);
     }
 
-    private ResponseEntity<Error> errorResponse(final String e, HttpStatusCode statusCode) {
+    @Nullable
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        Error errorResponse = null;
+
+        if (ex instanceof Errors errors) {
+            errorResponse = errorResponse(errors.getAllErrors());
+        } else if (ex instanceof MethodValidationResult errors) {
+            errorResponse = errorResponse(errors.getAllErrors());
+        } else {
+            var message = statusCode instanceof HttpStatus hs ? hs.getReasonPhrase() : statusCode.toString();
+            var detail = body instanceof ProblemDetail pb ? pb.getDetail() : ex.getMessage();
+            var nonSensitiveDetail = !statusCode.is5xxServerError() ? detail : StringUtils.EMPTY;
+            errorResponse = errorResponse(message, nonSensitiveDetail);
+        }
+
+        request.setAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, ex, SCOPE_REQUEST);
+        return new ResponseEntity<>(errorResponse, headers, statusCode);
+    }
+
+    private Error errorResponse(List<? extends MessageSourceResolvable> errors) {
+        var messages = errors.stream().map(this::formatErrorMessage).toList();
+        var errorStatus = new ErrorStatus().messages(messages);
+        return new Error().status(errorStatus);
+    }
+
+    private Error errorResponse(final String message, final String detail) {
         var errorMessage = new ErrorStatusMessagesInner();
-        errorMessage.setMessage(e);
+        errorMessage.setDetail(detail);
+        errorMessage.setMessage(message);
         var errorStatus = new ErrorStatus().addMessagesItem(errorMessage);
         var error = new Error().status(errorStatus);
-        return new ResponseEntity<>(error, statusCode);
+        return error;
+    }
+
+    private ErrorStatusMessagesInner formatErrorMessage(MessageSourceResolvable error) {
+        var detail = error.getDefaultMessage();
+
+        if (error instanceof FieldError fieldError) {
+            detail = fieldError.getField() + " field " + fieldError.getDefaultMessage();
+        } else if (error instanceof DefaultMessageSourceResolvable resolvable && !(error instanceof ObjectError)) {
+            detail = messageSource.getMessage(resolvable, Locale.getDefault());
+        }
+
+        return new ErrorStatusMessagesInner()
+                .message(BAD_REQUEST.getReasonPhrase())
+                .detail(detail);
+    }
+
+    private static class ErrorMessageSource extends StaticMessageSource {
+
+        ErrorMessageSource() {
+            setUseCodeAsDefaultMessage(true);
+        }
+
+        @Override
+        @Nullable
+        protected String getDefaultMessage(MessageSourceResolvable resolvable, Locale locale) {
+            var message = super.getDefaultMessage(resolvable, locale);
+            var field = getField(resolvable);
+            if (StringUtils.isNotBlank(field)) {
+                return field + " " + message;
+            }
+            return message;
+        }
+
+        private String getField(MessageSourceResolvable resolvable) {
+            if (resolvable instanceof FieldError error) {
+                return error.getField();
+            }
+
+            var arguments = resolvable.getArguments();
+            if (arguments != null && arguments.length > 0 && arguments[0] instanceof MessageSourceResolvable msr) {
+                return msr.getDefaultMessage();
+            }
+
+            return StringUtils.EMPTY;
+        }
     }
 }

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/ControllerTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/ControllerTest.java
@@ -70,7 +70,7 @@ abstract class ControllerTest extends RestJavaIntegrationTest {
                 .defaultHeader("Origin", "http://example.com");
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "java:S6103"})
     protected final void validateError(
             ThrowableAssert.ThrowingCallable callable,
             Class<? extends HttpClientErrorException> clazz,

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/ControllerTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/ControllerTest.java
@@ -18,11 +18,13 @@ package com.hedera.mirror.restjava.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
 
 import com.hedera.mirror.rest.model.Error;
 import com.hedera.mirror.rest.model.ErrorStatusMessagesInner;
 import com.hedera.mirror.restjava.RestJavaIntegrationTest;
 import com.hedera.mirror.restjava.RestJavaProperties;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ThrowableAssert;
@@ -34,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
@@ -47,11 +50,10 @@ import org.springframework.web.client.RestClient.RequestHeadersUriSpec;
 abstract class ControllerTest extends RestJavaIntegrationTest {
 
     private static final String BASE_PATH = "/api/v1/";
+    protected RestClient.Builder restClientBuilder;
 
     @Autowired
     private RestJavaProperties properties;
-
-    protected RestClient.Builder restClientBuilder;
 
     private String baseUrl;
 
@@ -68,22 +70,27 @@ abstract class ControllerTest extends RestJavaIntegrationTest {
                 .defaultHeader("Origin", "http://example.com");
     }
 
+    @SuppressWarnings("unchecked")
     protected final void validateError(
             ThrowableAssert.ThrowingCallable callable,
             Class<? extends HttpClientErrorException> clazz,
-            String message) {
+            String... detail) {
+        AtomicReference<HttpClientErrorException> e = new AtomicReference<>();
         assertThatThrownBy(callable)
                 .isInstanceOf(clazz)
                 .asInstanceOf(InstanceOfAssertFactories.type(clazz))
-                .extracting(r -> r.getResponseBodyAs(Error.class)
-                        .getStatus()
-                        .getMessages()
-                        .get(0))
-                .returns(null, ErrorStatusMessagesInner::getData)
-                .returns(null, ErrorStatusMessagesInner::getDetail)
-                .extracting(ErrorStatusMessagesInner::getMessage)
-                .asInstanceOf(InstanceOfAssertFactories.STRING)
-                .containsIgnoringCase(message);
+                .satisfies(r -> e.set(r))
+                .extracting(
+                        r -> r.getResponseBodyAs(Error.class).getStatus().getMessages(),
+                        list(ErrorStatusMessagesInner.class))
+                .hasSize(detail.length)
+                .allSatisfy(error -> assertThat(error.getData()).isNull())
+                .allSatisfy(error -> assertThat(error.getMessage())
+                        .isEqualTo(HttpStatus.resolve(e.get().getStatusCode().value())
+                                .getReasonPhrase()))
+                .extracting(ErrorStatusMessagesInner::getDetail)
+                .asInstanceOf(InstanceOfAssertFactories.list(String.class))
+                .contains(detail);
     }
 
     protected abstract class EndpointTest {
@@ -131,7 +138,10 @@ abstract class ControllerTest extends RestJavaIntegrationTest {
                     () -> defaultRequest(restClient.post()).retrieve().toBodilessEntity();
 
             // Then
-            validateError(callable, HttpClientErrorException.MethodNotAllowed.class, "Method Not Allowed");
+            validateError(
+                    callable,
+                    HttpClientErrorException.MethodNotAllowed.class,
+                    "Request method 'POST' is not supported");
         }
     }
 }

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/TopicControllerTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/controller/TopicControllerTest.java
@@ -116,8 +116,18 @@ class TopicControllerTest extends ControllerTest {
             validateError(callable, HttpClientErrorException.NotFound.class, "Topic not found: " + entity.toEntityId());
         }
 
-        @NullAndEmptySource
+        @ParameterizedTest
         @ValueSource(strings = {"999", "0.999", "0.0.999"})
+        void entityNotFound(String id) {
+            // When
+            ThrowingCallable callable =
+                    () -> restClient.get().uri("", id).retrieve().body(Topic.class);
+
+            // Then
+            validateError(callable, HttpClientErrorException.NotFound.class, "Entity not found: 0.0.999");
+        }
+
+        @NullAndEmptySource
         @ParameterizedTest
         void notFound(String id) {
             // When
@@ -125,7 +135,7 @@ class TopicControllerTest extends ControllerTest {
                     () -> restClient.get().uri("", id).retrieve().body(Topic.class);
 
             // Then
-            validateError(callable, HttpClientErrorException.NotFound.class, "not found");
+            validateError(callable, HttpClientErrorException.NotFound.class, "No static resource api/v1/topics.");
         }
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/LoggingFilter.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/config/LoggingFilter.java
@@ -79,7 +79,7 @@ class LoggingFilter extends OncePerRequestFilter {
 
         if (actuator) {
             log.debug(LOG_FORMAT, params);
-        } else if (status != HttpStatus.OK.value()) {
+        } else if (status >= HttpStatus.INTERNAL_SERVER_ERROR.value()) {
             log.warn(LOG_FORMAT, params);
         } else {
             log.info(LOG_FORMAT, params);


### PR DESCRIPTION
**Description**:

Standardize rest-java error response similar to #9046:

* Add error message to web3 access logs
* Consolidate similar exception handlers
* Change error handling to always return exception message for non-5xx errors
* Change error message to status reason phrase and move prior message to detail

**Related issue(s)**:

Fixes #9070

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
