### PR TITLE
Retain existing allowance (spender) columns when updating NFT metadata

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/entity/EntityId.java
@@ -44,6 +44,14 @@ public final class EntityId implements Serializable, Comparable<EntityId> {
 
     public static final EntityId EMPTY = new EntityId(0L);
 
+    /*
+     * Indicates a domain entity ID is not being set (to null or non-null) in the current operation and that
+     * the existing DB column value is to be preserved. This is reflected as the value of -1 that can be
+     * referenced within the @UpsertColumn syntax. See the AbstractNft delegatingSpender and spender
+     * fields as examples. In this case, this sentinel value is set in TokenUpdateNftsTransactionHandler.
+     */
+    public static final EntityId UNSET = new EntityId();
+
     static final int NUM_BITS = 32;
     static final int REALM_BITS = 16;
     static final int SHARD_BITS = 15;
@@ -75,6 +83,11 @@ public final class EntityId implements Serializable, Comparable<EntityId> {
         }
 
         this.id = id;
+    }
+
+    // Used only to construct constant UNSET above
+    private EntityId() {
+        this.id = -1L;
     }
 
     /**

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractNft.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/token/AbstractNft.java
@@ -47,7 +47,7 @@ public abstract class AbstractNft implements History {
     @Column(updatable = false)
     private Long createdTimestamp;
 
-    @UpsertColumn(coalesce = "{0}")
+    @UpsertColumn(coalesce = "case when delegating_spender < 0 then e_{0} else {0} end")
     private EntityId delegatingSpender;
 
     private Boolean deleted;
@@ -58,7 +58,7 @@ public abstract class AbstractNft implements History {
     @jakarta.persistence.Id
     private long serialNumber;
 
-    @UpsertColumn(coalesce = "{0}")
+    @UpsertColumn(coalesce = "case when spender < 0 then e_{0} else {0} end")
     private EntityId spender;
 
     @jakarta.persistence.Id

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListener.java
@@ -578,6 +578,17 @@ public class SqlEntityListener implements EntityListener, RecordStreamFileListen
             src.setTimestampUpper(dest.getTimestampLower());
         }
 
+        /*
+         * An unset spender field indicates this is an NFT metadata only update, and that the existing allowance
+         * information must be retained from the source.
+         */
+        if (EntityId.UNSET.equals(dest.getSpender())) {
+            dest.setSpender(src.getSpender());
+        }
+        if (EntityId.UNSET.equals(dest.getDelegatingSpender())) {
+            dest.setDelegatingSpender(src.getDelegatingSpender());
+        }
+
         return dest;
     }
 

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateNftsTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateNftsTransactionHandler.java
@@ -64,6 +64,8 @@ class TokenUpdateNftsTransactionHandler extends AbstractTransactionHandler {
         var consensusTimestamp = recordItem.getConsensusTimestamp();
         var nftBuilder = Nft.builder()
                 .metadata(toBytes(transactionBody.getMetadata().getValue()))
+                .delegatingSpender(EntityId.UNSET)
+                .spender(EntityId.UNSET)
                 .timestampRange(Range.atLeast(consensusTimestamp))
                 .tokenId(tokenId.getId());
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateNftsTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/TokenUpdateNftsTransactionHandlerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.collect.Range;
+import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.AbstractNft;
 import com.hedera.mirror.common.domain.token.Nft;
@@ -84,6 +85,8 @@ class TokenUpdateNftsTransactionHandlerTest extends AbstractTransactionHandlerTe
                     .isNotNull()
                     .returns(expectedMetadata, Nft::getMetadata)
                     .returns(expectedSerialNumbers.get(i), AbstractNft::getSerialNumber)
+                    .returns(EntityId.UNSET, Nft::getDelegatingSpender)
+                    .returns(EntityId.UNSET, Nft::getSpender)
                     .returns(Range.atLeast(recordItem.getConsensusTimestamp()), Nft::getTimestampRange)
                     .returns(transaction.getEntityId().getId(), AbstractNft::getTokenId);
         }


### PR DESCRIPTION
**Description**:
Retain existing `spender` and `delegatingSpender` upon NFT metadata update.

**Related issue(s)**:

Fixes #9041

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
