### PR TITLE
Disable stackgres metrics exporter in testnet-eu

### DIFF
--- a/clusters/testnet-eu/testnet-citus/helmrelease.yaml
+++ b/clusters/testnet-eu/testnet-citus/helmrelease.yaml
@@ -82,7 +82,9 @@ spec:
       coordinator:
         config:
           citus.max_cached_conns_per_worker: "6"
+        enableMetricsExporter: false
       worker:
+        enableMetricsExporter: false
         persistentVolume:
           size: 900Gi
     test:


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR disables stackgres metrics exporter in testnet-eu since prometheus started to OOM crash again.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
