### PR TITLE
Adjust some stackgres charts configs (0.111)

### DIFF
--- a/charts/hedera-mirror/values-prod.yaml
+++ b/charts/hedera-mirror/values-prod.yaml
@@ -124,7 +124,6 @@ rosetta:
 
 stackgres:
   coordinator:
-    enableMetricsExporter: true
     instances: 2
     resources:
       cpu: 7350m
@@ -145,7 +144,6 @@ stackgres:
       size: 256Gi
       storageClass: zfs
   worker:
-    enableMetricsExporter: true
     instances: 3
     replicasPerInstance: 1
     resources:

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -278,7 +278,7 @@ stackgres:
       autovacuum_max_workers: "2"
       checkpoint_timeout: "1800"
       citus.executor_slow_start_interval: "20ms"
-      citus.max_cached_conns_per_worker: "1"
+      citus.max_cached_conns_per_worker: "6"
       citus.max_shared_pool_size: "850"
       full_page_writes: "true"  # Required for replication to work in recovery scenarios
       log_checkpoints: "true"


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR backports the changes to `release/0.111`

- Disable stackgres metrics exporter
- Increase citus max cached worker connections to 6

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
