### PR TITLE
Fix previewnet reset behavior

### DIFF
--- a/clusters/previewnet/previewnet/helmrelease.yaml
+++ b/clusters/previewnet/previewnet/helmrelease.yaml
@@ -19,6 +19,9 @@ spec:
       namespace: common
   driftDetection:
     mode: enabled
+    ignore:
+      - paths:
+        - /spec/replicas
   install:
     crds: CreateReplace
   interval: 90s


### PR DESCRIPTION
**Description**:

Fix previewnet reset behavior caused by `driftDetection` scaling importer up brought down by reset process before `cleanup.sql` can complete

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
