### PR TITLE
Suppress drift detection for SGScript in mainnet

### DIFF
--- a/clusters/mainnet-eu/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-eu/mainnet-citus/helmrelease.yaml
@@ -20,6 +20,11 @@ spec:
       namespace: common
   driftDetection:
     mode: warn
+    ignore:
+      - paths:
+          - /spec/scripts
+        target:
+          kind: SGScript
   install:
     crds: CreateReplace
   interval: 90s

--- a/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-na/mainnet-citus/helmrelease.yaml
@@ -20,6 +20,11 @@ spec:
       namespace: common
   driftDetection:
     mode: warn
+    ignore:
+      - paths:
+          - /spec/scripts
+        target:
+          kind: SGScript
   install:
     crds: CreateReplace
   interval: 90s


### PR DESCRIPTION
**Description**:

Suppress drift detection for SGScript in mainnet.

**Related issue(s)**:

**Notes for reviewer**:

It's ok to do both clusters simultaneously since this won't trigger a redeploy of the app or helm test.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
