### PR TITLE
Disable postgres SSL to fix random query timeout

### DIFF
--- a/charts/hedera-mirror-common/templates/test-rest-java.yaml
+++ b/charts/hedera-mirror-common/templates/test-rest-java.yaml
@@ -31,6 +31,10 @@ spec:
         name: BASE_URL
         type: basic
         value: http://{{ $target.release }}-restjava.{{ $target.namespace }}.svc.cluster.local
+      TEST_REPORTS_DIR:
+        name: TEST_REPORTS_DIR
+        type: basic
+        value: /share
   type: k6-custom/script
 {{- end}}
 {{- end }}

--- a/charts/hedera-mirror-common/templates/test-rest.yaml
+++ b/charts/hedera-mirror-common/templates/test-rest.yaml
@@ -31,6 +31,10 @@ spec:
         name: BASE_URL
         type: basic
         value: http://{{ $target.release }}-rest.{{ $target.namespace }}.svc.cluster.local
+      TEST_REPORTS_DIR:
+        name: TEST_REPORTS_DIR
+        type: basic
+        value: /share
   type: k6-custom/script
 {{- end }}
 {{- end }}

--- a/charts/hedera-mirror-common/templates/test-web3.yaml
+++ b/charts/hedera-mirror-common/templates/test-web3.yaml
@@ -31,6 +31,10 @@ spec:
         name: BASE_URL
         type: basic
         value: http://{{ $target.release }}-web3.{{ $target.namespace }}.svc.cluster.local
+      TEST_REPORTS_DIR:
+        name: TEST_REPORTS_DIR
+        type: basic
+        value: /share
   type: k6-custom/script
 {{- end }}
 {{- end }}

--- a/charts/hedera-mirror/templates/stackgres/stackgres-cluster.yaml
+++ b/charts/hedera-mirror/templates/stackgres/stackgres-cluster.yaml
@@ -16,7 +16,7 @@ spec:
         - sgScript: {{ include "hedera-mirror.stackgres" . }}-coordinator
     pods:
       disableMetricsExporter: {{ not .Values.stackgres.coordinator.enableMetricsExporter }}
-      disablePostgresUtil: true
+      disablePostgresUtil: {{ not .Values.stackgres.coordinator.enablePostgresUtil }}
       persistentVolume: {{ .Values.stackgres.coordinator.persistentVolume | toYaml | nindent 8 }}
       resources:
         disableResourcesRequestsSplitFromTotal: {{ .Values.stackgres.dedicatedResourcesRequests }}
@@ -37,6 +37,8 @@ spec:
     disableClusterPodAntiAffinity: {{ not .Values.stackgres.podAntiAffinity }}
   postgres:
     extensions: {{ .Values.stackgres.extensions | toYaml | nindent 6 }}
+    ssl:
+      enabled: false  # Disable SSL to work around https://github.com/hashgraph/hedera-mirror-node/issues/9143
     version: {{ .Values.stackgres.postgresVersion | quote }}
   prometheusAutobind: {{ or .Values.stackgres.coordinator.enableMetricsExporter .Values.stackgres.worker.enableMetricsExporter }}
   replication:
@@ -53,7 +55,7 @@ spec:
     overrides: {{ .Values.stackgres.worker.overrides | toYaml | nindent 6 }}
     pods:
       disableMetricsExporter: {{ not .Values.stackgres.coordinator.enableMetricsExporter }}
-      disablePostgresUtil: true
+      disablePostgresUtil: {{ not .Values.stackgres.coordinator.enablePostgresUtil }}
       persistentVolume: {{ .Values.stackgres.worker.persistentVolume | toYaml | nindent 8 }}
       resources:
         disableResourcesRequestsSplitFromTotal: {{ .Values.stackgres.dedicatedResourcesRequests }}

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -280,6 +280,7 @@ stackgres:
       citus.executor_slow_start_interval: "20ms"
       citus.max_cached_conns_per_worker: "6"
       citus.max_shared_pool_size: "850"
+      citus.node_conninfo: "sslmode=disable"  # Disable SSL to work around https://github.com/hashgraph/hedera-mirror-node/issues/9143
       full_page_writes: "true"  # Required for replication to work in recovery scenarios
       log_checkpoints: "true"
       log_timezone: "Etc/UTC"
@@ -293,6 +294,7 @@ stackgres:
       wal_recycle: "off"  # Not needed with ZFS
       work_mem: "32MB"
     enableMetricsExporter: false
+    enablePostgresUtil: true
     instances: 1
     replication:
       mode: sync-all
@@ -331,6 +333,7 @@ stackgres:
     config:
       autovacuum_max_workers: "2"
       checkpoint_timeout: "1800"
+      citus.node_conninfo: "sslmode=disable" # Disable SSL to work around https://github.com/hashgraph/hedera-mirror-node/issues/9143
       full_page_writes: "false"  # Not required for ZFS and Enabling this causes hash indexes to have spikes in write performance.
       log_checkpoints: "true"
       log_timezone: "Etc/UTC"
@@ -344,6 +347,7 @@ stackgres:
       wal_recycle: "off"  # Not needed with ZFS
       work_mem: "32MB"
     enableMetricsExporter: false
+    enablePostgresUtil: true
     instances: 1
     overrides: []  # Override shard(s) configuration
     replicasPerInstance: 1

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -277,7 +277,7 @@ stackgres:
     config:
       autovacuum_max_workers: "2"
       checkpoint_timeout: "1800"
-      citus.executor_slow_start_interval: "20ms"
+      citus.executor_slow_start_interval: "10ms"
       citus.max_cached_conns_per_worker: "6"
       citus.max_shared_pool_size: "850"
       citus.node_conninfo: "sslmode=disable"  # Disable SSL to work around https://github.com/hashgraph/hedera-mirror-node/issues/9143
@@ -292,7 +292,7 @@ stackgres:
       shared_buffers: "9GB"
       wal_init_zero: "off"  # Not needed with ZFS
       wal_recycle: "off"  # Not needed with ZFS
-      work_mem: "32MB"
+      work_mem: "24MB"
     enableMetricsExporter: false
     enablePostgresUtil: true
     instances: 1
@@ -345,7 +345,7 @@ stackgres:
       shared_buffers: "9GB"
       wal_init_zero: "off"  # Not needed with ZFS
       wal_recycle: "off"  # Not needed with ZFS
-      work_mem: "32MB"
+      work_mem: "24MB"
     enableMetricsExporter: false
     enablePostgresUtil: true
     instances: 1

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -333,7 +333,7 @@ stackgres:
     config:
       autovacuum_max_workers: "2"
       checkpoint_timeout: "1800"
-      citus.node_conninfo: "sslmode=disable" # Disable SSL to work around https://github.com/hashgraph/hedera-mirror-node/issues/9143
+      citus.node_conninfo: "sslmode=disable"  # Disable SSL to work around https://github.com/hashgraph/hedera-mirror-node/issues/9143
       full_page_writes: "false"  # Not required for ZFS and Enabling this causes hash indexes to have spikes in write performance.
       log_checkpoints: "true"
       log_timezone: "Etc/UTC"


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR fixes the random readonly query timeout issue in citus

- Disable SSL
- Enable postgres-util container
- Reduce postgresql work_mem to 24MB to lower memory pressue
- Add `TEST_REPORTS_DIR` env variable to all testkube tests

**Related issue(s)**:

Fixes #8748 
Fixes #9143 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
After much effort to diagnose and experiment, found disabling SSL solves the issue. Though I'm not clear about why SSL connection (via unix socket) can cause such issue, the changes here are much needed so we can move on to other tasks.

If needed, we can open a ticket upstream, however, the configuration itself (coordinator -> worker connection pgbouncer pooling) isn't supported by stackgres.

The changes which enable postgres-util container is a must to gain pgbouncer info. Without it, it's impossible to view a lot of pgbouner stats. The problem is pgbouner can only be connected via unix socket with psql command, `psql -p 6432 -U pgbouncer pgbouncer`. We can do so in the `patroni` container.  However a lot of commands will just fail to show results, e.g., `show clients`, complaining about `more` is not available as it's not installed in the patroni container.

Verified for the upgrade path from <= 0.112.0-rc3 helm charts with SSL defaults to enabled, to charts in this PR, no manual steps are needed.
 
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
