### PR TITLE
Refactor `ContractCallServiceERCTokenTest` delegate transfer

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
@@ -23,6 +23,7 @@ import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SENDER_ALIAS;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SENDER_PUBLIC_KEY;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SPENDER_ALIAS;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SPENDER_PUBLIC_KEY;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.google.protobuf.ByteString;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -621,6 +622,30 @@ class ContractCallServiceERCTokenModificationFunctionsTest extends AbstractContr
                 BigInteger.valueOf(serialNumber));
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void delegateTransferDoesNotExecuteAndReturnEmpty() throws Exception {
+        // Given
+        final var recipient = accountPersist();
+        final var treasury = accountPersist();
+        final var token = fungibleTokenPersist(treasury);
+        final var tokenEntity = entityIdFromEvmAddress(toAddress(token.getTokenId()));
+        final var tokenAddress = toAddress(tokenEntity.getId());
+        tokenAssociateAccountPersist(recipient, entityIdFromEvmAddress(toAddress(tokenEntity.getId())));
+
+        final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
+        final var contractAddress = Address.fromHexString(contract.getContractAddress());
+        final var contractEntityId = entityIdFromEvmAddress(contractAddress);
+
+        tokenAssociateAccountPersist(contractEntityId, tokenEntity);
+        final var amount = 10L;
+        // When
+        contract.send_delegateTransfer(
+                tokenAddress.toHexString(), toAddress(recipient).toHexString(), BigInteger.valueOf(amount)).send();
+        final var result = testWeb3jService.getTransactionResult();
+        //Then
+        assertThat(result).isEqualTo("0x");
     }
 
     private EntityId accountPersistWithAlias(final Address alias, final ByteString publicKey) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenTest.java
@@ -118,15 +118,6 @@ class ContractCallServiceERCTokenTest extends ContractCallTestSetup {
                 .isInstanceOf(MirrorEvmTransactionException.class);
     }
 
-    @Test
-    void delegateTransferDoesNotExecuteAndReturnEmpty() {
-        final var functionHash = functionEncodeDecoder.functionHashFor(
-                "delegateTransfer", ERC_ABI_PATH, FUNGIBLE_TOKEN_ADDRESS, SPENDER_ADDRESS, 2L);
-        final var serviceParameters =
-                serviceParametersForExecution(functionHash, ERC_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.LATEST);
-        assertThat(contractCallService.processCall(serviceParameters)).isEqualTo("0x");
-    }
-
     @Getter
     @RequiredArgsConstructor
     public enum ErcContractReadOnlyFunctionsNegative implements ContractFunctionProviderEnum {


### PR DESCRIPTION
**Description**:

With this PR the `ContractCallServiceERCTokenTest` integration test file is partially refactored using the web3j plugin and the big enum is now replaced with multiple JUnit tests so that it is easier to debug a particular scenario. This way also the number of persisted entities per test is reduced significantly and now we persist only the ones that are needed in the particular test.

This PR refactors delegate transfer test, so it can be more readable. 

**Related issue(s)**:

Related and partially addresses: #9162 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)