### PR TITLE
Refactor ContractDebugServiceTest modification precompile functions

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -31,7 +31,9 @@ import com.hedera.mirror.web3.Web3IntegrationTest;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.service.model.CallServiceParameters.CallType;
+import com.hedera.mirror.web3.service.model.ContractDebugParameters;
 import com.hedera.mirror.web3.service.model.ContractExecutionParameters;
+import com.hedera.mirror.web3.utils.ContractFunctionProviderRecord;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.mirror.web3.web3j.TestWeb3jService;
 import com.hedera.mirror.web3.web3j.TestWeb3jService.Web3jTestConfiguration;
@@ -213,6 +215,29 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
 
     protected String getAliasFromEntity(Entity entity) {
         return Bytes.wrap(entity.getEvmAddress()).toHexString();
+    }
+
+    protected ContractDebugParameters getDebugParameters(
+            final ContractFunctionProviderRecord functionProvider, final Bytes callDataBytes) {
+        return ContractDebugParameters.builder()
+                .block(functionProvider.block())
+                .callData(callDataBytes)
+                .consensusTimestamp(domainBuilder.timestamp())
+                .gas(TRANSACTION_GAS_LIMIT)
+                .receiver(functionProvider.contractAddress())
+                .sender(new HederaEvmAccount(functionProvider.sender()))
+                .value(functionProvider.value())
+                .build();
+    }
+
+    protected ContractFunctionProviderRecord getContractFunctionProviderWithSender(
+            final String contract, final Entity sender) {
+        final var contractAddress = Address.fromHexString(contract);
+        final var senderAddress = Address.fromHexString(getAliasFromEntity(sender));
+        return ContractFunctionProviderRecord.builder()
+                .contractAddress(contractAddress)
+                .sender(senderAddress)
+                .build();
     }
 
     public enum KeyType {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -2652,17 +2652,8 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
     }
 
     private void verifyOpcodeTracerCall(final String callData, final ContractFunctionProviderRecord functionProvider) {
-
         final var callDataBytes = Bytes.fromHexString(callData);
-        final var debugParameters = ContractDebugParameters.builder()
-                .block(functionProvider.block())
-                .callData(callDataBytes)
-                .consensusTimestamp(domainBuilder.timestamp())
-                .gas(15_000_000L)
-                .receiver(functionProvider.contractAddress())
-                .sender(new HederaEvmAccount(functionProvider.sender()))
-                .value(functionProvider.value())
-                .build();
+        final var debugParameters = getDebugParameters(functionProvider, callDataBytes);
 
         if (functionProvider.expectedErrorMessage() != null) {
             verifyThrowingOpcodeTracerCall(debugParameters, functionProvider);
@@ -2679,15 +2670,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
                 .build();
 
         final var callDataBytes = Bytes.fromHexString(callData);
-        final var debugParameters = ContractDebugParameters.builder()
-                .block(functionProvider.block())
-                .callData(callDataBytes)
-                .consensusTimestamp(domainBuilder.timestamp())
-                .gas(15_000_000L)
-                .receiver(functionProvider.contractAddress())
-                .sender(new HederaEvmAccount(functionProvider.sender()))
-                .value(functionProvider.value())
-                .build();
+        final var debugParameters = getDebugParameters(functionProvider, callDataBytes);
 
         if (functionProvider.expectedErrorMessage() != null) {
             verifyThrowingOpcodeTracerCall(debugParameters, functionProvider);
@@ -2732,15 +2715,5 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
                 .usingRecursiveComparison()
                 .withComparatorForFields(gasComparator(), "gas")
                 .isEqualTo(expected.opcodes());
-    }
-
-    private ContractFunctionProviderRecord getContractFunctionProviderWithSender(
-            final String contract, final Entity sender) {
-        final var contractAddress = Address.fromHexString(contract);
-        final var senderAddress = Address.fromHexString(getAliasFromEntity(sender));
-        return ContractFunctionProviderRecord.builder()
-                .contractAddress(contractAddress)
-                .sender(senderAddress)
-                .build();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -31,8 +31,12 @@ import static com.hedera.mirror.web3.utils.ContractCallTestUtil.TRANSACTION_GAS_
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.ZERO_VALUE;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.isWithinExpectedGasRange;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.longValueOf;
+import static com.hedera.mirror.web3.utils.OpcodeTracerUtil.OPTIONS;
+import static com.hedera.mirror.web3.utils.OpcodeTracerUtil.gasComparator;
+import static com.hedera.mirror.web3.utils.OpcodeTracerUtil.toHumanReadableMessage;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.doAnswer;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.mirror.common.domain.entity.Entity;
@@ -48,9 +52,14 @@ import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenPauseStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenSupplyTypeEnum;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.convert.BytesDecoder;
+import com.hedera.mirror.web3.evm.contracts.execution.OpcodesProcessingResult;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
+import com.hedera.mirror.web3.service.model.ContractDebugParameters;
 import com.hedera.mirror.web3.service.model.ContractExecutionParameters;
+import com.hedera.mirror.web3.utils.ContractFunctionProviderRecord;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.mirror.web3.web3j.generated.ModificationPrecompileTestContract;
 import com.hedera.mirror.web3.web3j.generated.ModificationPrecompileTestContract.AccountAmount;
@@ -66,6 +75,7 @@ import com.hedera.mirror.web3.web3j.generated.PrecompileTestContract.FungibleTok
 import com.hedera.mirror.web3.web3j.generated.PrecompileTestContract.KeyValue;
 import com.hedera.mirror.web3.web3j.generated.PrecompileTestContract.NonFungibleTokenInfo;
 import com.hedera.mirror.web3.web3j.generated.PrecompileTestContract.TokenInfo;
+import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hedera.services.store.contracts.precompile.codec.KeyValueWrapper.KeyValueType;
 import com.hedera.services.store.models.Id;
@@ -77,18 +87,49 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.web3j.protocol.core.RemoteFunctionCall;
 import org.web3j.tx.Contract;
 
+@RequiredArgsConstructor
 class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest {
+
+    private final ContractDebugService contractDebugService;
+
+    @Captor
+    private ArgumentCaptor<ContractDebugParameters> paramsCaptor;
+
+    @Captor
+    private ArgumentCaptor<Long> gasCaptor;
+
+    private HederaEvmTransactionProcessingResult resultCaptor;
+    private ContractCallContext contextCaptor;
+
+    @BeforeEach
+    void setUpArgumentCaptors() {
+        doAnswer(invocation -> {
+            final var transactionProcessingResult =
+                    (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
+            resultCaptor = transactionProcessingResult;
+            contextCaptor = ContractCallContext.get();
+            return transactionProcessingResult;
+        })
+                .when(processor)
+                .execute(paramsCaptor.capture(), gasCaptor.capture());
+    }
 
     @Test
     void isTokenFrozen() throws Exception {
@@ -117,7 +158,6 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         assertThat(functionCall.send()).isTrue();
-
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
     }
 
@@ -153,7 +193,6 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         assertThat(functionCall.send()).isTrue();
-
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
     }
 
@@ -172,7 +211,6 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         assertThat(functionCall.send()).isTrue();
-
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
     }
 
@@ -408,57 +446,57 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
     @CsvSource(
             textBlock =
                     """
-    FUNGIBLE_COMMON, ECDSA_SECPK256K1, ADMIN_KEY
-    FUNGIBLE_COMMON, ECDSA_SECPK256K1, KYC_KEY
-    FUNGIBLE_COMMON, ECDSA_SECPK256K1, FREEZE_KEY
-    FUNGIBLE_COMMON, ECDSA_SECPK256K1, WIPE_KEY
-    FUNGIBLE_COMMON, ECDSA_SECPK256K1, SUPPLY_KEY
-    FUNGIBLE_COMMON, ECDSA_SECPK256K1, FEE_SCHEDULE_KEY
-    FUNGIBLE_COMMON, ECDSA_SECPK256K1, PAUSE_KEY
-    FUNGIBLE_COMMON, ED25519, ADMIN_KEY
-    FUNGIBLE_COMMON, ED25519, FREEZE_KEY
-    FUNGIBLE_COMMON, ED25519, WIPE_KEY
-    FUNGIBLE_COMMON, ED25519, SUPPLY_KEY
-    FUNGIBLE_COMMON, ED25519, FEE_SCHEDULE_KEY
-    FUNGIBLE_COMMON, ED25519, PAUSE_KEY
-    FUNGIBLE_COMMON, CONTRACT_ID, ADMIN_KEY
-    FUNGIBLE_COMMON, CONTRACT_ID, FREEZE_KEY
-    FUNGIBLE_COMMON, CONTRACT_ID, WIPE_KEY
-    FUNGIBLE_COMMON, CONTRACT_ID, SUPPLY_KEY
-    FUNGIBLE_COMMON, CONTRACT_ID, FEE_SCHEDULE_KEY
-    FUNGIBLE_COMMON, CONTRACT_ID, PAUSE_KEY
-    FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, ADMIN_KEY
-    FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, FREEZE_KEY
-    FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, WIPE_KEY
-    FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, SUPPLY_KEY
-    FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, FEE_SCHEDULE_KEY
-    FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, PAUSE_KEY
-    NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, ADMIN_KEY
-    NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, KYC_KEY
-    NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, FREEZE_KEY
-    NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, WIPE_KEY
-    NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, SUPPLY_KEY
-    NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, FEE_SCHEDULE_KEY
-    NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, PAUSE_KEY
-    NON_FUNGIBLE_UNIQUE, ED25519, ADMIN_KEY
-    NON_FUNGIBLE_UNIQUE, ED25519, FREEZE_KEY
-    NON_FUNGIBLE_UNIQUE, ED25519, WIPE_KEY
-    NON_FUNGIBLE_UNIQUE, ED25519, SUPPLY_KEY
-    NON_FUNGIBLE_UNIQUE, ED25519, FEE_SCHEDULE_KEY
-    NON_FUNGIBLE_UNIQUE, ED25519, PAUSE_KEY
-    NON_FUNGIBLE_UNIQUE, CONTRACT_ID, ADMIN_KEY
-    NON_FUNGIBLE_UNIQUE, CONTRACT_ID, FREEZE_KEY
-    NON_FUNGIBLE_UNIQUE, CONTRACT_ID, WIPE_KEY
-    NON_FUNGIBLE_UNIQUE, CONTRACT_ID, SUPPLY_KEY
-    NON_FUNGIBLE_UNIQUE, CONTRACT_ID, FEE_SCHEDULE_KEY
-    NON_FUNGIBLE_UNIQUE, CONTRACT_ID, PAUSE_KEY
-    NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, ADMIN_KEY
-    NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, FREEZE_KEY
-    NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, WIPE_KEY
-    NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, SUPPLY_KEY
-    NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, FEE_SCHEDULE_KEY
-    NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, PAUSE_KEY
-""")
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, ADMIN_KEY
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, KYC_KEY
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, FREEZE_KEY
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, WIPE_KEY
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, SUPPLY_KEY
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, FEE_SCHEDULE_KEY
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, PAUSE_KEY
+                                FUNGIBLE_COMMON, ED25519, ADMIN_KEY
+                                FUNGIBLE_COMMON, ED25519, FREEZE_KEY
+                                FUNGIBLE_COMMON, ED25519, WIPE_KEY
+                                FUNGIBLE_COMMON, ED25519, SUPPLY_KEY
+                                FUNGIBLE_COMMON, ED25519, FEE_SCHEDULE_KEY
+                                FUNGIBLE_COMMON, ED25519, PAUSE_KEY
+                                FUNGIBLE_COMMON, CONTRACT_ID, ADMIN_KEY
+                                FUNGIBLE_COMMON, CONTRACT_ID, FREEZE_KEY
+                                FUNGIBLE_COMMON, CONTRACT_ID, WIPE_KEY
+                                FUNGIBLE_COMMON, CONTRACT_ID, SUPPLY_KEY
+                                FUNGIBLE_COMMON, CONTRACT_ID, FEE_SCHEDULE_KEY
+                                FUNGIBLE_COMMON, CONTRACT_ID, PAUSE_KEY
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, ADMIN_KEY
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, FREEZE_KEY
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, WIPE_KEY
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, SUPPLY_KEY
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, FEE_SCHEDULE_KEY
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, PAUSE_KEY
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, ADMIN_KEY
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, KYC_KEY
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, FREEZE_KEY
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, WIPE_KEY
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, SUPPLY_KEY
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, FEE_SCHEDULE_KEY
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, PAUSE_KEY
+                                NON_FUNGIBLE_UNIQUE, ED25519, ADMIN_KEY
+                                NON_FUNGIBLE_UNIQUE, ED25519, FREEZE_KEY
+                                NON_FUNGIBLE_UNIQUE, ED25519, WIPE_KEY
+                                NON_FUNGIBLE_UNIQUE, ED25519, SUPPLY_KEY
+                                NON_FUNGIBLE_UNIQUE, ED25519, FEE_SCHEDULE_KEY
+                                NON_FUNGIBLE_UNIQUE, ED25519, PAUSE_KEY
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, ADMIN_KEY
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, FREEZE_KEY
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, WIPE_KEY
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, SUPPLY_KEY
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, FEE_SCHEDULE_KEY
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, PAUSE_KEY
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, ADMIN_KEY
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, FREEZE_KEY
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, WIPE_KEY
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, SUPPLY_KEY
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, FEE_SCHEDULE_KEY
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, PAUSE_KEY
+                            """)
     void getTokenKey(
             final TokenTypeEnum tokenType,
             final KeyValueType keyValueType,
@@ -949,6 +987,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @ParameterizedTest
@@ -972,6 +1011,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @ParameterizedTest
@@ -1010,6 +1050,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1043,6 +1084,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @ParameterizedTest
@@ -1063,12 +1105,13 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         // When
         final var functionCall = single
                 ? contract.call_associateTokenExternal(
-                        getAddressFromEntity(notAssociatedAccount), getAddressFromEntity(tokenEntity))
+                getAddressFromEntity(notAssociatedAccount), getAddressFromEntity(tokenEntity))
                 : contract.call_associateTokensExternal(
                         getAddressFromEntity(notAssociatedAccount), List.of(getAddressFromEntity(tokenEntity)));
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1088,6 +1131,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @ParameterizedTest
@@ -1110,12 +1154,13 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         // When
         final var functionCall = single
                 ? contract.call_dissociateTokenExternal(
-                        getAddressFromEntity(associatedAccount), getAddressFromEntity(tokenEntity))
+                getAddressFromEntity(associatedAccount), getAddressFromEntity(tokenEntity))
                 : contract.call_dissociateTokensExternal(
                         getAddressFromEntity(associatedAccount), List.of(getAddressFromEntity(tokenEntity)));
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1139,6 +1184,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1161,12 +1207,12 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         // When
         final var functionCall = contract.call_mintTokenExternal(
                 getAddressFromEntity(tokenEntity), BigInteger.valueOf(30), new ArrayList<>());
-
         final var result = functionCall.send();
-        assertThat(result.component2()).isEqualTo(BigInteger.valueOf(totalSupply + 30L));
 
         // Then
+        assertThat(result.component2()).isEqualTo(BigInteger.valueOf(totalSupply + 30L));
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1190,10 +1236,10 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         final var result = functionCall.send();
 
-        assertThat(result.component3().getFirst()).isEqualTo(BigInteger.ONE);
-
         // Then
+        assertThat(result.component3().getFirst()).isEqualTo(BigInteger.ONE);
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1222,6 +1268,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         // Then
         assertThat(result.component2()).isEqualTo(BigInteger.valueOf(totalSupply - 4L));
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1245,16 +1292,16 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
+        // When
         final var functionCall = contract.call_burnTokenExternal(
                 getAddressFromEntity(tokenEntity), BigInteger.ZERO, List.of(BigInteger.ONE));
 
         final var result = functionCall.send();
 
-        // When
-        assertThat(result.component2()).isEqualTo(BigInteger.valueOf(totalSupply - 1));
-
         // Then
+        assertThat(result.component2()).isEqualTo(BigInteger.valueOf(totalSupply - 1));
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1278,6 +1325,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1305,6 +1353,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1328,6 +1377,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1351,6 +1401,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1369,6 +1420,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1386,6 +1438,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1413,6 +1466,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1431,6 +1485,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1456,6 +1511,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1479,10 +1535,16 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         final var functionCall = contract.call_createFungibleTokenExternal(token, initialSupply, decimals);
         final var result = functionCall.send();
 
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .value(value)
+                .build();
+
         // Then
         assertThat(result.component2()).isNotEqualTo(Address.ZERO.toHexString());
 
         verifyEthCallAndEstimateGas(functionCall, contract, value);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
     }
 
     @Test
@@ -1524,10 +1586,16 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
                 token, initialSupply, decimals, List.of(fixedFee), List.of(fractionalFee));
         final var result = functionCall.send();
 
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .value(value)
+                .build();
+
         // Then
         assertThat(result.component2()).isNotEqualTo(Address.ZERO.toHexString());
 
         verifyEthCallAndEstimateGas(functionCall, contract, value);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
     }
 
     @Test
@@ -1549,10 +1617,16 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         final var functionCall = contract.call_createNonFungibleTokenExternal(token);
         final var result = functionCall.send();
 
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .value(value)
+                .build();
+
         // Then
         assertThat(result.component2()).isNotEqualTo(Address.ZERO.toHexString());
 
         verifyEthCallAndEstimateGas(functionCall, contract, value);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
     }
 
     @Test
@@ -1592,10 +1666,15 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
                 token, List.of(fixedFee), List.of(royaltyFee));
         final var result = functionCall.send();
 
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .value(value)
+                .build();
         // Then
         assertThat(result.component2()).isNotEqualTo(Address.ZERO.toHexString());
 
         verifyEthCallAndEstimateGas(functionCall, contract, value);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
     }
 
     @Test
@@ -1617,6 +1696,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, 0L);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -1886,17 +1966,23 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         testWeb3jService.setSender(getAliasFromEntity(payer));
         final var functionCall = "single".equals(type)
                 ? contract.call_transferTokenExternal(
-                        getAddressFromEntity(tokenEntity),
-                        getAliasFromEntity(sender),
-                        getAliasFromEntity(receiver),
-                        BigInteger.valueOf(1L))
+                getAddressFromEntity(tokenEntity),
+                getAliasFromEntity(sender),
+                getAliasFromEntity(receiver),
+                BigInteger.valueOf(1L))
                 : contract.call_transferTokensExternal(
                         getAddressFromEntity(tokenEntity),
                         List.of(getAliasFromEntity(sender), getAliasFromEntity(receiver)),
                         List.of(BigInteger.ONE, BigInteger.valueOf(-1L)));
 
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .sender(Address.fromHexString(getAliasFromEntity(payer)))
+                .build();
+
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
     }
 
     @ParameterizedTest
@@ -1925,18 +2011,63 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         testWeb3jService.setSender(getAliasFromEntity(payer));
         final var functionCall = "single".equals(type)
                 ? contract.call_transferNFTExternal(
-                        getAddressFromEntity(tokenEntity),
-                        getAliasFromEntity(sender),
-                        getAliasFromEntity(receiver),
-                        BigInteger.ONE)
+                getAddressFromEntity(tokenEntity),
+                getAliasFromEntity(sender),
+                getAliasFromEntity(receiver),
+                BigInteger.ONE)
                 : contract.call_transferNFTsExternal(
                         getAddressFromEntity(tokenEntity),
                         List.of(getAliasFromEntity(sender)),
                         List.of(getAliasFromEntity(receiver)),
                         List.of(BigInteger.ONE));
 
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .sender(Address.fromHexString(getAliasFromEntity(payer)))
+                .build();
+
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
+    }
+
+    @Test
+    void transferFromNft() throws Exception {
+        // Given
+        final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
+        final var sender = persistAccountEntity();
+        final var tokenEntity = persistTokenEntity();
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE))
+                .persist();
+        domainBuilder
+                .nft()
+                .customize(n -> n.tokenId(tokenEntity.getId()).serialNumber(1L).accountId(sender.toEntityId()))
+                .persist();
+        final var receiver = persistAccountEntity();
+        final var payer = persistAccountEntity();
+
+        persistAssociation(tokenEntity, payer);
+        persistAssociation(tokenEntity, sender);
+        persistAssociation(tokenEntity, receiver);
+
+        // When
+        testWeb3jService.setSender(getAliasFromEntity(payer));
+        final var functionCall = contract.call_transferFromNFTExternal(
+                getAddressFromEntity(tokenEntity),
+                getAliasFromEntity(sender),
+                getAliasFromEntity(receiver),
+                BigInteger.ONE);
+
+        // Then
+        verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        final var callData = functionCall.encodeFunctionCall();
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .sender(Address.fromHexString(getAliasFromEntity(payer)))
+                .build();
+        verifyOpcodeTracerCall(callData, contractFunctionProvider);
     }
 
     @Test
@@ -1955,8 +2086,14 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         final var functionCall = contract.call_cryptoTransferExternal(transferList, new ArrayList<>());
 
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .sender(Address.fromHexString(getAliasFromEntity(payer)))
+                .build();
+
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
     }
 
     @Test
@@ -1984,8 +2121,14 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         final var functionCall =
                 contract.call_cryptoTransferExternal(new TransferList(new ArrayList<>()), List.of(tokenTransferList));
 
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .sender(Address.fromHexString(getAliasFromEntity(payer)))
+                .build();
+
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
     }
 
     @Test
@@ -2016,8 +2159,14 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         final var functionCall = contract.call_cryptoTransferExternal(transferList, List.of(tokenTransferList));
 
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .sender(Address.fromHexString(getAliasFromEntity(payer)))
+                .build();
+
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
     }
 
     @Test
@@ -2052,8 +2201,14 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         final var functionCall =
                 contract.call_cryptoTransferExternal(new TransferList(new ArrayList<>()), List.of(tokenTransferList));
 
+        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .sender(Address.fromHexString(getAliasFromEntity(payer)))
+                .build();
+
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
     }
 
     @Test
@@ -2074,6 +2229,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @Test
@@ -2096,21 +2252,22 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     @ParameterizedTest
     @CsvSource(
             textBlock =
                     """
-        FUNGIBLE_COMMON, ED25519
-        FUNGIBLE_COMMON, ECDSA_SECPK256K1
-        FUNGIBLE_COMMON, CONTRACT_ID
-        FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID
-        NON_FUNGIBLE_UNIQUE, ED25519
-        NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1
-        NON_FUNGIBLE_UNIQUE, CONTRACT_ID
-        NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID
-        """)
+                            FUNGIBLE_COMMON, ED25519
+                            FUNGIBLE_COMMON, ECDSA_SECPK256K1
+                            FUNGIBLE_COMMON, CONTRACT_ID
+                            FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID
+                            NON_FUNGIBLE_UNIQUE, ED25519
+                            NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1
+                            NON_FUNGIBLE_UNIQUE, CONTRACT_ID
+                            NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID
+                            """)
     void updateTokenKey(final TokenTypeEnum tokenTypeEnum, final KeyValueType keyValueType) throws Exception {
         // Given
         final var allCasesKeyType = 0b1111111;
@@ -2130,6 +2287,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
     private void verifyEthCallAndEstimateGas(
@@ -2334,14 +2492,14 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         final var fractionalFee = TokenTypeEnum.FUNGIBLE_COMMON.equals(tokenType)
                 ? FractionalFee.builder()
-                        .allCollectorsAreExempt(true)
-                        .collectorAccountId(feeCollector.toEntityId())
-                        .denominator(domainBuilder.number())
-                        .maximumAmount(domainBuilder.number())
-                        .minimumAmount(1L)
-                        .numerator(domainBuilder.number())
-                        .netOfTransfers(true)
-                        .build()
+                .allCollectorsAreExempt(true)
+                .collectorAccountId(feeCollector.toEntityId())
+                .denominator(domainBuilder.number())
+                .maximumAmount(domainBuilder.number())
+                .minimumAmount(1L)
+                .numerator(domainBuilder.number())
+                .netOfTransfers(true)
+                .build()
                 : null;
 
         final var fallbackFee = FallbackFee.builder()
@@ -2351,12 +2509,12 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         final var royaltyFee = TokenTypeEnum.NON_FUNGIBLE_UNIQUE.equals(tokenType)
                 ? RoyaltyFee.builder()
-                        .allCollectorsAreExempt(true)
-                        .collectorAccountId(feeCollector.toEntityId())
-                        .denominator(domainBuilder.number())
-                        .fallbackFee(fallbackFee)
-                        .numerator(domainBuilder.number())
-                        .build()
+                .allCollectorsAreExempt(true)
+                .collectorAccountId(feeCollector.toEntityId())
+                .denominator(domainBuilder.number())
+                .fallbackFee(fallbackFee)
+                .numerator(domainBuilder.number())
+                .build()
                 : null;
 
         if (TokenTypeEnum.FUNGIBLE_COMMON.equals(tokenType)) {
@@ -2414,13 +2572,13 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
                     false,
                     key.getContractID().hasContractNum()
                             ? EntityIdUtils.asTypedEvmAddress(key.getContractID())
-                                    .toHexString()
+                            .toHexString()
                             : Address.ZERO.toHexString(),
                     key.getEd25519().toByteArray(),
                     key.getECDSASecp256K1().toByteArray(),
                     key.getDelegatableContractId().hasContractNum()
                             ? EntityIdUtils.asTypedEvmAddress(key.getDelegatableContractId())
-                                    .toHexString()
+                            .toHexString()
                             : Address.ZERO.toHexString());
         } catch (InvalidProtocolBufferException e) {
             throw new IllegalArgumentException("Unable to parse key", e);
@@ -2439,7 +2597,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
                 token.getSymbol(),
                 treasuryAccountId != null
                         ? EntityIdUtils.asHexedEvmAddress(new Id(
-                                treasuryAccountId.getShard(), treasuryAccountId.getRealm(), treasuryAccountId.getNum()))
+                        treasuryAccountId.getShard(), treasuryAccountId.getRealm(), treasuryAccountId.getNum()))
                         : Address.ZERO.toHexString(),
                 new String(token.getMetadata(), StandardCharsets.UTF_8),
                 token.getSupplyType().equals(TokenSupplyTypeEnum.FINITE),
@@ -2503,5 +2661,88 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
                 getAddressFromEntityId(royaltyFee.getFallbackFee().getDenominatingTokenId()),
                 false,
                 getAddressFromEvmAddress(feeCollector.getEvmAddress()));
+    }
+
+    private void verifyOpcodeTracerCall(final String callData, final ContractFunctionProviderRecord functionProvider) {
+
+        final var callDataBytes = Bytes.fromHexString(callData);
+        final var debugParameters = ContractDebugParameters.builder()
+                .block(functionProvider.block())
+                .callData(callDataBytes)
+                .consensusTimestamp(domainBuilder.timestamp())
+                .gas(15_000_000L)
+                .receiver(functionProvider.contractAddress())
+                .sender(new HederaEvmAccount(functionProvider.sender()))
+                .value(functionProvider.value())
+                .build();
+
+        if (functionProvider.expectedErrorMessage() != null) {
+            verifyThrowingOpcodeTracerCall(debugParameters, functionProvider);
+        } else {
+            verifySuccessfulOpcodeTracerCall(debugParameters);
+        }
+        assertThat(paramsCaptor.getValue()).isEqualTo(debugParameters);
+        assertThat(gasCaptor.getValue()).isEqualTo(debugParameters.getGas());
+    }
+
+    private void verifyOpcodeTracerCall(final String callData, final Contract contract) {
+        ContractFunctionProviderRecord functionProvider = ContractFunctionProviderRecord.builder()
+                .contractAddress(Address.fromHexString(contract.getContractAddress()))
+                .build();
+
+        final var callDataBytes = Bytes.fromHexString(callData);
+        final var debugParameters = ContractDebugParameters.builder()
+                .block(functionProvider.block())
+                .callData(callDataBytes)
+                .consensusTimestamp(domainBuilder.timestamp())
+                .gas(15_000_000L)
+                .receiver(functionProvider.contractAddress())
+                .sender(new HederaEvmAccount(functionProvider.sender()))
+                .value(functionProvider.value())
+                .build();
+
+        if (functionProvider.expectedErrorMessage() != null) {
+            verifyThrowingOpcodeTracerCall(debugParameters, functionProvider);
+        } else {
+            verifySuccessfulOpcodeTracerCall(debugParameters);
+        }
+        assertThat(paramsCaptor.getValue()).isEqualTo(debugParameters);
+        assertThat(gasCaptor.getValue()).isEqualTo(debugParameters.getGas());
+    }
+
+    @SneakyThrows
+    private void verifyThrowingOpcodeTracerCall(
+            final ContractDebugParameters params, final ContractFunctionProviderRecord function) {
+        final var actual = contractDebugService.processOpcodeCall(params, OPTIONS);
+        assertThat(actual.transactionProcessingResult().isSuccessful()).isFalse();
+        assertThat(actual.transactionProcessingResult().getOutput()).isEqualTo(Bytes.EMPTY);
+        assertThat(actual.transactionProcessingResult())
+                .satisfiesAnyOf(
+                        result -> assertThat(result.getRevertReason())
+                                .isPresent()
+                                .map(BytesDecoder::maybeDecodeSolidityErrorStringToReadableMessage)
+                                .hasValue(function.expectedErrorMessage()),
+                        result -> assertThat(result.getHaltReason())
+                                .isPresent()
+                                .map(ExceptionalHaltReason::getDescription)
+                                .hasValue(function.expectedErrorMessage()));
+        assertThat(actual.opcodes().size()).isNotZero();
+        assertThat(toHumanReadableMessage(actual.opcodes().getLast().reason()))
+                .isEqualTo(function.expectedErrorMessage());
+    }
+
+    private void verifySuccessfulOpcodeTracerCall(final ContractDebugParameters params) {
+        final var actual = contractDebugService.processOpcodeCall(params, OPTIONS);
+        final var expected = new OpcodesProcessingResult(resultCaptor, contextCaptor.getOpcodes());
+        // Compare transaction processing result
+        assertThat(actual.transactionProcessingResult())
+                .usingRecursiveComparison()
+                .ignoringFields("logs")
+                .isEqualTo(expected.transactionProcessingResult());
+        // Compare opcodes with gas tolerance
+        assertThat(actual.opcodes())
+                .usingRecursiveComparison()
+                .withComparatorForFields(gasComparator(), "gas")
+                .isEqualTo(expected.opcodes());
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -121,12 +121,12 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
     @BeforeEach
     void setUpArgumentCaptors() {
         doAnswer(invocation -> {
-            final var transactionProcessingResult =
-                    (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
-            resultCaptor = transactionProcessingResult;
-            contextCaptor = ContractCallContext.get();
-            return transactionProcessingResult;
-        })
+                    final var transactionProcessingResult =
+                            (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
+                    resultCaptor = transactionProcessingResult;
+                    contextCaptor = ContractCallContext.get();
+                    return transactionProcessingResult;
+                })
                 .when(processor)
                 .execute(paramsCaptor.capture(), gasCaptor.capture());
     }
@@ -1105,7 +1105,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         // When
         final var functionCall = single
                 ? contract.call_associateTokenExternal(
-                getAddressFromEntity(notAssociatedAccount), getAddressFromEntity(tokenEntity))
+                        getAddressFromEntity(notAssociatedAccount), getAddressFromEntity(tokenEntity))
                 : contract.call_associateTokensExternal(
                         getAddressFromEntity(notAssociatedAccount), List.of(getAddressFromEntity(tokenEntity)));
 
@@ -1154,7 +1154,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         // When
         final var functionCall = single
                 ? contract.call_dissociateTokenExternal(
-                getAddressFromEntity(associatedAccount), getAddressFromEntity(tokenEntity))
+                        getAddressFromEntity(associatedAccount), getAddressFromEntity(tokenEntity))
                 : contract.call_dissociateTokensExternal(
                         getAddressFromEntity(associatedAccount), List.of(getAddressFromEntity(tokenEntity)));
 
@@ -1966,10 +1966,10 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         testWeb3jService.setSender(getAliasFromEntity(payer));
         final var functionCall = "single".equals(type)
                 ? contract.call_transferTokenExternal(
-                getAddressFromEntity(tokenEntity),
-                getAliasFromEntity(sender),
-                getAliasFromEntity(receiver),
-                BigInteger.valueOf(1L))
+                        getAddressFromEntity(tokenEntity),
+                        getAliasFromEntity(sender),
+                        getAliasFromEntity(receiver),
+                        BigInteger.valueOf(1L))
                 : contract.call_transferTokensExternal(
                         getAddressFromEntity(tokenEntity),
                         List.of(getAliasFromEntity(sender), getAliasFromEntity(receiver)),
@@ -2011,10 +2011,10 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         testWeb3jService.setSender(getAliasFromEntity(payer));
         final var functionCall = "single".equals(type)
                 ? contract.call_transferNFTExternal(
-                getAddressFromEntity(tokenEntity),
-                getAliasFromEntity(sender),
-                getAliasFromEntity(receiver),
-                BigInteger.ONE)
+                        getAddressFromEntity(tokenEntity),
+                        getAliasFromEntity(sender),
+                        getAliasFromEntity(receiver),
+                        BigInteger.ONE)
                 : contract.call_transferNFTsExternal(
                         getAddressFromEntity(tokenEntity),
                         List.of(getAliasFromEntity(sender)),
@@ -2086,14 +2086,11 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         final var functionCall = contract.call_cryptoTransferExternal(transferList, new ArrayList<>());
 
-        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
-                .contractAddress(Address.fromHexString(contract.getContractAddress()))
-                .sender(Address.fromHexString(getAliasFromEntity(payer)))
-                .build();
-
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
-        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
+        verifyOpcodeTracerCall(
+                functionCall.encodeFunctionCall(),
+                getContractFunctionProviderWithSender(contract.getContractAddress(), payer));
     }
 
     @Test
@@ -2121,14 +2118,11 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         final var functionCall =
                 contract.call_cryptoTransferExternal(new TransferList(new ArrayList<>()), List.of(tokenTransferList));
 
-        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
-                .contractAddress(Address.fromHexString(contract.getContractAddress()))
-                .sender(Address.fromHexString(getAliasFromEntity(payer)))
-                .build();
-
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
-        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
+        verifyOpcodeTracerCall(
+                functionCall.encodeFunctionCall(),
+                getContractFunctionProviderWithSender(contract.getContractAddress(), payer));
     }
 
     @Test
@@ -2159,14 +2153,11 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         final var functionCall = contract.call_cryptoTransferExternal(transferList, List.of(tokenTransferList));
 
-        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
-                .contractAddress(Address.fromHexString(contract.getContractAddress()))
-                .sender(Address.fromHexString(getAliasFromEntity(payer)))
-                .build();
-
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
-        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
+        verifyOpcodeTracerCall(
+                functionCall.encodeFunctionCall(),
+                getContractFunctionProviderWithSender(contract.getContractAddress(), payer));
     }
 
     @Test
@@ -2201,14 +2192,11 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         final var functionCall =
                 contract.call_cryptoTransferExternal(new TransferList(new ArrayList<>()), List.of(tokenTransferList));
 
-        final var contractFunctionProvider = ContractFunctionProviderRecord.builder()
-                .contractAddress(Address.fromHexString(contract.getContractAddress()))
-                .sender(Address.fromHexString(getAliasFromEntity(payer)))
-                .build();
-
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
-        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contractFunctionProvider);
+        verifyOpcodeTracerCall(
+                functionCall.encodeFunctionCall(),
+                getContractFunctionProviderWithSender(contract.getContractAddress(), payer));
     }
 
     @Test
@@ -2492,14 +2480,14 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         final var fractionalFee = TokenTypeEnum.FUNGIBLE_COMMON.equals(tokenType)
                 ? FractionalFee.builder()
-                .allCollectorsAreExempt(true)
-                .collectorAccountId(feeCollector.toEntityId())
-                .denominator(domainBuilder.number())
-                .maximumAmount(domainBuilder.number())
-                .minimumAmount(1L)
-                .numerator(domainBuilder.number())
-                .netOfTransfers(true)
-                .build()
+                        .allCollectorsAreExempt(true)
+                        .collectorAccountId(feeCollector.toEntityId())
+                        .denominator(domainBuilder.number())
+                        .maximumAmount(domainBuilder.number())
+                        .minimumAmount(1L)
+                        .numerator(domainBuilder.number())
+                        .netOfTransfers(true)
+                        .build()
                 : null;
 
         final var fallbackFee = FallbackFee.builder()
@@ -2509,12 +2497,12 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
 
         final var royaltyFee = TokenTypeEnum.NON_FUNGIBLE_UNIQUE.equals(tokenType)
                 ? RoyaltyFee.builder()
-                .allCollectorsAreExempt(true)
-                .collectorAccountId(feeCollector.toEntityId())
-                .denominator(domainBuilder.number())
-                .fallbackFee(fallbackFee)
-                .numerator(domainBuilder.number())
-                .build()
+                        .allCollectorsAreExempt(true)
+                        .collectorAccountId(feeCollector.toEntityId())
+                        .denominator(domainBuilder.number())
+                        .fallbackFee(fallbackFee)
+                        .numerator(domainBuilder.number())
+                        .build()
                 : null;
 
         if (TokenTypeEnum.FUNGIBLE_COMMON.equals(tokenType)) {
@@ -2572,13 +2560,13 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
                     false,
                     key.getContractID().hasContractNum()
                             ? EntityIdUtils.asTypedEvmAddress(key.getContractID())
-                            .toHexString()
+                                    .toHexString()
                             : Address.ZERO.toHexString(),
                     key.getEd25519().toByteArray(),
                     key.getECDSASecp256K1().toByteArray(),
                     key.getDelegatableContractId().hasContractNum()
                             ? EntityIdUtils.asTypedEvmAddress(key.getDelegatableContractId())
-                            .toHexString()
+                                    .toHexString()
                             : Address.ZERO.toHexString());
         } catch (InvalidProtocolBufferException e) {
             throw new IllegalArgumentException("Unable to parse key", e);
@@ -2597,7 +2585,7 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
                 token.getSymbol(),
                 treasuryAccountId != null
                         ? EntityIdUtils.asHexedEvmAddress(new Id(
-                        treasuryAccountId.getShard(), treasuryAccountId.getRealm(), treasuryAccountId.getNum()))
+                                treasuryAccountId.getShard(), treasuryAccountId.getRealm(), treasuryAccountId.getNum()))
                         : Address.ZERO.toHexString(),
                 new String(token.getMetadata(), StandardCharsets.UTF_8),
                 token.getSupplyType().equals(TokenSupplyTypeEnum.FINITE),
@@ -2744,5 +2732,15 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
                 .usingRecursiveComparison()
                 .withComparatorForFields(gasComparator(), "gas")
                 .isEqualTo(expected.opcodes());
+    }
+
+    private ContractFunctionProviderRecord getContractFunctionProviderWithSender(
+            final String contract, final Entity sender) {
+        final var contractAddress = Address.fromHexString(contract);
+        final var senderAddress = Address.fromHexString(getAliasFromEntity(sender));
+        return ContractFunctionProviderRecord.builder()
+                .contractAddress(contractAddress)
+                .sender(senderAddress)
+                .build();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/ContractFunctionProviderRecord.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/ContractFunctionProviderRecord.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.utils;
+
+import com.hedera.mirror.web3.viewmodel.BlockType;
+import lombok.Builder;
+import lombok.With;
+import org.hyperledger.besu.datatypes.Address;
+
+@Builder
+public record ContractFunctionProviderRecord(
+        Address contractAddress, Address sender, long value, String expectedErrorMessage, @With BlockType block) {
+
+    public static ContractFunctionProviderRecordBuilder builder() {
+        return new ContractFunctionProviderRecordBuilder()
+                .block(BlockType.LATEST)
+                .sender(Address.fromHexString(""));
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/OpcodeTracerUtil.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/OpcodeTracerUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.utils;
+
+import com.hedera.mirror.web3.convert.BytesDecoder;
+import com.hedera.mirror.web3.evm.contracts.execution.traceability.OpcodeTracerOptions;
+import java.util.Comparator;
+import lombok.experimental.UtilityClass;
+import org.apache.tuweni.bytes.Bytes;
+
+@UtilityClass
+public class OpcodeTracerUtil {
+
+    public static final OpcodeTracerOptions OPTIONS = new OpcodeTracerOptions(false, false, false);
+
+    public static String toHumanReadableMessage(final String solidityError) {
+        return BytesDecoder.maybeDecodeSolidityErrorStringToReadableMessage(Bytes.fromHexString(solidityError));
+    }
+
+    public static Comparator<Long> gasComparator() {
+        return (d1, d2) -> {
+            final var diff = Math.abs(d1 - d2);
+            return Math.toIntExact(diff <= 64L ? 0 : d1 - d2);
+        };
+    }
+}


### PR DESCRIPTION
**Description**:
This pr refactors `ContractDebugServiceTest`. Migrated tests from `evmPrecompileSupportedModificationTokenFunctions` that uses `SupportedContractModificationFunctions`. Test were migrated into `ContractCallServicePrecompileTest` as it also tests `SupportedContractModificationFunctions`. We just add the opcode assertions in the already existing tests there since they use the same setup. This also decreases the time for all tests to run. 

This PR modifies:
`ContractDebugServiceTest` - removed `evmPrecompileSupportedModificationTokenFunctions` function.
`ContractCallServicePrecompileTest` - added debug trace assertions in the tests testing modification precompile contract functions - uses exactly the same function of the removed `evmPrecompileSupportedModificationTokenFunctions`.
Added `OpcodeTracerUtil` class

This pr is related to #8944 but there will be a couple of prs more in future before we can close this task.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
