### PR TITLE
Update the web3j-cli download task to use the official release

### DIFF
--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -123,6 +123,7 @@ val compileHistoricalSolidityContracts =
         description = "Compiles the historical solidity contracts to java files using web3j-cli"
         group = "historical"
         mustRunAfter(tasks.named("generateTestContractWrappers"))
+        dependsOn(downloadWeb3j)
         dependsOn(extractOpenZeppelin)
         dependsOn(tasks.named("compileTestSolidity"))
         val scriptPath = file("./src/main/resources/scripts/compile_solidity.sh").absolutePath

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -75,9 +75,7 @@ val downloadWeb3j =
         description = "Download and install Web3j CLI"
         group = "historical"
 
-        val homeDir = System.getProperty("user.home")
-
-        commandLine("bash", "-c", "curl -L get.web3j.io | sh && source $homeDir/.web3j/source.sh")
+        commandLine("bash", "-c", "curl -L get.web3j.io | sh")
     }
 
 // Tasks to download OpenZeppelin contracts

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -70,35 +70,12 @@ tasks.compileJava { options.compilerArgs.add("--enable-preview") }
 
 tasks.test { jvmArgs = listOf("--enable-preview") }
 
-val web3jDir = rootDir.resolve(".gradle").resolve("web3j")
-val web3jVersion = "1.6.0"
-val web3jName = "web3j-cli-shadow-${web3jVersion}.tar"
-val web3jFile = web3jDir.resolve(web3jName)
-
 val downloadWeb3j =
-    tasks.register("downloadWeb3j") {
-        val url =
-            "https://github.com/bilyana-gospodinova/web3j-cli/releases/download/${web3jVersion}/${web3jName}"
-        description = "Download Web3j CLI"
+    tasks.register<Exec>("downloadWeb3j") {
+        description = "Download and install Web3j CLI"
         group = "historical"
-        doLast {
-            web3jDir.mkdirs()
-            val connection = URI(url).toURL().openConnection() as HttpURLConnection
-            connection.inputStream.use { input ->
-                web3jFile.outputStream().use { output -> input.copyTo(output) }
-            }
-        }
-        onlyIf { !web3jFile.exists() }
-    }
 
-val extractWeb3j =
-    tasks.register<Copy>("extractWeb3j") {
-        description = "Extracts the Web3j CLI"
-        group = "historical"
-        dependsOn(downloadWeb3j)
-        from(tarTree(web3jFile))
-        into(web3jDir)
-        eachFile { path = path.replaceFirst("web3j-cli-shadow-${web3jVersion}", "") }
+        commandLine("bash", "-c", "curl -L get.web3j.io | sh")
     }
 
 // Tasks to download OpenZeppelin contracts
@@ -146,7 +123,6 @@ val compileHistoricalSolidityContracts =
         description = "Compiles the historical solidity contracts to java files using web3j-cli"
         group = "historical"
         mustRunAfter(tasks.named("generateTestContractWrappers"))
-        dependsOn(extractWeb3j)
         dependsOn(extractOpenZeppelin)
         dependsOn(tasks.named("compileTestSolidity"))
         val scriptPath = file("./src/main/resources/scripts/compile_solidity.sh").absolutePath

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -75,7 +75,9 @@ val downloadWeb3j =
         description = "Download and install Web3j CLI"
         group = "historical"
 
-        commandLine("bash", "-c", "curl -L get.web3j.io | sh")
+        val homeDir = System.getProperty("user.home")
+
+        commandLine("bash", "-c", "curl -L get.web3j.io | sh && source $homeDir/.web3j/source.sh")
     }
 
 // Tasks to download OpenZeppelin contracts

--- a/hedera-mirror-web3/src/main/resources/scripts/compile_solidity.sh
+++ b/hedera-mirror-web3/src/main/resources/scripts/compile_solidity.sh
@@ -38,7 +38,7 @@ for i in "${!SOLC_VERSIONS[@]}"; do
     solc --base-path . --allow-paths node_modules --abi --bin --overwrite -o ${TEMP_DIR} "$contract_path"
 
     # Generate Java files using web3j
-    ../.gradle/web3j/bin/web3j generate solidity \
+    web3j generate solidity \
       -b "${TEMP_DIR}/${contract_name}.bin" \
       -a "${TEMP_DIR}/${contract_name}.abi" \
       -o "$OUTPUT_DIR" \

--- a/hedera-mirror-web3/src/main/resources/scripts/compile_solidity.sh
+++ b/hedera-mirror-web3/src/main/resources/scripts/compile_solidity.sh
@@ -38,7 +38,7 @@ for i in "${!SOLC_VERSIONS[@]}"; do
     solc --base-path . --allow-paths node_modules --abi --bin --overwrite -o ${TEMP_DIR} "$contract_path"
 
     # Generate Java files using web3j
-    web3j generate solidity \
+    $HOME/.web3j/web3j generate solidity \
       -b "${TEMP_DIR}/${contract_name}.bin" \
       -a "${TEMP_DIR}/${contract_name}.abi" \
       -o "$OUTPUT_DIR" \


### PR DESCRIPTION
**Description**:
There is an official release of the `web3j-cli`, so this PR removes the custom download logic from the custom repo and updates the gradle task to use the official release. 

It would be nice if we can add the cli as a gradle dependency and not use gradle tasks to download it at all.

**Related issue(s)**: 

Fixes: #9074
