### PR TITLE
Return 501 NOT_SUPPORTED error response for unsupported precompiles

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
@@ -19,10 +19,12 @@ package com.hedera.mirror.web3.controller;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.springframework.http.HttpStatus.TOO_MANY_REQUESTS;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
+import com.hedera.mirror.web3.evm.exception.PrecompileNotSupportedException;
 import com.hedera.mirror.web3.exception.EntityNotFoundException;
 import com.hedera.mirror.web3.exception.InvalidInputException;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
@@ -99,6 +101,17 @@ class GenericControllerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     private ResponseEntity<?> queryTimeoutException(final QueryTimeoutException e, WebRequest request) {
         return handleExceptionInternal(e, null, null, SERVICE_UNAVAILABLE, request);
+    }
+
+    /**
+     * Temporary handler, intended for dealing with forthcoming features that are not yet available, such as the absence
+     * of a precompile
+     **/
+    @ExceptionHandler
+    private ResponseEntity<?> precompileNotSupportedException(
+            final PrecompileNotSupportedException e, WebRequest request) {
+        //        return new ResponseEntity<>(new GenericErrorResponse(e.getMessage()), NOT_IMPLEMENTED);
+        return handleExceptionInternal(e, null, null, NOT_IMPLEMENTED, request);
     }
 
     @ExceptionHandler

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
@@ -110,7 +110,6 @@ class GenericControllerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     private ResponseEntity<?> precompileNotSupportedException(
             final PrecompileNotSupportedException e, WebRequest request) {
-        //        return new ResponseEntity<>(new GenericErrorResponse(e.getMessage()), NOT_IMPLEMENTED);
         return handleExceptionInternal(e, null, null, NOT_IMPLEMENTED, request);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/PrecompileNotSupportedException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/exception/PrecompileNotSupportedException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.evm.exception;
+
+@SuppressWarnings("java:S110")
+public class PrecompileNotSupportedException extends EvmException {
+
+    public PrecompileNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/AbiConstants.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/AbiConstants.java
@@ -224,6 +224,9 @@ public class AbiConstants {
     // updateTokenExpiryInfo(address token, Expiry expiryInfoStruct)
     public static final int ABI_ID_UPDATE_TOKEN_EXPIRY_INFO_V2 = 0xd27be6cd;
 
+    // isAssociated(). Should be called as IHRC(tokenAddress).isAssociated(). Currently it's not supported.
+    public static final int ABI_HRC_IS_ASSOCIATED = 0x4d8fdd6d;
+
     private AbiConstants() {
         throw new UnsupportedOperationException("Utility class");
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -19,7 +19,6 @@ package com.hedera.services.store.contracts.precompile;
 import static com.hedera.mirror.web3.common.PrecompileContext.PRECOMPILE_CONTEXT;
 import static com.hedera.node.app.service.evm.contracts.operations.HederaExceptionalHaltReason.ERROR_DECODING_PRECOMPILE_INPUT;
 import static com.hedera.node.app.service.evm.store.contracts.HederaEvmWorldStateTokenAccount.TOKEN_PROXY_ACCOUNT_NONCE;
-import static com.hedera.node.app.service.evm.store.contracts.utils.DescriptorUtils.getRedirectTarget;
 import static com.hedera.node.app.service.evm.store.contracts.utils.DescriptorUtils.isTokenProxyRedirect;
 import static com.hedera.node.app.service.evm.store.contracts.utils.DescriptorUtils.isViewFunction;
 import static com.hedera.node.app.service.evm.utils.ValidationUtils.validateTrue;

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/contracts/precompile/HTSPrecompiledContract.java
@@ -499,7 +499,7 @@ public class HTSPrecompiledContract extends EvmHTSPrecompiledContract {
         if (AbiConstants.ABI_HRC_IS_ASSOCIATED == target.descriptor()) {
             // We can't support this precompile since the copied code from mono services does not have the necessary
             // logic
-            throw new PrecompileNotSupportedException(StringUtils.EMPTY);
+            throw new PrecompileNotSupportedException("HRC isAssociated() precompile is not supported.");
         }
 
         final var executor = infrastructureFactory.newRedirectExecutor(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -346,10 +346,9 @@ class ContractControllerTest {
 
     @Test
     void callWithNotSupportedPrecompile() throws Exception {
-        final var error = "Precompile not supported";
         final var request = request();
 
-        given(service.processCall(any())).willThrow(new PrecompileNotSupportedException(error));
+        given(service.processCall(any())).willThrow(new PrecompileNotSupportedException(StringUtils.EMPTY));
         contractCall(request)
                 .andExpect(status().isNotImplemented())
                 .andExpect(content()

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hedera.mirror.web3.Web3Properties;
+import com.hedera.mirror.web3.evm.exception.PrecompileNotSupportedException;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.exception.BlockNumberNotFoundException;
 import com.hedera.mirror.web3.exception.BlockNumberOutOfRangeException;
@@ -340,6 +342,19 @@ class ContractControllerTest {
         contractCall(request)
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string(convert(new GenericErrorResponse(BAD_REQUEST.getReasonPhrase(), error))));
+    }
+
+    @Test
+    void callWithNotSupportedPrecompile() throws Exception {
+        final var error = "Precompile not supported";
+        final var request = request();
+
+        given(service.processCall(any())).willThrow(new PrecompileNotSupportedException(error));
+        contractCall(request)
+                .andExpect(status().isNotImplemented())
+                .andExpect(content()
+                        .string(convert(
+                                new GenericErrorResponse(NOT_IMPLEMENTED.getReasonPhrase(), StringUtils.EMPTY))));
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/HTSPrecompiledContractTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/store/contract/precompile/HTSPrecompiledContractTest.java
@@ -32,6 +32,7 @@ import static org.mockito.BDDMockito.given;
 import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.common.PrecompileContext;
+import com.hedera.mirror.web3.evm.exception.PrecompileNotSupportedException;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.StackedStateFrames;
 import com.hedera.mirror.web3.evm.store.Store;
@@ -313,9 +314,10 @@ class HTSPrecompiledContractTest {
         given(worldUpdater.permissivelyUnaliased(any()))
                 .willAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
         given(messageFrame.getMessageFrameStack()).willReturn(messageFrameStack);
-        final var precompileResult = subject.computeCosted(functionHash, messageFrame, gasCalculator, tokenAccessor);
 
-        assertThat(FAILURE_RESULT).isEqualTo(precompileResult);
+        assertThrows(
+                PrecompileNotSupportedException.class,
+                () -> subject.computeCosted(functionHash, messageFrame, gasCalculator, tokenAccessor));
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -100,9 +100,21 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest 
         final var functionCall = contract.call_callMissingPrecompile();
 
         // Then
-        assertThatThrownBy(functionCall::send)
-                .isInstanceOf(PrecompileNotSupportedException.class)
-                .hasMessage("Precompile is not supported");
+        assertThatThrownBy(functionCall::send).isInstanceOf(PrecompileNotSupportedException.class);
+    }
+
+    // Temporary test until we start supporting this precompile
+    @Test
+    void hrcIsAssociatedFails() {
+        // Given
+        final var token = persistFungibleToken();
+        final var contract = testWeb3jService.deploy(PrecompileTestContract::deploy);
+
+        // When
+        final var functionCall = contract.call_hrcIsAssociated(getAddressFromEntity(token));
+
+        // Then
+        assertThatThrownBy(functionCall::send).isInstanceOf(PrecompileNotSupportedException.class);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -48,6 +48,7 @@ import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenPauseStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenSupplyTypeEnum;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
+import com.hedera.mirror.web3.evm.exception.PrecompileNotSupportedException;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.service.model.ContractExecutionParameters;
@@ -89,6 +90,20 @@ import org.web3j.protocol.core.RemoteFunctionCall;
 import org.web3j.tx.Contract;
 
 class ContractCallServicePrecompileTest extends AbstractContractCallServiceTest {
+
+    @Test
+    void unsupportedPrecompileFails() {
+        // Given
+        final var contract = testWeb3jService.deploy(PrecompileTestContract::deploy);
+
+        // When
+        final var functionCall = contract.call_callMissingPrecompile();
+
+        // Then
+        assertThatThrownBy(functionCall::send)
+                .isInstanceOf(PrecompileNotSupportedException.class)
+                .hasMessage("Precompile is not supported");
+    }
 
     @Test
     void isTokenFrozen() throws Exception {

--- a/hedera-mirror-web3/src/test/solidity/PrecompileTestContract.sol
+++ b/hedera-mirror-web3/src/test/solidity/PrecompileTestContract.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.18;
 pragma experimental ABIEncoderV2;
+
 import "./HederaTokenService.sol";
 import "./HederaResponseCodes.sol";
 
 contract PrecompileTestContract is HederaTokenService {
 
 
-    function isTokenAddress(address token)external returns(bool){
+    function isTokenAddress(address token) external returns (bool){
         (int response,bool tokenFlag) = HederaTokenService.isToken(token);
 
         if (response != HederaResponseCodes.SUCCESS) {
@@ -16,7 +17,7 @@ contract PrecompileTestContract is HederaTokenService {
         return tokenFlag;
     }
 
-    function isTokenFrozen(address token, address account)external returns(bool){
+    function isTokenFrozen(address token, address account) external returns (bool){
         (int response,bool frozen) = HederaTokenService.isFrozen(token, account);
 
         if (response != HederaResponseCodes.SUCCESS) {
@@ -25,7 +26,7 @@ contract PrecompileTestContract is HederaTokenService {
         return frozen;
     }
 
-    function isKycGranted(address token, address account) external returns(bool){
+    function isKycGranted(address token, address account) external returns (bool){
         (int response,bool kycGranted) = HederaTokenService.isKyc(token, account);
 
         if (response != HederaResponseCodes.SUCCESS) {
@@ -34,7 +35,7 @@ contract PrecompileTestContract is HederaTokenService {
         return kycGranted;
     }
 
-    function getTokenDefaultFreeze(address token) external returns(bool) {
+    function getTokenDefaultFreeze(address token) external returns (bool) {
         (int response,bool frozen) = HederaTokenService.getTokenDefaultFreezeStatus(token);
 
         if (response != HederaResponseCodes.SUCCESS) {
@@ -43,7 +44,7 @@ contract PrecompileTestContract is HederaTokenService {
         return frozen;
     }
 
-    function getTokenDefaultKyc(address token) external returns(bool) {
+    function getTokenDefaultKyc(address token) external returns (bool) {
         (int response,bool kyc) = HederaTokenService.getTokenDefaultKycStatus(token);
 
         if (response != HederaResponseCodes.SUCCESS) {
@@ -94,7 +95,7 @@ contract PrecompileTestContract is HederaTokenService {
         nonFungibleTokenInfo = retrievedTokenInfo;
     }
 
-    function getType(address token) external returns(int) {
+    function getType(address token) external returns (int) {
         (int statusCode, int tokenType) = HederaTokenService.getTokenType(token);
 
         if (statusCode != HederaResponseCodes.SUCCESS) {
@@ -120,7 +121,7 @@ contract PrecompileTestContract is HederaTokenService {
         //"(bool,address,bytes,bytes,address)";
 
 
-        if(responseCode != HederaResponseCodes.SUCCESS) {
+        if (responseCode != HederaResponseCodes.SUCCESS) {
             revert();
         }
 
@@ -142,4 +143,9 @@ contract PrecompileTestContract is HederaTokenService {
         (_responseCode, approved) = HederaTokenService.isApprovedForAll(token, owner, operator);
     }
 
+    function callMissingPrecompile() public returns (bool success, bytes memory result) {
+        (success, result) = address(0x167).call(
+            abi.encodeWithSignature("fakeSignature()"));
+        require(success);
+    }
 }

--- a/hedera-mirror-web3/src/test/solidity/PrecompileTestContract.sol
+++ b/hedera-mirror-web3/src/test/solidity/PrecompileTestContract.sol
@@ -148,4 +148,12 @@ contract PrecompileTestContract is HederaTokenService {
             abi.encodeWithSignature("fakeSignature()"));
         require(success);
     }
+
+    function hrcIsAssociated(address token) public returns (bool isAssociated) {
+        isAssociated = IHRC(token).isAssociated();
+    }
+}
+
+interface IHRC {
+    function isAssociated() external returns (bool associated);
 }


### PR DESCRIPTION
**Description**:
This PR aims to protect the web3 calls to reach unimplemented precompiles due to missing functionality in the copied mono code base. When the `json-rpc-relay` tries to invoke such precompile it will receive the informative `501` error and perform the needed fallback logic. Currently they receive `500` `INTERNAL_ERROR` with `CONTRACT_REVERT_EXECUTED` status, which might be misleading.

The PR adds:
- logic to return NOT_SUPPORTED status for any new dynamic/modification precompile
- logic to return NOT_SUPPORTED status for HRC_IS_ASSOCIATED view precompile. That's the only read only precompile added in services after switching to modularized code and is not supported in `hedera-mirror-web3`. Unfortunately, we don't have a way to add a universal check for each not supported view precompile, since there is not distinction between not found precompile and failed input validation for the view precompiles, so we will have to add a check for each not supported precompile explicitly

**Related issue(s)**:

Fixes #9136 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
