### PR TITLE
Optimize stackgres connection pooling

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -358,6 +358,9 @@ promtail:
 
 stackgres:
   enabled: false
+  operator:
+    image:
+      name: gcr.io/mirrornode/stackgres-operator
   prometheusRules:
     enabled: true
     DatabaseStorageFull:
@@ -385,7 +388,8 @@ testkube:
       rest: {}
       restjava: {}
       web3: {}
-    delay: 330s  # Delay duration between test suite steps
+    delay: 600s  # Delay duration between test suite steps. This needs to be at least 600s to match the pgbouncer server
+                 # connection idle timeout, so that connections will be freed up for the next set of tests
     extraExecutionRequestVariables: {}
     gitBranch: ""  # Default to .Chart.AppVersion
     schedule: ""  # Cron schedule of the test suite, default to no schedule

--- a/charts/hedera-mirror/templates/stackgres/stackgres-cluster.yaml
+++ b/charts/hedera-mirror/templates/stackgres/stackgres-cluster.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   coordinator:
     configurations:
-      sgPoolingConfig: {{ include "hedera-mirror.stackgres" . }}
+      sgPoolingConfig: {{ include "hedera-mirror.stackgres" . }}-coordinator
       sgPostgresConfig: {{ include "hedera-mirror.stackgres" . }}-coordinator
     instances: {{ .Values.stackgres.coordinator.instances }}
     managedSql:
@@ -46,7 +46,7 @@ spec:
   shards:
     clusters: {{ .Values.stackgres.worker.instances }}
     configurations:
-      sgPoolingConfig: {{ include "hedera-mirror.stackgres" . }}
+      sgPoolingConfig: {{ include "hedera-mirror.stackgres" . }}-worker
       sgPostgresConfig: {{ include "hedera-mirror.stackgres" . }}-worker
     instancesPerCluster: {{ .Values.stackgres.worker.replicasPerInstance }}
     managedSql:

--- a/charts/hedera-mirror/templates/stackgres/stackgres-pooling-config-coordinator.yaml
+++ b/charts/hedera-mirror/templates/stackgres/stackgres-pooling-config-coordinator.yaml
@@ -3,10 +3,10 @@ apiVersion: stackgres.io/v1
 kind: SGPoolingConfig
 metadata:
   labels: {{ include "hedera-mirror.labels" . | nindent 4 }}
-  name: {{ include "hedera-mirror.stackgres" . }}
+  name: {{ include "hedera-mirror.stackgres" . }}-coordinator
   namespace: {{ include "hedera-mirror.namespace" . }}
 spec:
   pgBouncer:
     pgbouncer.ini:
-      {{ toYaml .Values.stackgres.pgbouncer | nindent 6 }}
+      {{ toYaml .Values.stackgres.coordinator.pgbouncer | nindent 6 }}
 {{- end -}}

--- a/charts/hedera-mirror/templates/stackgres/stackgres-pooling-config-worker.yaml
+++ b/charts/hedera-mirror/templates/stackgres/stackgres-pooling-config-worker.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.stackgres.enabled -}}
+apiVersion: stackgres.io/v1
+kind: SGPoolingConfig
+metadata:
+  labels: {{ include "hedera-mirror.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror.stackgres" . }}-worker
+  namespace: {{ include "hedera-mirror.namespace" . }}
+spec:
+  pgBouncer:
+    pgbouncer.ini:
+      {{ toYaml .Values.stackgres.worker.pgbouncer | nindent 6 }}
+{{- end -}}

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -278,6 +278,7 @@ stackgres:
       autovacuum_max_workers: "2"
       checkpoint_timeout: "1800"
       citus.executor_slow_start_interval: "10ms"
+      citus.force_max_query_parallelization: "on"
       citus.max_cached_conns_per_worker: "6"
       citus.max_shared_pool_size: "850"
       citus.node_conninfo: "sslmode=disable"  # Disable SSL to work around https://github.com/hashgraph/hedera-mirror-node/issues/9143
@@ -296,6 +297,18 @@ stackgres:
     enableMetricsExporter: false
     enablePostgresUtil: true
     instances: 1
+    pgbouncer:
+      pgbouncer:
+        default_pool_size: "800"
+        ignore_startup_parameters: extra_float_digits,options,statement_timeout
+        max_client_conn: "1600"
+        max_prepared_statements: "512"
+        pool_mode: transaction
+      users:
+        mirror_node:
+          pool_mode: session
+        mirror_importer:
+          pool_mode: session
     replication:
       mode: sync-all
     resources:
@@ -313,20 +326,6 @@ stackgres:
     - name: pg_trgm
       version: "1.6"
   nameOverride: citus
-  pgbouncer:
-    pgbouncer:
-      default_pool_size: "800"
-      ignore_startup_parameters: extra_float_digits,options,statement_timeout
-      max_client_conn: "800"
-      max_db_connections: "0"
-      max_prepared_statements: "256"
-      max_user_connections: "0"
-      pool_mode: transaction
-    users:
-      mirror_node:
-        pool_mode: session
-      mirror_importer:
-        pool_mode: session
   podAntiAffinity: true
   postgresVersion: 16
   worker:
@@ -350,6 +349,18 @@ stackgres:
     enablePostgresUtil: true
     instances: 1
     overrides: []  # Override shard(s) configuration
+    pgbouncer:
+      pgbouncer:
+        default_pool_size: "900"
+        ignore_startup_parameters: extra_float_digits,options,statement_timeout
+        max_client_conn: "2000"
+        max_prepared_statements: "512"
+        pool_mode: transaction
+      users:
+        mirror_node:
+          pool_mode: session
+        mirror_importer:
+          pool_mode: session
     replicasPerInstance: 1
     resources:
       cpu: 100m

--- a/hedera-mirror-test/k6/src/rest/test/contractsResult.js
+++ b/hedera-mirror-test/k6/src/rest/test/contractsResult.js
@@ -30,8 +30,7 @@ const {options, run, setup} = new RestTestScenarioBuilder()
     const url = `${testParameters['BASE_URL_PREFIX']}${getUrl(testParameters)}`;
     return http.get(url);
   })
-  .requiredParameters('DEFAULT_CONTRACT_ID')
-  .check('Contracts id state OK', (r) => isValidListResponse(r, resultListName))
+  .check('Contracts results OK', (r) => isValidListResponse(r, resultListName))
   .build();
 
 export {getUrl, options, run, setup};


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR optimizes stackgres connection pooling configs:

- Increase `max_client_connections` and `max_prepared_statements`
- Separate coordinator and worker pgbouncer config
- Set customized stackgres-operator image as the default
- Fix small issues in k6 test contractsResults.js

**Related issue(s)**:

Fixes #9196

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

js REST api k6 tests show better stability, though it's marginal difference of pass rate, e.g., for `/api/v1/transactions?limit=100`, pass rate increased to 99% or just 32 failed requests, v.s., 98.2% or 6000 failed requests.

Web3 show more improvements, `contractCallBalance` has a pass rate of 98% at 7277/s v.s. in 0.112.0-rc2 99.79% pass rate and 4505.53, in 0.111.0-rc2 99.94% pass rate and 6013.31/s

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
