### PR TITLE
Improve balance performance in Citus by un-distributing balance tables (0.112)

### DIFF
--- a/charts/hedera-mirror-common/templates/prometheusrule.yaml
+++ b/charts/hedera-mirror-common/templates/prometheusrule.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.stackgres.prometheusRules.enabled .Values.stackgres.enabled -}}
+{{- if and .Values.prometheus.enabled .Values.stackgres.prometheusRules.enabled .Values.stackgres.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/charts/hedera-mirror/templates/stackgres/stackgres-cluster.yaml
+++ b/charts/hedera-mirror/templates/stackgres/stackgres-cluster.yaml
@@ -54,8 +54,8 @@ spec:
         - sgScript: {{ include "hedera-mirror.stackgres" . }}-worker
     overrides: {{ .Values.stackgres.worker.overrides | toYaml | nindent 6 }}
     pods:
-      disableMetricsExporter: {{ not .Values.stackgres.coordinator.enableMetricsExporter }}
-      disablePostgresUtil: {{ not .Values.stackgres.coordinator.enablePostgresUtil }}
+      disableMetricsExporter: {{ not .Values.stackgres.worker.enableMetricsExporter }}
+      disablePostgresUtil: {{ not .Values.stackgres.worker.enablePostgresUtil }}
       persistentVolume: {{ .Values.stackgres.worker.persistentVolume | toYaml | nindent 8 }}
       resources:
         disableResourcesRequestsSplitFromTotal: {{ .Values.stackgres.dedicatedResourcesRequests }}

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.5.0__undistribute_balance_tables.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.5.0__undistribute_balance_tables.sql
@@ -1,0 +1,2 @@
+select undistribute_table('account_balance');
+select undistribute_table('token_balance');

--- a/hedera-mirror-rest/__tests__/specs/balances/not-found.json
+++ b/hedera-mirror-rest/__tests__/specs/balances/not-found.json
@@ -51,7 +51,10 @@
       }
     ]
   },
-  "url": "/api/v1/balances?account.id=0.0.3",
+  "urls": [
+    "/api/v1/balances?account.id=0.0.3",
+    "/api/v1/balances?account.publickey=97c6b472d72b34598dc4f5ca20b68d40916cf9f68f32bbc3dcacebd0680fe920&timestamp=lte:2345"
+  ],
   "responseStatus": 200,
   "responseJson": {
     "timestamp": null,

--- a/hedera-mirror-rest/__tests__/specs/network/supply/invalid-parameters-bounds.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/invalid-parameters-bounds.json
@@ -1,0 +1,19 @@
+{
+  "description": "Network supply API with invalid bounds",
+  "setup": {},
+  "urls": [
+    "/api/v1/network/supply?timestamp=gt:2&timestamp=1&",
+    "/api/v1/network/supply?timestamp=gt:2&timestamp=lt:1&",
+    "/api/v1/network/supply?timestamp=gte:2&timestamp=lte:1&"
+  ],
+  "responseStatus": 400,
+  "responseJson": {
+    "_status": {
+      "messages": [
+        {
+          "message": "Lower timestamp cannot be higher than upper timestamp"
+        }
+      ]
+    }
+  }
+}

--- a/hedera-mirror-rest/__tests__/specs/network/supply/timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/network/supply/timestamp.json
@@ -4,52 +4,65 @@
     "accounts": [],
     "balances": [
       {
-        "timestamp": 1000000000,
+        "timestamp": 1600000000000000000,
+        "id": 2,
+        "balance": 10
+      },
+      {
+        "timestamp": 1600000000000000000,
+        "id": 42,
+        "balance": 20
+      },
+      {
+        "timestamp": 1700000000000000000,
         "id": 2,
         "balance": 1
       },
       {
-        "timestamp": 1000000000,
+        "timestamp": 1700000000000000000,
         "id": 42,
         "balance": 1
       },
       {
-        "timestamp": 1000000005,
+        "timestamp": 1700000000000000005,
         "id": 1,
         "balance": 10
       },
       {
-        "timestamp": 1000000005,
+        "timestamp": 1700000000000000005,
         "id": 2,
         "balance": 4000000000000000000
       },
       {
-        "timestamp": 1000000005,
+        "timestamp": 1700000000000000005,
         "id": 42,
         "balance": 50
       },
       {
-        "timestamp": 1000000005,
+        "timestamp": 1700000000000000005,
         "id": 100,
         "balance": 1
       }
     ]
   },
   "urls": [
-    "/api/v1/network/supply?timestamp=1",
-    "/api/v1/network/supply?timestamp=1.000000000",
-    "/api/v1/network/supply?timestamp=eq:1",
-    "/api/v1/network/supply?timestamp=eq:1.000000000",
-    "/api/v1/network/supply?timestamp=1.000000001",
-    "/api/v1/network/supply?timestamp=eq:1.000000001",
-    "/api/v1/network/supply?timestamp=lte:1.000000000",
-    "/api/v1/network/supply?timestamp=gte:1.000000000&timestamp=lte:1.000000000",
-    "/api/v1/network/supply?timestamp=gt:0&timestamp=lt:1.000000005"
+    "/api/v1/network/supply?timestamp=1700000000",
+    "/api/v1/network/supply?timestamp=1700000000.000000000",
+    "/api/v1/network/supply?timestamp=eq:1700000000",
+    "/api/v1/network/supply?timestamp=eq:1700000000.000000000",
+    "/api/v1/network/supply?timestamp=1700000000.000000001",
+    "/api/v1/network/supply?timestamp=eq:1700000000.000000001",
+    "/api/v1/network/supply?timestamp=lte:1700000000.000000000",
+    "/api/v1/network/supply?timestamp=lt:1700000000.000000005",
+    "/api/v1/network/supply?timestamp=gte:1700000000.000000000&timestamp=lte:1700000000.000000000",
+    "/api/v1/network/supply?timestamp=gt:0&timestamp=lt:1700000000.000000005",
+    "/api/v1/network/supply?timestamp=gte:1700000000.000000000&timestamp=lt:1700000000.000000005",
+    "/api/v1/network/supply?timestamp=gte:1500000000.000000000&timestamp=gte:1700000000.000000000&timestamp=lte:1700000000.00000000&timestamp=lt:1800000000.000000000"
   ],
   "responseStatus": 200,
   "responseJson": {
     "released_supply": "4999999999999999998",
-    "timestamp": "1.000000000",
+    "timestamp": "1700000000.000000000",
     "total_supply": "5000000000000000000"
   }
 }

--- a/hedera-mirror-rest/utils.js
+++ b/hedera-mirror-rest/utils.js
@@ -1124,8 +1124,7 @@ const buildAndValidateFilters = (
   query,
   acceptedParameters,
   filterValidator = filterValidityChecks,
-  filterDependencyChecker = filterDependencyCheck,
-  excludedCombinatons = [[]]
+  filterDependencyChecker = filterDependencyCheck
 ) => {
   const {badParams, filters} = buildFilters(query);
   const {invalidParams, unknownParams} = validateAndParseFilters(filters, filterValidator, acceptedParameters);

--- a/hedera-mirror-test/k6/README.md
+++ b/hedera-mirror-test/k6/README.md
@@ -1,13 +1,13 @@
 # K6 Performance Tests
 
-This module covers the [k6](https://k6.io/) based performance tests for Mirror Node APIs including rest, rosetta,
-and web3.
+This module covers the [k6](https://k6.io/) based performance tests for Mirror Node APIs including rest, rest-java,
+rosetta, and web3.
 
 ## Setup
 
 The k6 test engine is needed to run the tests. Please follow
-the [official documentation](https://k6.io/docs/getting-started/installation/) to install k6. If running on a VM,
-ensure the following OS properties are set to avoid resource exhaustion:
+the [official documentation](https://k6.io/docs/getting-started/installation/) to install k6. Ensure the following OS
+properties are set to avoid resource exhaustion:
 
 ```shell
 ulimit -n 1048576
@@ -15,110 +15,124 @@ echo "1" > /proc/sys/net/ipv4/tcp_tw_reuse
 echo "16384 65535" > /proc/sys/net/ipv4/ip_local_port_range
 ```
 
-## Run The Tests
+## Configuration
 
-The tests are organized per API, and they reside in `src/rest`, `src/rest-java`, `src/rosetta`, and `src/web3` respectively. You can run
-the tests of an API as a test suite. You can also run tests one at a time.
-
-### Test Suite
-
-To run a test suite, such as rest, use the following command.
+Configuration of the k6 tests is done via environment variables. Environment variables can be passed directly to k6 or
+placed in an environment file and sourced before each run. For example, here's a `k6.env`:
 
 ```shell
-DEFAULT_DURATION=1s \
-DEFAULT_VUS=1 \
-BASE_URL=https://testnet.mirrornode.hedera.com \
-DEFAULT_LIMIT=100 \
-DEFAULT_START_ACCOUNT=0.0.34196600 k6 run src/rest/apis.js
-```
-
-Another option is to have a parameters file named `parameters.env` with the content:
-
-```shell
-export DEFAULT_DURATION=1s
-export DEFAULT_VUS=1
 export BASE_URL=https://testnet.mirrornode.hedera.com
+export DEFAULT_DURATION=1s
 export DEFAULT_LIMIT=100
-export DEFAULT_START_ACCOUNT=0.0.34196600
+export DEFAULT_VUS=1
 ```
 
-And execute k6 after exporting the values for the env variables:
+This file can then be sourced before executing k6:
 
 ```shell
-source parameters.env
-k6 run src/rest/apis.js
+source k6.env
 ```
 
-For non domain specific parameters like:
+For non-domain specific parameters like `DEFAULT_DURATION`, `DEFAULT_VUS`, etc. a sane default will be used if not
+provided. For domain specific parameters, when the value of a parameter is explicitly set then that value will be used,
+otherwise its value will be found by querying the APIs. The `DEFAULT_SETUP_TIMEOUT` controls how much time it should
+spend querying for defaults. However, it's strongly recommended to explicitly provide values for all domain specific
+parameters to produce consistent results between runs. Some entities have considerably more data than others and
+be considerably slower if they're picked and vice versa.
 
-- DEFAULT_DURATION
-- DEFAULT_VUS
-- BASE_URL
-- DEFAULT_LIMIT
+### Common
 
-The value can be set via environment variables. If no value is set, then a sane default will be used.
+The following parameters can be used to configure all tests regardless of API:
 
-For domain specific parameters the following rule is used:
-When the value of a parameter is set with an environment variable, the value will be used, but if no value is set for a
-particular parameter, then its value will be found by querying either the rest or rosetta APIs.
+| Name                  | Default          | Description                                                        |
+| --------------------- | ---------------- | ------------------------------------------------------------------ |
+| BASE_URL              | http://localhost | The URL prefix without `/api/v1` to connect to                     |
+| DEFAULT_DURATION      | 120s             | How much time to execute each test                                 |
+| DEFAULT_LIMIT         | 100              | For list APIs, the number of results to return in the response     |
+| DEFAULT_SETUP_TIMEOUT | 5m               | The amount of time to discover domain specific defaults            |
+| DEFAULT_VUS           | 10               | The number of virtual users k6 should use to parallelize execution |
 
-The default timeout set to discover the parameters is 5 minutes, increase `DEFAULT_SETUP_TIMEOUT` if needed.
+### REST API
 
-The following parameters can be used to configure a rest test:
+The following parameters can be used to configure a REST test:
 
-- DEFAULT_ACCOUNT_ID
-- DEFAULT_ACCOUNT_ID_NFTS
-- DEFAULT_ACCOUNT_ID_TOKEN
-- DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE
-- DEFAULT_ACCOUNT_BALANCE
-- DEFAULT_BALANCE_TIMESTAMP
-- DEFAULT_BLOCK_NUMBER
-- DEFAULT_BLOCK_HASH
-- DEFAULT_CONTRACT_ID
-- DEFAULT_CONTRACT_TIMESTAMP
-- DEFAULT_CONTRACT_RESULT_HASH
-- DEFAULT_NFT_ID
-- DEFAULT_NFT_SERIAL
-- DEFAULT_PUBLIC_KEY
-- DEFAULT_SCHEDULE_ACCOUNT_ID
-- DEFAULT_SCHEDULE_ID
-- DEFAULT_TOKEN_BALANCE_TIMESTAMP
-- DEFAULT_TOKEN_ID
-- DEFAULT_TOKEN_NAME
-- DEFAULT_TOPIC_ID
-- DEFAULT_TOPIC_SEQUENCE
-- DEFAULT_TOPIC_TIMESTAMP
-- DEFAULT_TRANSACTION_HASH
-- DEFAULT_TRANSACTION_ID
+| Name                               | Default | Description                        |
+| ---------------------------------- | ------- | ---------------------------------- |
+| DEFAULT_ACCOUNT_ID                 |         |                                    |
+| DEFAULT_ACCOUNT_ID_NFTS            |         |                                    |
+| DEFAULT_ACCOUNT_ID_TOKEN           |         |                                    |
+| DEFAULT_ACCOUNT_ID_TOKEN_ALLOWANCE |         |                                    |
+| DEFAULT_ACCOUNT_BALANCE            |         |                                    |
+| DEFAULT_BALANCE_TIMESTAMP          | now()   |                                    |
+| DEFAULT_BLOCK_NUMBER               |         |                                    |
+| DEFAULT_BLOCK_HASH                 |         |                                    |
+| DEFAULT_CONTRACT_ID                |         |                                    |
+| DEFAULT_CONTRACT_TIMESTAMP         |         |                                    |
+| DEFAULT_CONTRACT_RESULT_HASH       |         |                                    |
+| DEFAULT_NFT_ID                     |         |                                    |
+| DEFAULT_NFT_SERIAL                 |         |                                    |
+| DEFAULT_PUBLIC_KEY                 |         |                                    |
+| DEFAULT_SCHEDULE_ACCOUNT_ID        |         |                                    |
+| DEFAULT_SCHEDULE_ID                |         |                                    |
+| DEFAULT_START_ACCOUNT              | 0       |                                    |
+| DEFAULT_TOKEN_BALANCE_TIMESTAMP    | now()   |                                    |
+| DEFAULT_TOKEN_ID                   |         |                                    |
+| DEFAULT_TOKEN_NAME                 |         |                                    |
+| DEFAULT_TOPIC_ID                   |         |                                    |
+| DEFAULT_TOPIC_SEQUENCE             |         |                                    |
+| DEFAULT_TOPIC_TIMESTAMP            |         |                                    |
+| DEFAULT_TRANSACTION_HASH           |         |                                    |
+| DEFAULT_TRANSACTION_ID             |         |                                    |
+| REST_TEST_EXCLUDE                  | ^$      | The rest test scenarios to exclude |
+| REST_TEST_INCLUDE                  | .\*     | The rest test scenarios to include |
+
+### REST Java API
 
 The following parameters can be used to configure a rest-java test:
 
-- DEFAULT_ACCOUNT_ID_NFTS_ALLOWANCE_OWNER
-- DEFAULT_ACCOUNT_ID_NFTS_ALLOWANCE_SPENDER
+| Name                                      | Default | Description                             |
+| ----------------------------------------- | ------- | --------------------------------------- |
+| DEFAULT_ACCOUNT_ID_NFTS_ALLOWANCE_OWNER   |         |                                         |
+| DEFAULT_ACCOUNT_ID_NFTS_ALLOWANCE_SPENDER |         |                                         |
+| RESTJAVA_TEST_EXCLUDE                     | ^$      | The rest-java test scenarios to exclude |
+| RESTJAVA_TEST_INCLUDE                     | .\*     | The rest-java test scenarios to include |
+
+### Rosetta API
 
 The following parameters can be used to configure a rosetta test:
 
-- DEFAULT_BLOCK_INDEX
-- DEFAULT_BLOCK_HASH
-- DEFAULT_NETWORK
-- DEFAULT_TRANSACTION_HASH
+| Name                     | Default | Description                           |
+| ------------------------ | ------- | ------------------------------------- |
+| DEFAULT_BLOCK_INDEX      |         |                                       |
+| DEFAULT_BLOCK_HASH       |         |                                       |
+| DEFAULT_NETWORK          |         |                                       |
+| DEFAULT_TRANSACTION_HASH |         |                                       |
+| ROSETTA_TEST_EXCLUDE     | ^$      | The rosetta test scenarios to exclude |
+| ROSETTA_TEST_INCLUDE     | .\*     | The rosetta test scenarios to include |
+
+### Web3 API
 
 The following parameters can be used to configure a web3 test:
 
-- ACCOUNT_ADDRESS - 64 character hex encoded account address without `0x` prefix
-- DEFAULT_ACCOUNT_ADDRESS - 40 character hex encoded account address without `0x` prefix
-- DEFAULT_CONTRACT_ADDRESS - 40 character hex encoded contract address without `0x` prefix (Parent contract should be deployed)
-- ERC_CONTRACT_ADDRESS - 40 character hex encoded contract address without `0x` prefix (ErcTestContract contract in hedera-mirror-test/src/test/resources/solidity/contracts/ErcTestContract.sol should be deployed)
-- HTS_CONTRACT_ADDRESS - 40 character hex encoded contract address without `0x` prefix (PrecompileTestContract contract in hedera-mirror-test/src/test/resources/solidity/contracts/PrecompileTestContract.sol should be deployed)
-- KEY_TYPE - 64 character hex encoded key type without `0x` prefix
-- NON_FUNGIBLE_TOKEN_ADDRESS - 64 character hex encoded non-fungible token address without `0x` prefix
-- RUN_ESTIMATE_TESTS - If set to true, estimate gas tests will be run.
-- SERIAL_NUMBER - 64 character hex encoded nft serial number without `0x` prefix
-- SPENDER_ADDRESS - 64 character hex encoded account address without `0x` prefix
-- TOKEN_ADDRESS - 64 character hex encoded token address without `0x` prefix
+| Name                       | Default | Description                                                                                    |
+| -------------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| ACCOUNT_ADDRESS            |         | 64 character hex encoded account address without `0x` prefix                                   |
+| DEFAULT_ACCOUNT_ADDRESS    |         | 40 character hex encoded account address without `0x` prefix                                   |
+| DEFAULT_CONTRACT_ADDRESS   |         | 40 character hex encoded contract address without `0x` prefix for `Parent.sol`                 |
+| ERC_CONTRACT_ADDRESS       |         | 40 character hex encoded contract address without `0x` prefix for `ErcTestContract.sol`        |
+| HTS_CONTRACT_ADDRESS       |         | 40 character hex encoded contract address without `0x` prefix for `PrecompileTestContract.sol` |
+| KEY_TYPE                   |         | 64 character hex encoded key type without `0x` prefix                                          |
+| NON_FUNGIBLE_TOKEN_ADDRESS |         | 64 character hex encoded non-fungible token address without `0x` prefix                        |
+| RUN_ESTIMATE_TESTS         |         | If set to true, estimate gas tests will be run.                                                |
+| SERIAL_NUMBER              |         | 64 character hex encoded nft serial number without `0x` prefix                                 |
+| SPENDER_ADDRESS            |         | 64 character hex encoded account address without `0x` prefix                                   |
+| TOKEN_ADDRESS              |         | 64 character hex encoded token address without `0x` prefix                                     |
+| WEB3_TEST_EXCLUDE          | ^$      | The web3 test scenarios to exclude                                                             |
+| WEB3_TEST_INCLUDE          | .\*     | The web3 test scenarios to include                                                             |
 
-For k6 to be run we need to deploy contracts first. For that, we can use Hedera SDK.
-Example for ERC_CONTRACT deployment with js SDK
+For k6 to be run we need to deploy the relevant contracts in `hedera-mirror-test/src/test/resources/solidity` first. For
+that, we can use Hedera SDK. Example for ERC_CONTRACT deployment
+with js SDK
 
 ```js
 const contractCreate = await new ContractCreateFlow()
@@ -129,144 +143,7 @@ const contractCreate = await new ContractCreateFlow()
   .execute(client);
 ```
 
-The test suite will run the tests sequentially with a configurable graceful stop time in between, so they don't
-interfere with each other.
-
-Once the tests complete, `k6` will show a summary report.
-
-```
-          /\      |‾‾| /‾‾/   /‾‾/
-     /\  /  \     |  |/  /   /  /
-    /  \/    \    |     (   /   ‾‾\
-   /          \   |  |\  \ |  (‾)  |
-  / __________ \  |__| \__\ \_____/ .io
-
-  execution: local
-     script: apis.js
-     output: -
-
-  scenarios: (100.00%) 11 scenarios, 500 max VUs, 11m55s max duration (incl. graceful stop):
-           * accountBalance: 500 looping VUs for 1m0s (exec: run, gracefulStop: 5s)
-           * block: 500 looping VUs for 1m0s (exec: run, startTime: 1m5s, gracefulStop: 5s)
-           * blockTransaction: 500 looping VUs for 1m0s (exec: run, startTime: 2m10s, gracefulStop: 5s)
-           * constructionCombine: 500 looping VUs for 1m0s (exec: run, startTime: 3m15s, gracefulStop: 5s)
-           * constructionHash: 500 looping VUs for 1m0s (exec: run, startTime: 4m20s, gracefulStop: 5s)
-           * constructionParse: 500 looping VUs for 1m0s (exec: run, startTime: 5m25s, gracefulStop: 5s)
-           * constructionPayloads: 500 looping VUs for 1m0s (exec: run, startTime: 6m30s, gracefulStop: 5s)
-           * constructionPreprocess: 500 looping VUs for 1m0s (exec: run, startTime: 7m35s, gracefulStop: 5s)
-           * networkList: 500 looping VUs for 1m0s (exec: run, startTime: 8m40s, gracefulStop: 5s)
-           * networkOptions: 500 looping VUs for 1m0s (exec: run, startTime: 9m45s, gracefulStop: 5s)
-           * networkStatus: 500 looping VUs for 1m0s (exec: run, startTime: 10m50s, gracefulStop: 5s)
-
-
-running (11m50.2s), 000/500 VUs, 2910275 complete and 0 interrupted iterations
-accountBalance         ✓ [======================================] 500 VUs  1m0s
-block                  ✓ [======================================] 500 VUs  1m0s
-blockTransaction       ✓ [======================================] 500 VUs  1m0s
-constructionCombine    ✓ [======================================] 500 VUs  1m0s
-constructionHash       ✓ [======================================] 500 VUs  1m0s
-constructionParse      ✓ [======================================] 500 VUs  1m0s
-constructionPayloads   ✓ [======================================] 500 VUs  1m0s
-constructionPreprocess ✓ [======================================] 500 VUs  1m0s
-networkList            ✓ [======================================] 500 VUs  1m0s
-networkOptions         ✓ [======================================] 500 VUs  1m0s
-networkStatus          ✓ [======================================] 500 VUs  1m0s
-     ✓ AccountBalance OK
-     ✓ Block OK
-     ✓ BlockTransaction OK
-     ✓ ConstructionCombine OK
-     ✓ ConstructionHash OK
-     ✓ ConstructionParse OK
-     ✓ ConstructionPayloads OK
-     ✓ ConstructionPreprocess OK
-     ✓ NetworkList OK
-     ✓ NetworkOptions OK
-     ✓ NetworkStatus OK
-
-     checks.........................................................: 100.00% ✓ 2910275     ✗ 0
-     ✓ { scenario:accountBalance }..................................: 100.00% ✓ 84283       ✗ 0
-     ✓ { scenario:blockTransaction }................................: 100.00% ✓ 171178      ✗ 0
-     ✓ { scenario:block }...........................................: 100.00% ✓ 99791       ✗ 0
-     ✓ { scenario:constructionCombine }.............................: 100.00% ✓ 277238      ✗ 0
-     ✓ { scenario:constructionHash }................................: 100.00% ✓ 353405      ✗ 0
-     ✓ { scenario:constructionParse }...............................: 100.00% ✓ 345479      ✗ 0
-     ✓ { scenario:constructionPayloads }............................: 100.00% ✓ 330888      ✗ 0
-     ✓ { scenario:constructionPreprocess }..........................: 100.00% ✓ 331073      ✗ 0
-     ✓ { scenario:networkList }.....................................: 100.00% ✓ 389307      ✗ 0
-     ✓ { scenario:networkOptions }..................................: 100.00% ✓ 346037      ✗ 0
-     ✓ { scenario:networkStatus }...................................: 100.00% ✓ 181596      ✗ 0
-     data_received..................................................: 11 GB   16 MB/s
-     data_sent......................................................: 1.6 GB  2.2 MB/s
-     http_req_blocked...............................................: avg=26.28ms  min=329.25µs med=26.12ms  max=3.09s    p(90)=45.56ms  p(95)=57.14ms
-     http_req_connecting............................................: avg=26.06ms  min=294.53µs med=25.98ms  max=3.09s    p(90)=45.09ms  p(95)=56.56ms
-     http_req_duration..............................................: avg=83.76ms  min=763.29µs med=51.09ms  max=6.8s     p(90)=145.26ms p(95)=225.72ms
-       { expected_response:true }...................................: avg=83.76ms  min=763.29µs med=51.09ms  max=6.8s     p(90)=145.26ms p(95)=225.72ms
-     ✗ { scenario:accountBalance,expected_response:true }...........: avg=351.87ms min=23.48ms  med=249.8ms  max=4.23s    p(90)=726.13ms p(95)=978.25ms
-     ✗ { scenario:block,expected_response:true }....................: avg=300.1ms  min=16.65ms  med=185.37ms max=6.8s     p(90)=507.75ms p(95)=889.7ms
-     ✗ { scenario:blockTransaction,expected_response:true }.........: avg=164.43ms min=6.05ms   med=108.42ms max=3.35s    p(90)=330.46ms p(95)=525.31ms
-     ✓ { scenario:constructionCombine,expected_response:true }......: avg=73.77ms  min=1.06ms   med=65.47ms  max=729.79ms p(90)=121.4ms  p(95)=147.72ms
-     ✓ { scenario:constructionHash,expected_response:true }.........: avg=49.23ms  min=813.14µs med=43.48ms  max=485.16ms p(90)=82.14ms  p(95)=100.07ms
-     ✓ { scenario:constructionParse,expected_response:true }........: avg=50.64ms  min=888.63µs med=45.11ms  max=528.51ms p(90)=81.39ms  p(95)=100.5ms
-     ✓ { scenario:constructionPayloads,expected_response:true }.....: avg=56.43ms  min=1.17ms   med=49.81ms  max=529.69ms p(90)=90.18ms  p(95)=111.18ms
-     ✓ { scenario:constructionPreprocess,expected_response:true }...: avg=52.87ms  min=1.08ms   med=47.77ms  max=486.11ms p(90)=82.71ms  p(95)=103.17ms
-     ✓ { scenario:networkList,expected_response:true }..............: avg=44.76ms  min=763.29µs med=40.33ms  max=469.95ms p(90)=67.94ms  p(95)=84.78ms
-     ✓ { scenario:networkOptions,expected_response:true }...........: avg=51.96ms  min=1.74ms   med=46.75ms  max=477.27ms p(90)=79.69ms  p(95)=97.45ms
-     ✓ { scenario:networkStatus,expected_response:true }............: avg=160.1ms  min=7.16ms   med=108.19ms max=2.52s    p(90)=321.2ms  p(95)=490.1ms
-     http_req_failed................................................: 0.00%   ✓ 0           ✗ 2910275
-     http_req_receiving.............................................: avg=7.96ms   min=24.5µs   med=5.23ms   max=481.33ms p(90)=18.99ms  p(95)=25.13ms
-     http_req_sending...............................................: avg=7.43ms   min=19.24µs  med=4.86ms   max=492.96ms p(90)=17.78ms  p(95)=23.77ms
-     http_req_tls_handshaking.......................................: avg=0s       min=0s       med=0s       max=0s       p(90)=0s       p(95)=0s
-     http_req_waiting...............................................: avg=68.35ms  min=455.36µs med=35.52ms  max=6.79s    p(90)=128.24ms p(95)=220.83ms
-     http_reqs......................................................: 2910275 4097.974399/s
-     ✓ { scenario:accountBalance }..................................: 84283   118.679361/s
-     ✓ { scenario:blockTransaction }................................: 171178  241.036693/s
-     ✓ { scenario:block }...........................................: 99791   140.516262/s
-     ✓ { scenario:constructionCombine }.............................: 277238  390.380368/s
-     ✓ { scenario:constructionHash }................................: 353405  497.631544/s
-     ✓ { scenario:constructionParse }...............................: 345479  486.4709/s
-     ✓ { scenario:constructionPayloads }............................: 330888  465.925231/s
-     ✓ { scenario:constructionPreprocess }..........................: 331073  466.185731/s
-     ✓ { scenario:networkList }.....................................: 389307  548.18535/s
-     ✓ { scenario:networkOptions }..................................: 346037  487.256623/s
-     ✓ { scenario:networkStatus }...................................: 181596  255.706337/s
-     iteration_duration.............................................: avg=113.49ms min=1.8ms    med=81.45ms  max=6.8s     p(90)=179.94ms p(95)=244.44ms
-     iterations.....................................................: 2910275 4097.974399/s
-     scenario_duration..............................................: 60166   min=38        max=60634
-     ✓ { scenario:accountBalance }..................................: 60634   min=139       max=60634
-     ✓ { scenario:blockTransaction }................................: 60253   min=40        max=60253
-     ✓ { scenario:block }...........................................: 60282   min=112       max=60282
-     ✓ { scenario:constructionCombine }.............................: 60068   min=39        max=60068
-     ✓ { scenario:constructionHash }................................: 60136   min=41        max=60136
-     ✓ { scenario:constructionParse }...............................: 60200   min=38        max=60200
-     ✓ { scenario:constructionPayloads }............................: 60071   min=53        max=60071
-     ✓ { scenario:constructionPreprocess }..........................: 60034   min=41        max=60034
-     ✓ { scenario:networkList }.....................................: 60086   min=43        max=60086
-     ✓ { scenario:networkOptions }..................................: 60041   min=40        max=60041
-     ✓ { scenario:networkStatus }...................................: 60166   min=66        max=60166
-     vus............................................................: 500     min=0         max=500
-     vus_max........................................................: 500     min=500       max=500  ERRO[0719] some thresholds have failed
-```
-
-Note: disregard the per scenario RPS reported in the `http_reqs` section since it's calculated as the total requests in
-a scenario divided by the run time of the test suite.
-
-With the test suite mode, a simplified markdown format report `report.md` will also be generated.
-
-| URL                      | VUS | Pass%  | RPS       | Avg. Req Duration | Skipped? | Comment |
-| ------------------------ | --- | ------ | --------- | ----------------- | -------- | ------- |
-| /account/balance         | 500 | 100.00 | 1390.03/s | 351.87ms          | No       |         |
-| /block                   | 500 | 100.00 | 1655.40/s | 300.11ms          | No       |         |
-| /block/transaction       | 500 | 100.00 | 2840.99/s | 164.44ms          | No       |         |
-| /construction/combine    | 500 | 100.00 | 4615.40/s | 73.77ms           | No       |         |
-| /construction/hash       | 500 | 100.00 | 5876.76/s | 49.23ms           | No       |         |
-| /construction/parse      | 500 | 100.00 | 5738.85/s | 50.65ms           | No       |         |
-| /construction/payloads   | 500 | 100.00 | 5508.28/s | 56.44ms           | No       |         |
-| /construction/preprocess | 500 | 100.00 | 5514.76/s | 52.88ms           | No       |         |
-| /network/list            | 500 | 100.00 | 6479.16/s | 44.77ms           | No       |         |
-| /network/options         | 500 | 100.00 | 5763.35/s | 51.97ms           | No       |         |
-| /network/status          | 500 | 100.00 | 3018.25/s | 160.10ms          | No       |         |
-
-#### Filter Test Case
+### Filter Test Case
 
 You can use the following test suite specific environment variables to filter the test cases in a suite to run,
 
@@ -288,7 +165,7 @@ Some examples:
   or `topic`
 - `REST_TEST_INCLUDE='^(account|token).*$'` will include only test cases that start with either `account` or `token`
 
-To run a testkube test / testsuite with test case filters, do
+To run a testkube test / testsuite with test case filters, run the following:
 
 ```shell
 testkube run testsuite test-suite-rest -v REST_TEST_EXCLUDE='^transaction.*$' -v WEB3_TEST_INCLUDE='^.*receive.*$'
@@ -296,13 +173,38 @@ testkube run testsuite test-suite-rest -v REST_TEST_EXCLUDE='^transaction.*$' -v
 
 Note you can pass multiple `-v` flags, one for each filter.
 
-### Single Test
+## Execution
 
-To run a single test, such as the rosetta accountBalance test, just do
+The tests are organized per API, and they reside in `src/rest`, `src/rest-java`, `src/rosetta`, and `src/web3`
+respectively. The API performance tests can be run as a test suite or individually.
+
+### Test Suite
+
+To run a test suite, such as rest, use the following command:
 
 ```shell
-source src/rosetta/k6.env
-k6 run src/rosetta/test/accountBalance.js
+source k6.env && k6 run src/rest/apis.js
 ```
 
-When it completes, k6 will show a similar summary report. However, there won't be a `report.md` report.
+The test suite will run the tests sequentially with a configurable grace period in between tests so that they don't
+interfere with each other. Once the tests complete, `k6` will show a test summary. Disregard the per scenario RPS
+reported in the `http_reqs` section since it's calculated as the total requests in a scenario divided by the run time of
+the test suite.
+
+At the end of a test suite run, a simplified Markdown format `report.md` will be generated. Below is an example
+of such a report. The main columns to consider are the `Pass RPS` and the `Avg. Req Duration`.
+
+| Scenario | URL       | VUS  | Pass%  | RPS       | Pass RPS  | Avg. Req Duration | Skipped? | Comment |
+| -------- | --------- | ---- | ------ | --------- | --------- | ----------------- | -------- | ------- |
+| accounts | /accounts | 1500 | 100.00 | 1390.03/s | 1390.03/s | 351.87ms          | No       |         |
+| blocks   | /block    | 1500 | 99.9   | 5571.63/s | 5572.19/s | 300.11ms          | No       |         |
+
+### Single Test
+
+To run a single test, such as the rosetta `accountBalance` test, use a command similar to the below:
+
+```shell
+source k6.env && k6 run src/rosetta/test/accountBalance.js
+```
+
+When it completes, k6 will show a similar summary report. However, there will not be a report file generated.

--- a/hedera-mirror-test/k6/src/lib/common.js
+++ b/hedera-mirror-test/k6/src/lib/common.js
@@ -106,7 +106,7 @@ const defaultFilters = {
 function getFilter(suite, exclude) {
   const key = `${suite.toUpperCase()}_TEST_${exclude ? 'EXCLUDE' : 'INCLUDE'}`;
   const value = __ENV[key];
-  return value ? new RegExp(value) : defaultFilters[exclude];
+  return value ? new RegExp(value, 'i') : defaultFilters[exclude];
 }
 
 function filterTests(tests, suite) {
@@ -117,8 +117,7 @@ function filterTests(tests, suite) {
   const exclude = getFilter(suite, true);
   const include = getFilter(suite, false);
   const filtered = Object.keys(tests).filter((name) => {
-    const normalized = name.toLowerCase();
-    return !exclude.test(normalized) && include.test(normalized);
+    return !exclude.test(name) && (name === 'rampUp' || include.test(name));
   });
   return Object.fromEntries(filtered.map((name) => [name, tests[name]]));
 }

--- a/hedera-mirror-test/k6/src/rest/test/balancesPublicKeyTimestamp.js
+++ b/hedera-mirror-test/k6/src/rest/test/balancesPublicKeyTimestamp.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,20 @@ import http from 'k6/http';
 import {isValidListResponse, RestTestScenarioBuilder} from '../libex/common.js';
 import {balanceListName} from '../libex/constants.js';
 
-const urlTag = '/balances?timestamp=X';
+const urlTag = '/balances?account.publickey={accountId}&timestamp={timestamp}';
 
 const getUrl = (testParameters) =>
-  `/balances?timestamp=${testParameters['DEFAULT_BALANCE_TIMESTAMP']}&limit=${testParameters['DEFAULT_LIMIT']}`;
+  `/balances?account.publickey=${testParameters['DEFAULT_PUBLIC_KEY']}&timestamp=${testParameters['DEFAULT_BALANCE_TIMESTAMP']}`;
 
 const {options, run, setup} = new RestTestScenarioBuilder()
-  .name('balancesTimestamp') // use unique scenario name among all tests
+  .name('balancesPublicKeyTimestamp') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
     const url = `${testParameters['BASE_URL_PREFIX']}${getUrl(testParameters)}`;
     return http.get(url);
   })
-  .check('Balances with timestamp OK', (r) => isValidListResponse(r, balanceListName))
+  .requiredParameters('DEFAULT_PUBLIC_KEY', 'DEFAULT_BALANCE_TIMESTAMP')
+  .check('Balances OK', (r) => isValidListResponse(r, balanceListName))
   .build();
 
 export {getUrl, options, run, setup};

--- a/hedera-mirror-test/k6/src/rest/test/index.js
+++ b/hedera-mirror-test/k6/src/rest/test/index.js
@@ -34,6 +34,7 @@ import * as accountsTokenAllowance from './accountsTokenAllowance.js';
 import * as balances from './balances.js';
 import * as balancesAccount from './balancesAccount.js';
 import * as balancesAccountTimestamp from './balancesAccountTimestamp.js';
+import * as balancesPublicKeyTimestamp from './balancesPublicKeyTimestamp.js';
 import * as balancesTimestamp from './balancesTimestamp.js';
 import * as blocks from './blocks.js';
 import * as blocksNumber from './blocksNumber.js';
@@ -52,6 +53,7 @@ import * as networkFees from './networkFees.js';
 import * as networkNodes from './networkNodes.js';
 import * as networkStake from './networkStake.js';
 import * as networkSupply from './networkSupply.js';
+import * as networkSupplyTimestamp from './networkSupplyTimestamp.js';
 import * as rampUp from './rampUp.js';
 import * as schedules from './schedules.js';
 import * as schedulesAccount from './schedulesAccount.js';
@@ -96,6 +98,7 @@ const tests = {
   balances,
   balancesAccount,
   balancesAccountTimestamp,
+  balancesPublicKeyTimestamp,
   balancesTimestamp,
   blocks,
   blocksNumber,
@@ -114,6 +117,7 @@ const tests = {
   networkNodes,
   networkStake,
   networkSupply,
+  networkSupplyTimestamp,
   rampUp,
   schedules,
   schedulesAccount,

--- a/hedera-mirror-test/k6/src/rest/test/networkSupplyTimestamp.js
+++ b/hedera-mirror-test/k6/src/rest/test/networkSupplyTimestamp.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,21 @@
 
 import http from 'k6/http';
 
-import {isValidListResponse, RestTestScenarioBuilder} from '../libex/common.js';
-import {balanceListName} from '../libex/constants.js';
+import {isSuccess, RestTestScenarioBuilder} from '../libex/common.js';
 
-const urlTag = '/balances?timestamp=X';
+const urlTag = '/network/supply?timestamp={timestamp}';
 
-const getUrl = (testParameters) =>
-  `/balances?timestamp=${testParameters['DEFAULT_BALANCE_TIMESTAMP']}&limit=${testParameters['DEFAULT_LIMIT']}`;
+const getUrl = (testParameters) => `/network/supply?timestamp=${testParameters['DEFAULT_BALANCE_TIMESTAMP']}`;
 
 const {options, run, setup} = new RestTestScenarioBuilder()
-  .name('balancesTimestamp') // use unique scenario name among all tests
+  .name('networkSupplyTimestamp') // use unique scenario name among all tests
   .tags({url: urlTag})
   .request((testParameters) => {
     const url = `${testParameters['BASE_URL_PREFIX']}${getUrl(testParameters)}`;
     return http.get(url);
   })
-  .check('Balances with timestamp OK', (r) => isValidListResponse(r, balanceListName))
+  .requiredParameters('DEFAULT_BALANCE_TIMESTAMP')
+  .check('Network supply OK', isSuccess)
   .build();
 
 export {getUrl, options, run, setup};


### PR DESCRIPTION
**Description**:

Cherry pick of #9195 to release/0.112:

* Add a `balancesPublicKeyTimestamp` k6 test
* Add a `networkSupplyTimestamp` k6 test
* Fix common chart not working when Prometheus is disabled
* Fix k6 not running ramp up when using include filters
* Fix k6 include/exclude filters not working with mixed case test names
* Fix `stackgres.worker.enableMetricsExporter` not taking effect
* Fix `stackgres.worker.enablePostgresUtil` not taking effect
* Fix `/balances?account.publickey&timestamp` not working with local table by moving to a separate public key lookup
* Improve balance API performance 10x by un-distributing balance tables
* Improve `/api/v1/network/supply?timestamp` performance by only querying at most 2 partitions
* Reorganize k6 README and put variables into tables

**Related issue(s)**:

Fixes #9139

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
