### PR TITLE
Increasing max age for entity list endpoints.

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1318,7 +1318,7 @@ paths:
         - tokens
 tags:
   - name: accounts
-    description: The accounts object represents the information associated with an account entity and returns a list of account information.
+    description: The accounts object represents the information associated with an account entity and returns a list of account information.The accounts list endpoint is cached and not updated as frequently as the account lookup by a specific ID endpoint.
     externalDocs:
       url: https://docs.hedera.com/guides/docs/mirror-node-api/cryptocurrency-api#accounts
   - name: balances
@@ -1326,9 +1326,9 @@ tags:
     externalDocs:
       url: https://docs.hedera.com/guides/docs/mirror-node-api/cryptocurrency-api#balances
   - name: contracts
-    description: The contracts objects represents the information associated with contract entities.
+    description: The contracts objects represents the information associated with contract entities.The contracts list endpoint is cached and not updated as frequently as the contract lookup by a specific ID endpoint.
   - name: schedules
-    description: The schedules object represents the information associated with a schedule entity.
+    description: The schedules object represents the information associated with a schedule entity.The schedules list endpoints is cached and not updated as frequently as the schedule lookup by a specific ID endpoint.
   - name: transactions
     description: The transaction object represents the transactions processed on the Hedera network.
     externalDocs:
@@ -1338,7 +1338,7 @@ tags:
     externalDocs:
       url: https://docs.hedera.com/guides/docs/mirror-node-api/cryptocurrency-api#topic-messages
   - name: tokens
-    description: The tokens object represents the information associated with a token entity and returns a list of token information.
+    description: The tokens object represents the information associated with a token entity and returns a list of token information.The tokens list endpoint is cached and not updated as frequently as the token lookup by a specific ID.
 info:
   title: Hedera Mirror Node REST API
   version: 0.113.0-SNAPSHOT

--- a/hedera-mirror-rest/config/application.yml
+++ b/hedera-mirror-rest/config/application.yml
@@ -88,12 +88,14 @@ hedera:
         headers:
           default: { "cache-control": "public, max-age=1" }
           path:
+            /api/v1/accounts: { "cache-control": "public, max-age=10" }
             /api/v1/accounts/:idOrAliasOrEvmAddress:
               { "cache-control": "public, max-age=2" }
             /api/v1/accounts/:idOrAliasOrEvmAddress/rewards:
               { "cache-control": "public, max-age=60" }
             /api/v1/blocks/:hashOrNumber:
               { "cache-control": "public, max-age=600" }
+            /api/v1/contracts: { "cache-control": "public, max-age=10" }
             /api/v1/contracts/:contractId/results/:consensusTimestamp([0-9.]+):
               { "cache-control": "public, max-age=600" }
             /api/v1/contracts/results/:transactionIdOrHash:
@@ -106,6 +108,8 @@ hedera:
             /api/v1/network/nodes: { "cache-control": "public, max-age=60" }
             /api/v1/network/stake: { "cache-control": "public, max-age=60" }
             /api/v1/network/supply: { "cache-control": "public, max-age=60" }
+            /api/v1/schedules: { "cache-control": "public, max-age=10" }
+            /api/v1/tokens: { "cache-control": "public, max-age=10" }
             /api/v1/tokens/:tokenId: { "cache-control": "public, max-age=5" }
             /api/v1/topics/:topicId/messages/:sequenceNumber:
               { "cache-control": "public, max-age=600" }


### PR DESCRIPTION
**Description**:
This PR increases max age for entity list endpoints.

This PR modifies ...
*  Increases max age for entity list endpoints in order to improve performance for these endpoints.
* Adds a note for extended caching to the openapi.yaml


**Related issue(s)**:

Fixes #9138

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
