### PR TITLE
Add check for `web3j-cli` existence before installation

### DIFF
--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -70,12 +70,16 @@ tasks.compileJava { options.compilerArgs.add("--enable-preview") }
 
 tasks.test { jvmArgs = listOf("--enable-preview") }
 
+val homeDir = System.getenv("HOME")
+val web3jDirectory = file("$homeDir/.web3j")
+
 val downloadWeb3j =
     tasks.register<Exec>("downloadWeb3j") {
         description = "Download and install Web3j CLI"
         group = "historical"
 
         commandLine("bash", "-c", "curl -L get.web3j.io | sh")
+        onlyIf { !web3jDirectory.exists() }
     }
 
 // Tasks to download OpenZeppelin contracts


### PR DESCRIPTION
**Description**:
As investigated by @kselveliev, it seems that the `web3j-cli` download script has a rate limit. This PR adds a check if it is already installed. A similar check exists in the download script but this PR aims to fix the rate limit issue by performing the check earlier - in our gradle task.