### PR TITLE
Refactor ContractCallServicePrecompileHistoricalTest

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -19,11 +19,13 @@ package com.hedera.mirror.web3.service;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.ESTIMATE_GAS_ERROR_MESSAGE;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.TRANSACTION_GAS_LIMIT;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.isWithinExpectedGasRange;
+import static com.hedera.mirror.web3.validation.HexValidator.HEX_PREFIX;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
@@ -238,6 +240,15 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                 .contractAddress(contractAddress)
                 .sender(senderAddress)
                 .build();
+    }
+
+    protected String getAddressFromEntityId(final EntityId entity) {
+        return HEX_PREFIX
+                + EntityIdUtils.asHexedEvmAddress(new Id(entity.getShard(), entity.getRealm(), entity.getNum()));
+    }
+
+    protected String getAddressFromEvmAddress(final byte[] evmAddress) {
+        return Address.wrap(Bytes.wrap(evmAddress)).toHexString();
     }
 
     public enum KeyType {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
@@ -1019,24 +1019,24 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                 .type(tokenType));
 
         switch (keyType) {
-            case AbstractContractCallServiceTest.KeyType.ADMIN_KEY:
+            case ADMIN_KEY:
                 break;
-            case AbstractContractCallServiceTest.KeyType.KYC_KEY:
+            case KYC_KEY:
                 tokenBuilder.customize(t -> t.kycKey(key.toByteArray()));
                 break;
-            case AbstractContractCallServiceTest.KeyType.FREEZE_KEY:
+            case FREEZE_KEY:
                 tokenBuilder.customize(t -> t.freezeKey(key.toByteArray()));
                 break;
-            case AbstractContractCallServiceTest.KeyType.WIPE_KEY:
+            case WIPE_KEY:
                 tokenBuilder.customize(t -> t.wipeKey(key.toByteArray()));
                 break;
-            case AbstractContractCallServiceTest.KeyType.SUPPLY_KEY:
+            case SUPPLY_KEY:
                 tokenBuilder.customize(t -> t.supplyKey(key.toByteArray()));
                 break;
-            case AbstractContractCallServiceTest.KeyType.FEE_SCHEDULE_KEY:
+            case FEE_SCHEDULE_KEY:
                 tokenBuilder.customize(t -> t.feeScheduleKey(key.toByteArray()));
                 break;
-            case AbstractContractCallServiceTest.KeyType.PAUSE_KEY:
+            case PAUSE_KEY:
                 tokenBuilder.customize(t -> t.pauseKey(key.toByteArray()));
                 break;
             default:

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
@@ -136,14 +136,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         final var account = persistAccountEntityHistorical(historicalRange);
         final var tokenEntity = persistTokenEntityHistorical(historicalRange);
         persistFungibleTokenHistorical(tokenEntity, historicalRange);
-        domainBuilder
-                .tokenAccount()
-                .customize(ta -> ta.tokenId(tokenEntity.getId())
-                        .accountId(account.getId())
-                        .kycStatus(TokenKycStatusEnum.GRANTED)
-                        .associated(true)
-                        .timestampRange(historicalRange))
-                .persist();
+        persistTokenRelationshipWithKycGrantedHistorical(tokenEntity, account, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -163,14 +156,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         final var account = persistAccountEntityHistoricalWithAlias(historicalRange);
         final var tokenEntity = persistTokenEntityHistorical(historicalRange);
         persistFungibleTokenHistorical(tokenEntity, historicalRange);
-        domainBuilder
-                .tokenAccount()
-                .customize(ta -> ta.tokenId(tokenEntity.getId())
-                        .accountId(account.getId())
-                        .kycStatus(TokenKycStatusEnum.GRANTED)
-                        .associated(true)
-                        .timestampRange(historicalRange))
-                .persist();
+        persistTokenRelationshipWithKycGrantedHistorical(tokenEntity, account, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -189,14 +175,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         final var historicalRange = setUpHistoricalContext(blockNumber);
         final var account = persistAccountEntityHistorical(historicalRange);
         final var tokenEntity = persistNftHistorical(historicalRange);
-        domainBuilder
-                .tokenAccount()
-                .customize(ta -> ta.tokenId(tokenEntity.getId())
-                        .accountId(account.getId())
-                        .kycStatus(TokenKycStatusEnum.GRANTED)
-                        .associated(true)
-                        .timestampRange(historicalRange))
-                .persist();
+        persistTokenRelationshipWithKycGrantedHistorical(tokenEntity, account, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -215,14 +194,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         final var historicalRange = setUpHistoricalContext(blockNumber);
         final var account = persistAccountEntityHistoricalWithAlias(historicalRange);
         final var tokenEntity = persistNftHistorical(historicalRange);
-        domainBuilder
-                .tokenAccount()
-                .customize(ta -> ta.tokenId(tokenEntity.getId())
-                        .accountId(account.getId())
-                        .kycStatus(TokenKycStatusEnum.GRANTED)
-                        .associated(true)
-                        .timestampRange(historicalRange))
-                .persist();
+        persistTokenRelationshipWithKycGrantedHistorical(tokenEntity, account, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -1339,5 +1311,17 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                 fractionalFees,
                 royaltyFees,
                 LEDGER_ID);
+    }
+
+    private void persistTokenRelationshipWithKycGrantedHistorical(
+            final Entity tokenEntity, final Entity account, final Range<Long> historicalRange) {
+        domainBuilder
+                .tokenAccount()
+                .customize(ta -> ta.tokenId(tokenEntity.getId())
+                        .accountId(account.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .associated(true)
+                        .timestampRange(historicalRange))
+                .persist();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
@@ -68,7 +68,7 @@ import org.web3j.tx.Contract;
 class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallServiceTest {
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void isTokenFrozen(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -96,7 +96,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void isTokenFrozenWithAlias(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -123,7 +123,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void isKycGranted(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -150,7 +150,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void isKycGrantedWithAlias(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -177,7 +177,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void isKycGrantedForNFT(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -203,7 +203,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void isKycGrantedForNFTWithAlias(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -229,7 +229,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void isTokenAddress(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -246,7 +246,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void isTokenAddressNFT(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -262,7 +262,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getDefaultKycToken(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -285,7 +285,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getDefaultKycNFT(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -301,7 +301,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getTokenType(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -318,7 +318,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getTokenTypeNFT(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -334,7 +334,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getTokenDefaultFreeze(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -357,7 +357,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getNFTDefaultFreeze(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -384,7 +384,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getCustomFeesForTokenWithFixedFee(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -424,7 +424,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getCustomFeesForTokenWithFractionalFee(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -468,7 +468,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getCustomFeesForTokenWithRoyaltyFee(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -514,7 +514,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getExpiryForToken(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -547,7 +547,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getApproved(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -579,7 +579,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getAllowanceForToken(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -610,7 +610,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void isApprovedForAllNFT(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -638,7 +638,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getFungibleTokenInfo(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -691,7 +691,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getNonFungibleTokenInfo(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -759,7 +759,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getTokenInfoFungible(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
@@ -807,7 +807,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     }
 
     @ParameterizedTest
-    @CsvSource({"50", "49"})
+    @ValueSource(longs = {50, 49})
     void getTokenInfoNonFungible(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
@@ -17,6 +17,12 @@
 package com.hedera.mirror.web3.service;
 
 import static com.hedera.mirror.web3.exception.BlockNumberNotFoundException.UNKNOWN_BLOCK_NUMBER;
+import static com.hedera.mirror.web3.service.AbstractContractCallServiceTest.KeyType.FEE_SCHEDULE_KEY;
+import static com.hedera.mirror.web3.service.AbstractContractCallServiceTest.KeyType.FREEZE_KEY;
+import static com.hedera.mirror.web3.service.AbstractContractCallServiceTest.KeyType.KYC_KEY;
+import static com.hedera.mirror.web3.service.AbstractContractCallServiceTest.KeyType.PAUSE_KEY;
+import static com.hedera.mirror.web3.service.AbstractContractCallServiceTest.KeyType.SUPPLY_KEY;
+import static com.hedera.mirror.web3.service.AbstractContractCallServiceTest.KeyType.WIPE_KEY;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.ECDSA_KEY;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.ED25519_KEY;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.KEY_WITH_ECDSA_TYPE;
@@ -1186,17 +1192,17 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         expectedTokenKeys.add(
                 new PrecompileTestContractHistorical.TokenKey(BigInteger.ONE, getKeyValue(tokenEntity.getKey())));
         expectedTokenKeys.add(
-                new PrecompileTestContractHistorical.TokenKey(BigInteger.valueOf(2), getKeyValue(token.getKycKey())));
+                new PrecompileTestContractHistorical.TokenKey(KYC_KEY.keyTypeNumeric, getKeyValue(token.getKycKey())));
         expectedTokenKeys.add(new PrecompileTestContractHistorical.TokenKey(
-                BigInteger.valueOf(4), getKeyValue(token.getFreezeKey())));
-        expectedTokenKeys.add(
-                new PrecompileTestContractHistorical.TokenKey(BigInteger.valueOf(8), getKeyValue(token.getWipeKey())));
+                FREEZE_KEY.keyTypeNumeric, getKeyValue(token.getFreezeKey())));
         expectedTokenKeys.add(new PrecompileTestContractHistorical.TokenKey(
-                BigInteger.valueOf(16), getKeyValue(token.getSupplyKey())));
+                WIPE_KEY.keyTypeNumeric, getKeyValue(token.getWipeKey())));
         expectedTokenKeys.add(new PrecompileTestContractHistorical.TokenKey(
-                BigInteger.valueOf(32), getKeyValue(token.getFeeScheduleKey())));
+                SUPPLY_KEY.keyTypeNumeric, getKeyValue(token.getSupplyKey())));
         expectedTokenKeys.add(new PrecompileTestContractHistorical.TokenKey(
-                BigInteger.valueOf(64), getKeyValue(token.getPauseKey())));
+                FEE_SCHEDULE_KEY.keyTypeNumeric, getKeyValue(token.getFeeScheduleKey())));
+        expectedTokenKeys.add(new PrecompileTestContractHistorical.TokenKey(
+                PAUSE_KEY.keyTypeNumeric, getKeyValue(token.getPauseKey())));
 
         return expectedTokenKeys;
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
@@ -16,352 +16,1322 @@
 
 package com.hedera.mirror.web3.service;
 
-import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_CALL;
+import static com.hedera.mirror.web3.exception.BlockNumberNotFoundException.UNKNOWN_BLOCK_NUMBER;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.ECDSA_KEY;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.ED25519_KEY;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.KEY_WITH_ECDSA_TYPE;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.KEY_WITH_ED_25519_TYPE;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.LEDGER_ID;
-import static com.hederahashgraph.api.proto.java.CustomFee.FeeCase.FIXED_FEE;
-import static com.hederahashgraph.api.proto.java.CustomFee.FeeCase.FRACTIONAL_FEE;
-import static com.hederahashgraph.api.proto.java.CustomFee.FeeCase.ROYALTY_FEE;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SENDER_ALIAS;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SENDER_PUBLIC_KEY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.google.common.collect.Range;
-import com.hedera.mirror.web3.exception.BlockNumberNotFoundException;
-import com.hedera.mirror.web3.exception.BlockNumberOutOfRangeException;
-import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
-import com.hedera.mirror.web3.utils.ContractFunctionProviderEnum;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.hedera.mirror.common.domain.balance.AccountBalance;
+import com.hedera.mirror.common.domain.balance.TokenBalance;
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.common.domain.token.CustomFee;
+import com.hedera.mirror.common.domain.token.FallbackFee;
+import com.hedera.mirror.common.domain.token.FractionalFee;
+import com.hedera.mirror.common.domain.token.RoyaltyFee;
+import com.hedera.mirror.common.domain.token.Token;
+import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
+import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
+import com.hedera.mirror.common.domain.token.TokenSupplyTypeEnum;
+import com.hedera.mirror.common.domain.token.TokenTransfer;
+import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.web3.viewmodel.BlockType;
-import java.util.Arrays;
+import com.hedera.mirror.web3.web3j.generated.PrecompileTestContractHistorical;
+import com.hedera.mirror.web3.web3j.generated.PrecompileTestContractHistorical.FixedFee;
+import com.hedera.mirror.web3.web3j.generated.PrecompileTestContractHistorical.FungibleTokenInfo;
+import com.hedera.mirror.web3.web3j.generated.PrecompileTestContractHistorical.KeyValue;
+import com.hedera.mirror.web3.web3j.generated.PrecompileTestContractHistorical.NonFungibleTokenInfo;
+import com.hedera.services.store.contracts.precompile.codec.KeyValueWrapper.KeyValueType;
+import com.hedera.services.store.models.Id;
+import com.hedera.services.utils.EntityIdUtils;
+import com.hederahashgraph.api.proto.java.Key;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.web3j.tx.Contract;
 
-class ContractCallServicePrecompileHistoricalTest extends ContractCallTestSetup {
-    private static Stream<Arguments> htsContractFunctionArgumentsProviderHistoricalReadOnly() {
-        List<String> blockNumbers = List.of(String.valueOf(EVM_V_34_BLOCK - 1), String.valueOf(EVM_V_34_BLOCK));
+class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallServiceTest {
 
-        return Arrays.stream(ContractReadFunctionsHistorical.values()).flatMap(htsFunction -> blockNumbers.stream()
-                .map(blockNumber -> Arguments.of(htsFunction, blockNumber)));
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void isTokenFrozen(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var account = persistAccountEntityHistorical(historicalRange);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        domainBuilder
+                .tokenAccount()
+                .customize(ta -> ta.tokenId(tokenEntity.getId())
+                        .accountId(account.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .freezeStatus(TokenFreezeStatusEnum.FROZEN)
+                        .associated(true)
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall =
+                contract.call_isTokenFrozen(getAddressFromEntity(tokenEntity), getAddressFromEntity(account));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
     }
 
     @ParameterizedTest
-    @MethodSource("htsContractFunctionArgumentsProviderHistoricalReadOnly")
-    void evmPrecompileReadOnlyTokenFunctionsTestEthCallHistorical(
-            final ContractReadFunctionsHistorical contractFunc, final String blockNumber) {
-        final var functionHash = functionEncodeDecoder.functionHashFor(
-                contractFunc.name, PRECOMPILE_TEST_CONTRACT_ABI_PATH, contractFunc.functionParameters);
-        final var serviceParameters = serviceParametersForExecution(
-                functionHash, PRECOMPILE_TEST_CONTRACT_ADDRESS, ETH_CALL, 0L, BlockType.of(blockNumber));
-        switch (contractFunc) {
-            case GET_CUSTOM_FEES_FOR_TOKEN_WITH_FIXED_FEE -> customFeePersistHistorical(
-                    FIXED_FEE,
-                    Range.closedOpen(
-                            recordFileBeforeEvm34.getConsensusStart(), recordFileBeforeEvm34.getConsensusEnd()));
-            case GET_CUSTOM_FEES_FOR_TOKEN_WITH_FRACTIONAL_FEE,
-                    GET_INFORMATION_FOR_TOKEN_FUNGIBLE,
-                    GET_INFORMATION_FOR_TOKEN_NFT,
-                    GET_FUNGIBLE_TOKEN_INFO,
-                    GET_NFT_INFO -> customFeePersistHistorical(
-                    FRACTIONAL_FEE,
-                    Range.closedOpen(
-                            recordFileBeforeEvm34.getConsensusStart(), recordFileBeforeEvm34.getConsensusEnd()));
-            case GET_CUSTOM_FEES_FOR_TOKEN_WITH_ROYALTY_FEE -> customFeePersistHistorical(
-                    ROYALTY_FEE,
-                    Range.closedOpen(
-                            recordFileBeforeEvm34.getConsensusStart(), recordFileBeforeEvm34.getConsensusEnd()));
-            default -> {
-                // Do nothing
-            }
-        }
-        final var successfulResponse = functionEncodeDecoder.encodedResultFor(
-                contractFunc.name, PRECOMPILE_TEST_CONTRACT_ABI_PATH, contractFunc.expectedResultFields);
+    @CsvSource({"50", "49"})
+    void isTokenFrozenWithAlias(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var account = persistAccountEntityHistoricalWithAlias(historicalRange);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        domainBuilder
+                .tokenAccount()
+                .customize(ta -> ta.tokenId(tokenEntity.getId())
+                        .accountId(account.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .freezeStatus(TokenFreezeStatusEnum.FROZEN)
+                        .associated(true)
+                        .timestampRange(historicalRange))
+                .persist();
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
-        if (Long.parseLong(blockNumber) < EVM_V_34_BLOCK) {
-            switch (contractFunc) {
-                    // These are the only cases where an exception is not thrown. There are custom
-                    // precompiles for these cases and an exception is thrown there but the top
-                    // stack frame overrides the result with the one from Besu and the zero address
-                    // is returned.
-                case HTS_GET_APPROVED, HTS_ALLOWANCE, HTS_IS_APPROVED_FOR_ALL -> {
-                    assertThat(contractCallService.processCall(serviceParameters))
-                            .isEqualTo(String.valueOf(Bytes32.ZERO));
-                    return;
-                }
-                default -> {
-                    // Do nothing
-                }
-            }
-            assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
-                    .isInstanceOf(MirrorEvmTransactionException.class);
-        } else {
-            assertThat(contractCallService.processCall(serviceParameters)).isEqualTo(successfulResponse);
-        }
+        // When
+        final var functionCall =
+                contract.call_isTokenFrozen(getAddressFromEntity(tokenEntity), getAliasFromEntity(account));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void isKycGranted(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var account = persistAccountEntityHistorical(historicalRange);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        domainBuilder
+                .tokenAccount()
+                .customize(ta -> ta.tokenId(tokenEntity.getId())
+                        .accountId(account.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .associated(true)
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall =
+                contract.call_isKycGranted(getAddressFromEntity(tokenEntity), getAddressFromEntity(account));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void isKycGrantedWithAlias(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var account = persistAccountEntityHistoricalWithAlias(historicalRange);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        domainBuilder
+                .tokenAccount()
+                .customize(ta -> ta.tokenId(tokenEntity.getId())
+                        .accountId(account.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .associated(true)
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall =
+                contract.call_isKycGranted(getAddressFromEntity(tokenEntity), getAliasFromEntity(account));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void isKycGrantedForNFT(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var account = persistAccountEntityHistorical(historicalRange);
+        final var tokenEntity = persistNftHistorical(historicalRange);
+        domainBuilder
+                .tokenAccount()
+                .customize(ta -> ta.tokenId(tokenEntity.getId())
+                        .accountId(account.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .associated(true)
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall =
+                contract.call_isKycGranted(getAddressFromEntity(tokenEntity), getAddressFromEntity(account));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void isKycGrantedForNFTWithAlias(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var account = persistAccountEntityHistoricalWithAlias(historicalRange);
+        final var tokenEntity = persistNftHistorical(historicalRange);
+        domainBuilder
+                .tokenAccount()
+                .customize(ta -> ta.tokenId(tokenEntity.getId())
+                        .accountId(account.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .associated(true)
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall =
+                contract.call_isKycGranted(getAddressFromEntity(tokenEntity), getAliasFromEntity(account));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void isTokenAddress(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_isTokenAddress(getAddressFromEntity(tokenEntity));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void isTokenAddressNFT(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenEntity = persistNftHistorical(historicalRange);
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_isTokenAddress(getAddressFromEntity(tokenEntity));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getDefaultKycToken(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_getTokenDefaultKyc(getAddressFromEntity(tokenEntity));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getDefaultKycNFT(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenEntity = persistNftHistorical(historicalRange);
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_getTokenDefaultKyc(getAddressFromEntity(tokenEntity));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getTokenType(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_getType(getAddressFromEntity(tokenEntity));
+
+        // Then
+        assertThat(functionCall.send()).isEqualTo(BigInteger.ZERO);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getTokenTypeNFT(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenEntity = persistNftHistorical(historicalRange);
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_getType(getAddressFromEntity(tokenEntity));
+
+        // Then
+        assertThat(functionCall.send()).isEqualTo(BigInteger.ONE);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getTokenDefaultFreeze(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .freezeDefault(true)
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_getTokenDefaultFreeze(getAddressFromEntity(tokenEntity));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getNFTDefaultFreeze(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                        .freezeDefault(true)
+                        .timestampRange(historicalRange))
+                .persist();
+        domainBuilder
+                .nft()
+                .customize(n -> n.tokenId(tokenEntity.getId()).serialNumber(1L).timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_getTokenDefaultFreeze(getAddressFromEntity(tokenEntity));
+
+        // Then
+        assertThat(functionCall.send()).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getCustomFeesForTokenWithFixedFee(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        final var collectorAccount = persistAccountEntityHistoricalWithAlias(historicalRange);
+        final var fixedFee = com.hedera.mirror.common.domain.token.FixedFee.builder()
+                .amount(100L)
+                .collectorAccountId(collectorAccount.toEntityId())
+                .denominatingTokenId(tokenEntity.toEntityId())
+                .build();
+        domainBuilder
+                .customFee()
+                .customize(f -> f.fixedFees(List.of(fixedFee))
+                        .fractionalFees(List.of())
+                        .royaltyFees(List.of())
+                        .tokenId(tokenEntity.getId())
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_getCustomFeesForToken(getAddressFromEntity(tokenEntity));
+
+        final var expectedFee = new PrecompileTestContractHistorical.FixedFee(
+                BigInteger.valueOf(100L),
+                getAddressFromEntity(tokenEntity),
+                false,
+                false,
+                Address.fromHexString(
+                                Bytes.wrap(collectorAccount.getEvmAddress()).toHexString())
+                        .toHexString());
+
+        // Then
+        assertThat(functionCall.send().component1().getFirst()).isEqualTo(expectedFee);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getCustomFeesForTokenWithFractionalFee(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var collectorAccount = persistAccountEntityHistoricalWithAlias(historicalRange);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        final var fractionalFee = FractionalFee.builder()
+                .collectorAccountId(collectorAccount.toEntityId())
+                .denominator(10L)
+                .minimumAmount(1L)
+                .maximumAmount(1000L)
+                .netOfTransfers(true)
+                .numerator(100L)
+                .build();
+        domainBuilder
+                .customFee()
+                .customize(f -> f.fractionalFees(List.of(fractionalFee))
+                        .fixedFees(List.of())
+                        .royaltyFees(List.of())
+                        .tokenId(tokenEntity.getId())
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_getCustomFeesForToken(getAddressFromEntity(tokenEntity));
+
+        final var expectedFee = new PrecompileTestContractHistorical.FractionalFee(
+                BigInteger.valueOf(100L),
+                BigInteger.valueOf(10L),
+                BigInteger.valueOf(1L),
+                BigInteger.valueOf(1000L),
+                true,
+                Address.fromHexString(
+                                Bytes.wrap(collectorAccount.getEvmAddress()).toHexString())
+                        .toHexString());
+
+        // Then
+        assertThat(functionCall.send().component2().getFirst()).isEqualTo(expectedFee);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getCustomFeesForTokenWithRoyaltyFee(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var collectorAccount = persistAccountEntityHistoricalWithAlias(historicalRange);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        final var royaltyFee = RoyaltyFee.builder()
+                .collectorAccountId(collectorAccount.toEntityId())
+                .denominator(10L)
+                .fallbackFee(FallbackFee.builder()
+                        .amount(100L)
+                        .denominatingTokenId(tokenEntity.toEntityId())
+                        .build())
+                .numerator(20L)
+                .build();
+        domainBuilder
+                .customFee()
+                .customize(f -> f.royaltyFees(List.of(royaltyFee))
+                        .fixedFees(List.of())
+                        .fractionalFees(List.of())
+                        .tokenId(tokenEntity.getId())
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_getCustomFeesForToken(getAddressFromEntity(tokenEntity));
+
+        final var expectedFee = new PrecompileTestContractHistorical.RoyaltyFee(
+                BigInteger.valueOf(20L),
+                BigInteger.valueOf(10L),
+                BigInteger.valueOf(100L),
+                EntityIdUtils.asHexedEvmAddress(
+                        new Id(tokenEntity.getShard(), tokenEntity.getRealm(), tokenEntity.getNum())),
+                false,
+                Address.fromHexString(
+                                Bytes.wrap(collectorAccount.getEvmAddress()).toHexString())
+                        .toHexString());
+
+        // Then
+        assertThat(functionCall.send().component3().getFirst()).isEqualTo(expectedFee);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getExpiryForToken(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var expiryPeriod = 9999999999999L;
+        final var autoRenewExpiry = 100000000L;
+        final var autoRenewAccount = persistAccountEntityHistorical(historicalRange);
+        final var tokenEntity = domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.TOKEN)
+                        .autoRenewAccountId(autoRenewAccount.getId())
+                        .expirationTimestamp(expiryPeriod)
+                        .timestampRange(historicalRange)
+                        .autoRenewPeriod(autoRenewExpiry))
+                .persist();
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_getExpiryInfoForToken(getAddressFromEntity(tokenEntity));
+
+        final var expectedExpiry = new PrecompileTestContractHistorical.Expiry(
+                BigInteger.valueOf(expiryPeriod).divide(BigInteger.valueOf(1_000_000_000L)),
+                Address.fromHexString(
+                                Bytes.wrap(autoRenewAccount.getEvmAddress()).toHexString())
+                        .toHexString(),
+                BigInteger.valueOf(autoRenewExpiry));
+
+        // Then
+        assertThat(functionCall.send()).isEqualTo(expectedExpiry);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getApproved(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var approvedAccount = persistAccountEntityHistoricalWithAlias(historicalRange);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                        .freezeDefault(true)
+                        .timestampRange(historicalRange))
+                .persist();
+        domainBuilder
+                .nft()
+                .customize(n -> n.tokenId(tokenEntity.getId())
+                        .serialNumber(1L)
+                        .timestampRange(historicalRange)
+                        .spender(approvedAccount.toEntityId()))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_htsGetApproved(getAddressFromEntity(tokenEntity), BigInteger.ONE);
+        final var result = functionCall.send();
+
+        // Then
+        assertThat(result).isEqualTo(SENDER_ALIAS.toHexString());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getAllowanceForToken(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var amountGranted = 50L;
+        final var owner = persistAccountEntityHistorical(historicalRange);
+        final var spender = persistAccountEntityHistorical(historicalRange);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+
+        domainBuilder
+                .tokenAllowance()
+                .customize(a -> a.tokenId(tokenEntity.getId())
+                        .owner(owner.getNum())
+                        .spender(spender.getNum())
+                        .amount(amountGranted)
+                        .amountGranted(amountGranted)
+                        .timestampRange(historicalRange))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_htsAllowance(
+                getAddressFromEntity(tokenEntity), getAliasFromEntity(owner), getAliasFromEntity(spender));
+
+        // Then
+        assertThat(functionCall.send()).isEqualTo(BigInteger.valueOf(amountGranted));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void isApprovedForAllNFT(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var owner = persistAccountEntityHistorical(historicalRange);
+        final var spender = persistAccountEntityHistorical(historicalRange);
+        final var tokenEntity = persistNftHistorical(historicalRange);
+
+        domainBuilder
+                .nftAllowance()
+                .customize(a -> a.tokenId(tokenEntity.getId())
+                        .owner(owner.getNum())
+                        .spender(spender.getNum())
+                        .timestampRange(historicalRange)
+                        .approvedForAll(true))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_htsIsApprovedForAll(
+                getAddressFromEntity(tokenEntity), getAliasFromEntity(owner), getAliasFromEntity(spender));
+
+        // Then
+        assertThat(functionCall.send()).isEqualTo(Boolean.TRUE);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getFungibleTokenInfo(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenSupply = 900L;
+
+        final var tokenEntity = domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.TOKEN).timestampRange(historicalRange))
+                .persist();
+        final var treasury =
+                accountPersistWithBalanceHistorical(tokenSupply, tokenEntity.toEntityId(), historicalRange);
+        final var feeCollector = persistAccountEntityHistorical(historicalRange);
+
+        final var token = domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .treasuryAccountId(treasury.toEntityId())
+                        .timestampRange(historicalRange)
+                        .totalSupply(tokenSupply))
+                .persist();
+
+        final var customFees = persistCustomFeesWithFeeCollectorHistorical(
+                feeCollector, tokenEntity, TokenTypeEnum.FUNGIBLE_COMMON, historicalRange);
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var result = contract.call_getInformationForFungibleToken(getAddressFromEntity(tokenEntity))
+                .send();
+
+        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury);
+
+        final var fixedFees = new ArrayList<FixedFee>();
+        fixedFees.add(getFixedFee(customFees.getFixedFees().getFirst(), feeCollector));
+
+        final var fractionalFees = new ArrayList<PrecompileTestContractHistorical.FractionalFee>();
+        fractionalFees.add(getFractionalFee(customFees.getFractionalFees().getFirst(), feeCollector));
+
+        final var royaltyFees = new ArrayList<PrecompileTestContractHistorical.RoyaltyFee>();
+
+        final var expectedTokenInfo = createExpectedTokenInfo(
+                expectedHederaToken, token, tokenEntity, fixedFees, fractionalFees, royaltyFees);
+
+        final var expectedFungibleTokenInfo =
+                new FungibleTokenInfo(expectedTokenInfo, BigInteger.valueOf(token.getDecimals()));
+
+        // Then
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedFungibleTokenInfo);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getNonFungibleTokenInfo(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+
+        final var owner = persistAccountEntityHistorical(historicalRange);
+        final var treasury = persistAccountEntityHistorical(historicalRange);
+        final var feeCollector = persistAccountEntityHistorical(historicalRange);
+        final var tokenEntity = domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.TOKEN)
+                        .timestampRange(historicalRange)
+                        .createdTimestamp(historicalRange.lowerEndpoint()))
+                .persist();
+        final var token = domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                        .treasuryAccountId(treasury.toEntityId())
+                        .timestampRange(historicalRange)
+                        .createdTimestamp(historicalRange.lowerEndpoint())
+                        .totalSupply(1L))
+                .persist();
+        final var nft = domainBuilder
+                .nft()
+                .customize(n -> n.tokenId(tokenEntity.getId())
+                        .serialNumber(1L)
+                        .accountId(owner.toEntityId())
+                        .timestampRange(historicalRange)
+                        .createdTimestamp(historicalRange.lowerEndpoint()))
+                .persist();
+
+        final var customFees = persistCustomFeesWithFeeCollectorHistorical(
+                feeCollector, tokenEntity, TokenTypeEnum.NON_FUNGIBLE_UNIQUE, historicalRange);
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var result = contract.call_getInformationForNonFungibleToken(
+                        getAddressFromEntity(tokenEntity), BigInteger.ONE)
+                .send();
+
+        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury);
+
+        final var fixedFees = new ArrayList<PrecompileTestContractHistorical.FixedFee>();
+        fixedFees.add(getFixedFee(customFees.getFixedFees().getFirst(), feeCollector));
+
+        final var fractionalFees = new ArrayList<PrecompileTestContractHistorical.FractionalFee>();
+
+        final var royaltyFees = new ArrayList<PrecompileTestContractHistorical.RoyaltyFee>();
+        royaltyFees.add(getRoyaltyFee(customFees.getRoyaltyFees().getFirst(), feeCollector));
+
+        final var expectedTokenInfo = createExpectedTokenInfo(
+                expectedHederaToken, token, tokenEntity, fixedFees, fractionalFees, royaltyFees);
+
+        final var expectedNonFungibleTokenInfo = new NonFungibleTokenInfo(
+                expectedTokenInfo,
+                BigInteger.valueOf(nft.getSerialNumber()),
+                getAddressFromEntityId(owner.toEntityId()),
+                BigInteger.valueOf(token.getCreatedTimestamp()).divide(BigInteger.valueOf(1_000_000_000L)),
+                nft.getMetadata(),
+                Address.ZERO.toHexString());
+
+        // Then
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedNonFungibleTokenInfo);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getTokenInfoFungible(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var tokenSupply = 1000L;
+
+        final var tokenEntity = domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.TOKEN).timestampRange(historicalRange))
+                .persist();
+        final var treasury =
+                accountPersistWithBalanceHistorical(tokenSupply, tokenEntity.toEntityId(), historicalRange);
+        final var feeCollector = persistAccountEntityHistorical(historicalRange);
+
+        final var token = domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .treasuryAccountId(treasury.toEntityId())
+                        .timestampRange(historicalRange)
+                        .totalSupply(tokenSupply))
+                .persist();
+
+        final var customFees = persistCustomFeesWithFeeCollectorHistorical(
+                feeCollector, tokenEntity, TokenTypeEnum.FUNGIBLE_COMMON, historicalRange);
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var result = contract.call_getInformationForToken(getAddressFromEntity(tokenEntity))
+                .send();
+
+        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury);
+
+        final var fixedFees = new ArrayList<PrecompileTestContractHistorical.FixedFee>();
+        fixedFees.add(getFixedFee(customFees.getFixedFees().getFirst(), feeCollector));
+
+        final var fractionalFees = new ArrayList<PrecompileTestContractHistorical.FractionalFee>();
+        fractionalFees.add(getFractionalFee(customFees.getFractionalFees().getFirst(), feeCollector));
+
+        final var expectedTokenInfo = createExpectedTokenInfo(
+                expectedHederaToken, token, tokenEntity, fixedFees, fractionalFees, Collections.emptyList());
+
+        // Then
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedTokenInfo);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"50", "49"})
+    void getTokenInfoNonFungible(long blockNumber) throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var treasury = persistAccountEntityHistorical(historicalRange);
+        final var feeCollector = persistAccountEntityHistorical(historicalRange);
+        final var tokenEntity = domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.TOKEN)
+                        .timestampRange(historicalRange)
+                        .createdTimestamp(historicalRange.lowerEndpoint()))
+                .persist();
+        final var token = domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                        .treasuryAccountId(treasury.toEntityId())
+                        .timestampRange(historicalRange)
+                        .createdTimestamp(historicalRange.lowerEndpoint())
+                        .totalSupply(1L))
+                .persist();
+        domainBuilder
+                .nft()
+                .customize(n -> n.tokenId(tokenEntity.getId())
+                        .serialNumber(1L)
+                        .timestampRange(historicalRange)
+                        .createdTimestamp(historicalRange.lowerEndpoint()))
+                .persist();
+
+        final var customFees = persistCustomFeesWithFeeCollectorHistorical(
+                feeCollector, tokenEntity, TokenTypeEnum.NON_FUNGIBLE_UNIQUE, historicalRange);
+
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var result = contract.call_getInformationForToken(getAddressFromEntity(tokenEntity))
+                .send();
+
+        final var expectedHederaToken = createExpectedHederaToken(tokenEntity, token, treasury);
+
+        final var fixedFees = new ArrayList<PrecompileTestContractHistorical.FixedFee>();
+        fixedFees.add(getFixedFee(customFees.getFixedFees().getFirst(), feeCollector));
+
+        final var royaltyFees = new ArrayList<PrecompileTestContractHistorical.RoyaltyFee>();
+        royaltyFees.add(getRoyaltyFee(customFees.getRoyaltyFees().getFirst(), feeCollector));
+
+        final var expectedTokenInfo = createExpectedTokenInfo(
+                expectedHederaToken, token, tokenEntity, fixedFees, Collections.emptyList(), royaltyFees);
+
+        // Then
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedTokenInfo);
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            textBlock =
+                    """
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, ADMIN_KEY, 50
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, ADMIN_KEY, 49
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, KYC_KEY, 50
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, KYC_KEY, 49
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, FREEZE_KEY, 50
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, FREEZE_KEY, 49
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, WIPE_KEY, 50
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, WIPE_KEY, 49
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, SUPPLY_KEY, 50
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, SUPPLY_KEY, 49
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, FEE_SCHEDULE_KEY, 50
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, FEE_SCHEDULE_KEY, 49
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, PAUSE_KEY, 50
+                                FUNGIBLE_COMMON, ECDSA_SECPK256K1, PAUSE_KEY, 49
+                                FUNGIBLE_COMMON, ED25519, ADMIN_KEY, 50
+                                FUNGIBLE_COMMON, ED25519, ADMIN_KEY, 49
+                                FUNGIBLE_COMMON, ED25519, FREEZE_KEY, 50
+                                FUNGIBLE_COMMON, ED25519, FREEZE_KEY, 49
+                                FUNGIBLE_COMMON, ED25519, WIPE_KEY, 50
+                                FUNGIBLE_COMMON, ED25519, WIPE_KEY, 49
+                                FUNGIBLE_COMMON, ED25519, SUPPLY_KEY, 50
+                                FUNGIBLE_COMMON, ED25519, SUPPLY_KEY, 49
+                                FUNGIBLE_COMMON, ED25519, FEE_SCHEDULE_KEY, 50
+                                FUNGIBLE_COMMON, ED25519, FEE_SCHEDULE_KEY, 49
+                                FUNGIBLE_COMMON, ED25519, PAUSE_KEY, 50
+                                FUNGIBLE_COMMON, ED25519, PAUSE_KEY, 49
+                                FUNGIBLE_COMMON, CONTRACT_ID, ADMIN_KEY, 50
+                                FUNGIBLE_COMMON, CONTRACT_ID, ADMIN_KEY, 49
+                                FUNGIBLE_COMMON, CONTRACT_ID, FREEZE_KEY, 50
+                                FUNGIBLE_COMMON, CONTRACT_ID, FREEZE_KEY, 49
+                                FUNGIBLE_COMMON, CONTRACT_ID, WIPE_KEY, 50
+                                FUNGIBLE_COMMON, CONTRACT_ID, WIPE_KEY, 49
+                                FUNGIBLE_COMMON, CONTRACT_ID, SUPPLY_KEY, 50
+                                FUNGIBLE_COMMON, CONTRACT_ID, SUPPLY_KEY, 49
+                                FUNGIBLE_COMMON, CONTRACT_ID, FEE_SCHEDULE_KEY, 50
+                                FUNGIBLE_COMMON, CONTRACT_ID, FEE_SCHEDULE_KEY, 49
+                                FUNGIBLE_COMMON, CONTRACT_ID, PAUSE_KEY, 50
+                                FUNGIBLE_COMMON, CONTRACT_ID, PAUSE_KEY, 49
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, ADMIN_KEY, 50
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, ADMIN_KEY, 49
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, FREEZE_KEY, 50
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, FREEZE_KEY, 49
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, WIPE_KEY, 50
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, WIPE_KEY, 49
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, SUPPLY_KEY, 50
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, SUPPLY_KEY, 49
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, FEE_SCHEDULE_KEY, 50
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, FEE_SCHEDULE_KEY, 49
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, PAUSE_KEY, 50
+                                FUNGIBLE_COMMON, DELEGATABLE_CONTRACT_ID, PAUSE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, ADMIN_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, ADMIN_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, KYC_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, KYC_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, FREEZE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, FREEZE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, WIPE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, WIPE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, SUPPLY_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, SUPPLY_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, FEE_SCHEDULE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, FEE_SCHEDULE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, PAUSE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ECDSA_SECPK256K1, PAUSE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ED25519, ADMIN_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ED25519, ADMIN_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ED25519, FREEZE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ED25519, FREEZE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ED25519, WIPE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ED25519, WIPE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ED25519, SUPPLY_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ED25519, SUPPLY_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ED25519, FEE_SCHEDULE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ED25519, FEE_SCHEDULE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, ED25519, PAUSE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, ED25519, PAUSE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, ADMIN_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, ADMIN_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, FREEZE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, FREEZE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, WIPE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, WIPE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, SUPPLY_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, SUPPLY_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, FEE_SCHEDULE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, FEE_SCHEDULE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, PAUSE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, CONTRACT_ID, PAUSE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, ADMIN_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, ADMIN_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, FREEZE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, FREEZE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, WIPE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, WIPE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, SUPPLY_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, SUPPLY_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, FEE_SCHEDULE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, FEE_SCHEDULE_KEY, 49
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, PAUSE_KEY, 50
+                                NON_FUNGIBLE_UNIQUE, DELEGATABLE_CONTRACT_ID, PAUSE_KEY, 49
+                            """)
+    void getTokenKey(
+            final TokenTypeEnum tokenType,
+            final KeyValueType keyValueType,
+            final AbstractContractCallServiceTest.KeyType keyType,
+            final long blockNumber)
+            throws Exception {
+        // Given
+        final var historicalRange = setUpHistoricalContext(blockNumber);
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        final var tokenEntity = getTokenWithKey(tokenType, keyValueType, keyType, contract, historicalRange);
+
+        // When
+        final var functionCall =
+                contract.call_getTokenKeyPublic(getAddressFromEntity(tokenEntity), keyType.getKeyTypeNumeric());
+
+        final var expectedKey = getKeyValueForType(keyValueType, contract.getContractAddress());
+
+        // Then
+        assertThat(functionCall.send()).isEqualTo(expectedKey);
     }
 
     @ParameterizedTest
     @ValueSource(longs = {51, Long.MAX_VALUE - 1})
     void evmPrecompileReadOnlyTokenFunctionsEthCallHistoricalNotExistingBlockTest(final long blockNumber) {
-        final var functionHash = functionEncodeDecoder.functionHashFor(
-                "isTokenFrozen",
-                PRECOMPILE_TEST_CONTRACT_ABI_PATH,
-                FUNGIBLE_TOKEN_ADDRESS_HISTORICAL,
-                SENDER_ADDRESS_HISTORICAL);
-        final var serviceParameters = serviceParametersForExecution(
-                functionHash,
-                PRECOMPILE_TEST_CONTRACT_ADDRESS,
-                ETH_CALL,
-                0L,
-                BlockType.of(String.valueOf(blockNumber)));
+        testWeb3jService.setBlockType(BlockType.of(String.valueOf(blockNumber)));
+        assertThatThrownBy(() -> testWeb3jService.deploy(PrecompileTestContractHistorical::deploy))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining(UNKNOWN_BLOCK_NUMBER);
+    }
 
-        final var latestBlockNumber = recordFileRepository.findLatestIndex().orElse(Long.MAX_VALUE);
+    private Entity getTokenWithKey(
+            final TokenTypeEnum tokenType,
+            final KeyValueType keyValueType,
+            final AbstractContractCallServiceTest.KeyType keyType,
+            final Contract contract,
+            final Range<Long> historicalRange) {
+        final Key key =
+                switch (keyValueType) {
+                    case ECDSA_SECPK256K1 -> KEY_WITH_ECDSA_TYPE;
+                    case ED25519 -> KEY_WITH_ED_25519_TYPE;
+                    case CONTRACT_ID -> getKeyWithContractId(contract);
+                    case DELEGATABLE_CONTRACT_ID -> getKeyWithDelegatableContractId(contract);
+                    default -> throw new IllegalArgumentException("Invalid key type");
+                };
 
-        // Block number (Long.MAX_VALUE - 1) does not exist in the DB and is after the
-        // latest block available in the DB => returning error
-        if (blockNumber > latestBlockNumber) {
-            assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
-                    .isInstanceOf(BlockNumberOutOfRangeException.class);
-        } else if (blockNumber == 51) {
-            // Block number 51 = (EVM_V_34_BLOCK + 1) does not exist in the DB but it is before the latest
-            // block available in the DB => throw an exception
-            assertThatThrownBy(() -> contractCallService.processCall(serviceParameters))
-                    .isInstanceOf(BlockNumberNotFoundException.class);
+        final var tokenEntity = domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.TOKEN).key(key.toByteArray()).timestampRange(historicalRange))
+                .persist();
+        final var tokenBuilder = domainBuilder.token().customize(t -> t.tokenId(tokenEntity.getId())
+                .type(tokenType));
+
+        switch (keyType) {
+            case AbstractContractCallServiceTest.KeyType.ADMIN_KEY:
+                break;
+            case AbstractContractCallServiceTest.KeyType.KYC_KEY:
+                tokenBuilder.customize(t -> t.kycKey(key.toByteArray()));
+                break;
+            case AbstractContractCallServiceTest.KeyType.FREEZE_KEY:
+                tokenBuilder.customize(t -> t.freezeKey(key.toByteArray()));
+                break;
+            case AbstractContractCallServiceTest.KeyType.WIPE_KEY:
+                tokenBuilder.customize(t -> t.wipeKey(key.toByteArray()));
+                break;
+            case AbstractContractCallServiceTest.KeyType.SUPPLY_KEY:
+                tokenBuilder.customize(t -> t.supplyKey(key.toByteArray()));
+                break;
+            case AbstractContractCallServiceTest.KeyType.FEE_SCHEDULE_KEY:
+                tokenBuilder.customize(t -> t.feeScheduleKey(key.toByteArray()));
+                break;
+            case AbstractContractCallServiceTest.KeyType.PAUSE_KEY:
+                tokenBuilder.customize(t -> t.pauseKey(key.toByteArray()));
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid key type");
+        }
+
+        tokenBuilder.persist();
+        return tokenEntity;
+    }
+
+    private KeyValue getKeyValueForType(final KeyValueType keyValueType, final String contractAddress) {
+        return switch (keyValueType) {
+            case CONTRACT_ID -> new KeyValue(
+                    Boolean.FALSE, contractAddress, new byte[0], new byte[0], Address.ZERO.toHexString());
+            case ED25519 -> new KeyValue(
+                    Boolean.FALSE, Address.ZERO.toHexString(), ED25519_KEY, new byte[0], Address.ZERO.toHexString());
+            case ECDSA_SECPK256K1 -> new KeyValue(
+                    Boolean.FALSE, Address.ZERO.toHexString(), new byte[0], ECDSA_KEY, Address.ZERO.toHexString());
+            case DELEGATABLE_CONTRACT_ID -> new KeyValue(
+                    Boolean.FALSE, Address.ZERO.toHexString(), new byte[0], new byte[0], contractAddress);
+            default -> throw new RuntimeException("Unsupported key type: " + keyValueType.name());
+        };
+    }
+
+    private Entity persistTokenEntityHistorical(final Range<Long> timestampRange) {
+        return domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.TOKEN).timestampRange(timestampRange))
+                .persist();
+    }
+
+    private void persistFungibleTokenHistorical(Entity tokenEntity, final Range<Long> timestampRange) {
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .timestampRange(timestampRange)
+                        .createdTimestamp(timestampRange.lowerEndpoint()))
+                .persist();
+    }
+
+    private Entity persistNftHistorical(final Range<Long> timestampRange) {
+        final var tokenEntity = persistTokenEntityHistorical(timestampRange);
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                        .timestampRange(timestampRange))
+                .persist();
+        domainBuilder
+                .nft()
+                .customize(n -> n.tokenId(tokenEntity.getId()).serialNumber(1L).timestampRange(timestampRange))
+                .persist();
+
+        return tokenEntity;
+    }
+
+    private Entity persistAccountEntityHistorical(final Range<Long> timestampRange) {
+        return domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.ACCOUNT)
+                        .deleted(false)
+                        .balance(1_000_000_000_000L)
+                        .timestampRange(timestampRange)
+                        .createdTimestamp(timestampRange.lowerEndpoint()))
+                .persist();
+    }
+
+    private Entity persistAccountEntityHistoricalWithAlias(final Range<Long> timestampRange) {
+        return domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.ACCOUNT)
+                        .alias(SENDER_PUBLIC_KEY.toByteArray())
+                        .deleted(false)
+                        .evmAddress(SENDER_ALIAS.toArray())
+                        .balance(1_000_000_000_000L)
+                        .createdTimestamp(timestampRange.lowerEndpoint())
+                        .timestampRange(timestampRange))
+                .persist();
+    }
+
+    private CustomFee persistCustomFeesWithFeeCollectorHistorical(
+            final Entity feeCollector,
+            final Entity tokenEntity,
+            final TokenTypeEnum tokenType,
+            final Range<Long> timestampRange) {
+        final var fixedFee = com.hedera.mirror.common.domain.token.FixedFee.builder()
+                .allCollectorsAreExempt(true)
+                .amount(domainBuilder.number())
+                .collectorAccountId(feeCollector.toEntityId())
+                .denominatingTokenId(tokenEntity.toEntityId())
+                .build();
+
+        final var fractionalFee = TokenTypeEnum.FUNGIBLE_COMMON.equals(tokenType)
+                ? FractionalFee.builder()
+                        .allCollectorsAreExempt(true)
+                        .collectorAccountId(feeCollector.toEntityId())
+                        .denominator(domainBuilder.number())
+                        .maximumAmount(domainBuilder.number())
+                        .minimumAmount(1L)
+                        .numerator(domainBuilder.number())
+                        .netOfTransfers(true)
+                        .build()
+                : null;
+
+        final var fallbackFee = FallbackFee.builder()
+                .amount(domainBuilder.number())
+                .denominatingTokenId(tokenEntity.toEntityId())
+                .build();
+
+        final var royaltyFee = TokenTypeEnum.NON_FUNGIBLE_UNIQUE.equals(tokenType)
+                ? RoyaltyFee.builder()
+                        .allCollectorsAreExempt(true)
+                        .collectorAccountId(feeCollector.toEntityId())
+                        .denominator(domainBuilder.number())
+                        .fallbackFee(fallbackFee)
+                        .numerator(domainBuilder.number())
+                        .build()
+                : null;
+
+        if (TokenTypeEnum.FUNGIBLE_COMMON.equals(tokenType)) {
+            return domainBuilder
+                    .customFee()
+                    .customize(f -> f.tokenId(tokenEntity.getId())
+                            .fixedFees(List.of(fixedFee))
+                            .fractionalFees(List.of(fractionalFee))
+                            .royaltyFees(new ArrayList<>())
+                            .timestampRange(timestampRange))
+                    .persist();
+        } else if (TokenTypeEnum.NON_FUNGIBLE_UNIQUE.equals(tokenType)) {
+            return domainBuilder
+                    .customFee()
+                    .customize(f -> f.tokenId(tokenEntity.getId())
+                            .fixedFees(List.of(fixedFee))
+                            .royaltyFees(List.of(royaltyFee))
+                            .fractionalFees(new ArrayList<>())
+                            .timestampRange(timestampRange))
+                    .persist();
+        }
+
+        return CustomFee.builder().build();
+    }
+
+    private List<PrecompileTestContractHistorical.TokenKey> getExpectedTokenKeys(
+            final Entity tokenEntity, final Token token) {
+        final var expectedTokenKeys = new ArrayList<PrecompileTestContractHistorical.TokenKey>();
+        expectedTokenKeys.add(
+                new PrecompileTestContractHistorical.TokenKey(BigInteger.ONE, getKeyValue(tokenEntity.getKey())));
+        expectedTokenKeys.add(
+                new PrecompileTestContractHistorical.TokenKey(BigInteger.valueOf(2), getKeyValue(token.getKycKey())));
+        expectedTokenKeys.add(new PrecompileTestContractHistorical.TokenKey(
+                BigInteger.valueOf(4), getKeyValue(token.getFreezeKey())));
+        expectedTokenKeys.add(
+                new PrecompileTestContractHistorical.TokenKey(BigInteger.valueOf(8), getKeyValue(token.getWipeKey())));
+        expectedTokenKeys.add(new PrecompileTestContractHistorical.TokenKey(
+                BigInteger.valueOf(16), getKeyValue(token.getSupplyKey())));
+        expectedTokenKeys.add(new PrecompileTestContractHistorical.TokenKey(
+                BigInteger.valueOf(32), getKeyValue(token.getFeeScheduleKey())));
+        expectedTokenKeys.add(new PrecompileTestContractHistorical.TokenKey(
+                BigInteger.valueOf(64), getKeyValue(token.getPauseKey())));
+
+        return expectedTokenKeys;
+    }
+
+    private PrecompileTestContractHistorical.FixedFee getFixedFee(
+            final com.hedera.mirror.common.domain.token.FixedFee fixedFee, final Entity feeCollector) {
+        return new PrecompileTestContractHistorical.FixedFee(
+                BigInteger.valueOf(fixedFee.getAmount()),
+                getAddressFromEntityId(fixedFee.getDenominatingTokenId()),
+                false,
+                false,
+                getAliasFromEntity(feeCollector));
+    }
+
+    private PrecompileTestContractHistorical.FractionalFee getFractionalFee(
+            final com.hedera.mirror.common.domain.token.FractionalFee fractionalFee, final Entity feeCollector) {
+        return new PrecompileTestContractHistorical.FractionalFee(
+                BigInteger.valueOf(fractionalFee.getNumerator()),
+                BigInteger.valueOf(fractionalFee.getDenominator()),
+                BigInteger.valueOf(fractionalFee.getMinimumAmount()),
+                BigInteger.valueOf(fractionalFee.getMaximumAmount()),
+                true,
+                getAliasFromEntity(feeCollector));
+    }
+
+    private PrecompileTestContractHistorical.RoyaltyFee getRoyaltyFee(
+            final com.hedera.mirror.common.domain.token.RoyaltyFee royaltyFee, final Entity feeCollector) {
+        return new PrecompileTestContractHistorical.RoyaltyFee(
+                BigInteger.valueOf(royaltyFee.getNumerator()),
+                BigInteger.valueOf(royaltyFee.getDenominator()),
+                BigInteger.valueOf(royaltyFee.getFallbackFee().getAmount()),
+                getAddressFromEntityId(royaltyFee.getFallbackFee().getDenominatingTokenId()),
+                false,
+                getAddressFromEvmAddress(feeCollector.getEvmAddress()));
+    }
+
+    private PrecompileTestContractHistorical.KeyValue getKeyValue(final byte[] serializedKey) {
+        try {
+            final var key = Key.parseFrom(serializedKey);
+            return new PrecompileTestContractHistorical.KeyValue(
+                    false,
+                    key.getContractID().hasContractNum()
+                            ? EntityIdUtils.asTypedEvmAddress(key.getContractID())
+                                    .toHexString()
+                            : Address.ZERO.toHexString(),
+                    key.getEd25519().toByteArray(),
+                    key.getECDSASecp256K1().toByteArray(),
+                    key.getDelegatableContractId().hasContractNum()
+                            ? EntityIdUtils.asTypedEvmAddress(key.getDelegatableContractId())
+                                    .toHexString()
+                            : Address.ZERO.toHexString());
+        } catch (InvalidProtocolBufferException e) {
+            throw new IllegalArgumentException("Unable to parse key", e);
         }
     }
 
-    @Getter
-    @RequiredArgsConstructor
-    enum ContractReadFunctionsHistorical implements ContractFunctionProviderEnum {
-        IS_FROZEN(
-                "isTokenFrozen",
-                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL},
-                new Boolean[] {true}),
-        IS_FROZEN_WITH_ALIAS(
-                "isTokenFrozen",
-                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL},
-                new Boolean[] {true}),
-        IS_KYC(
-                "isKycGranted",
-                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL},
-                new Boolean[] {true}),
-        IS_KYC_WITH_ALIAS(
-                "isKycGranted",
-                new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL},
-                new Boolean[] {true}),
-        IS_KYC_FOR_NFT(
-                "isKycGranted", new Address[] {NFT_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL}, new Boolean[] {true
-                }),
-        IS_KYC_FOR_NFT_WITH_ALIAS(
-                "isKycGranted", new Address[] {NFT_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL}, new Boolean[] {true}),
-        IS_TOKEN_PRECOMPILE("isTokenAddress", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Boolean[] {true}),
-        IS_TOKEN_PRECOMPILE_NFT("isTokenAddress", new Address[] {NFT_ADDRESS_HISTORICAL}, new Boolean[] {true}),
-        GET_TOKEN_DEFAULT_KYC(
-                "getTokenDefaultKyc", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Boolean[] {true}),
-        GET_TOKEN_DEFAULT_KYC_NFT("getTokenDefaultKyc", new Address[] {NFT_ADDRESS_HISTORICAL}, new Boolean[] {true}),
-        GET_TOKEN_TYPE("getType", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Long[] {0L}),
-        GET_TOKEN_TYPE_FOR_NFT("getType", new Address[] {NFT_ADDRESS_HISTORICAL}, new Long[] {1L}),
-        GET_TOKEN_DEFAULT_FREEZE(
-                "getTokenDefaultFreeze", new Address[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Boolean[] {true}),
-        GET_TOKEN_DEFAULT_FREEZE_FOR_NFT(
-                "getTokenDefaultFreeze", new Address[] {NFT_ADDRESS_HISTORICAL}, new Boolean[] {true}),
-        GET_TOKEN_ADMIN_KEY_WITH_CONTRACT_ADDRESS(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 1L},
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        GET_TOKEN_FREEZE_KEY_WITH_CONTRACT_ADDRESS(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 4L},
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        GET_TOKEN_WIPE_KEY_WITH_CONTRACT_ADDRESS(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 8L},
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        GET_TOKEN_SUPPLY_KEY_WITH_CONTRACT_ADDRESS(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 16L},
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        GET_TOKEN_ADMIN_KEY_WITH_ED25519_KEY(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 1L},
-                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
-        GET_TOKEN_FREEZE_KEY_WITH_ED25519_KEY(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 4L},
-                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
-        GET_TOKEN_WIPE_KEY_WITH_ED25519_KEY(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 8L},
-                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
-        GET_TOKEN_SUPPLY_KEY_WITH_ED25519_KEY(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 16L},
-                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
-        GET_TOKEN_ADMIN_KEY_WITH_ECDSA_KEY(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 1L},
-                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
-        GET_TOKEN_FREEZE_KEY_WITH_ECDSA_KEY(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 4L},
-                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
-        GET_TOKEN_WIPE_KEY_WITH_ECDSA_KEY(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 8L},
-                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
-        GET_TOKEN_SUPPLY_KEY_WITH_ECDSA_KEY(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 16L},
-                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
-        GET_TOKEN_ADMIN_KEY_WITH_DELEGATABLE_CONTRACT_ID(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 1L},
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        GET_TOKEN_FREEZE_KEY_WITH_DELEGATABLE_CONTRACT_ID(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 4L},
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        GET_TOKEN_WIPE_KEY_WITH_DELEGATABLE_CONTRACT_ID(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 8L},
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        GET_TOKEN_SUPPLY_KEY_WITH_DELEGATABLE_CONTRACT_ID(
-                "getTokenKeyPublic",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 16L},
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_CONTRACT_ADDRESS(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 2L},
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_CONTRACT_ADDRESS(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 32L},
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_CONTRACT_ADDRESS(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_CONTRACT_ADDRESS_HISTORICAL, 64L},
-                new Object[] {false, PRECOMPILE_TEST_CONTRACT_ADDRESS, new byte[0], new byte[0], Address.ZERO}),
-        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_ED25519_KEY(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 2L},
-                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
-        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_ED25519_KEY(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 32L},
-                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
-        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_ED25519_KEY(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ED25519_KEY_HISTORICAL, 64L},
-                new Object[] {false, Address.ZERO, ED25519_KEY, new byte[0], Address.ZERO}),
-        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_ECDSA_KEY(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 2L},
-                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
-        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_ECDSA_KEY(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 32L},
-                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
-        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_ECDSA_KEY(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_ECDSA_KEY_HISTORICAL, 64L},
-                new Object[] {false, Address.ZERO, new byte[0], ECDSA_KEY, Address.ZERO}),
-        GET_TOKEN_KYC_KEY_FOR_NFT_WITH_DELEGATABLE_CONTRACT_ID(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 2L},
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        GET_TOKEN_FEE_KEY_FOR_NFT_WITH_DELEGATABLE_CONTRACT_ID(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 32L},
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        GET_TOKEN_PAUSE_KEY_FOR_NFT_WITH_DELEGATABLE_CONTRACT_ID(
-                "getTokenKeyPublic",
-                new Object[] {NFT_ADDRESS_GET_KEY_WITH_DELEGATABLE_CONTRACT_ID_HISTORICAL, 64L},
-                new Object[] {false, Address.ZERO, new byte[0], new byte[0], PRECOMPILE_TEST_CONTRACT_ADDRESS}),
-        GET_CUSTOM_FEES_FOR_TOKEN_WITH_FIXED_FEE(
-                "getCustomFeesForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Object[] {
-                    new Object[] {100L, FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, false, false, SENDER_ALIAS_HISTORICAL},
-                    new Object[0],
-                    new Object[0]
-                }),
-        GET_CUSTOM_FEES_FOR_TOKEN_WITH_FRACTIONAL_FEE(
-                "getCustomFeesForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Object[] {
-                    new Object[0], new Object[] {100L, 10L, 1L, 1000L, true, SENDER_ALIAS_HISTORICAL}, new Object[0]
-                }),
-        GET_CUSTOM_FEES_FOR_TOKEN_WITH_ROYALTY_FEE(
-                "getCustomFeesForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Object[] {
-                    new Object[0],
-                    new Object[0],
-                    new Object[] {20L, 10L, 100L, FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ALIAS_HISTORICAL}
-                }),
-        GET_TOKEN_EXPIRY(
-                "getExpiryInfoForToken",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_WITH_EXPIRY_HISTORICAL},
-                new Object[] {1000L, AUTO_RENEW_ACCOUNT_ADDRESS_HISTORICAL, 8_000_000L}),
-        HTS_GET_APPROVED(
-                "htsGetApproved", new Object[] {NFT_ADDRESS_HISTORICAL, 1L}, new Object[] {SPENDER_ALIAS_HISTORICAL}),
-        HTS_ALLOWANCE(
-                "htsAllowance",
-                new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL, SPENDER_ADDRESS_HISTORICAL},
-                new Object[] {13L}),
-        HTS_IS_APPROVED_FOR_ALL(
-                "htsIsApprovedForAll",
-                new Object[] {NFT_ADDRESS_HISTORICAL, SENDER_ADDRESS_HISTORICAL, SPENDER_ADDRESS_HISTORICAL},
-                new Object[] {true}),
-        GET_FUNGIBLE_TOKEN_INFO(
-                "getInformationForFungibleToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Object[] {
-                    new Object[] {
-                        FUNGIBLE_HBAR_TOKEN_AND_KEYS_HISTORICAL,
-                        12345L,
-                        false,
-                        false,
-                        true,
-                        new Object[] {100L, 10L, 1L, 1000L, true, SENDER_ALIAS_HISTORICAL},
-                        LEDGER_ID
-                    },
-                    12
-                }),
-        GET_NFT_INFO("getInformationForNonFungibleToken", new Object[] {NFT_ADDRESS_HISTORICAL, 1L}, new Object[] {
-            new Object[] {
-                NFT_HBAR_TOKEN_AND_KEYS_HISTORICAL,
-                2L,
-                false,
-                false,
-                true,
-                new Object[] {0L, 0L, 0L, 0L, false, SENDER_ALIAS_HISTORICAL},
-                LEDGER_ID
-            },
-            1L,
-            OWNER_ADDRESS_HISTORICAL,
-            1475067194L,
-            "NFT_METADATA_URI".getBytes(),
-            SPENDER_ADDRESS_HISTORICAL
-        }),
-        GET_INFORMATION_FOR_TOKEN_FUNGIBLE(
-                "getInformationForToken", new Object[] {FUNGIBLE_TOKEN_ADDRESS_HISTORICAL}, new Object[] {
-                    FUNGIBLE_HBAR_TOKEN_AND_KEYS_HISTORICAL,
-                    12345L,
-                    false,
-                    false,
-                    true,
-                    new Object[] {100L, 10L, 1L, 1000L, true, SENDER_ALIAS_HISTORICAL},
-                    LEDGER_ID
-                }),
-        GET_INFORMATION_FOR_TOKEN_NFT("getInformationForToken", new Object[] {NFT_ADDRESS_HISTORICAL}, new Object[] {
-            NFT_HBAR_TOKEN_AND_KEYS_HISTORICAL,
-            2L,
-            false,
-            false,
-            true,
-            new Object[] {0L, 0L, 0L, 0L, false, SENDER_ALIAS_HISTORICAL},
-            LEDGER_ID
-        });
+    private Entity accountPersistWithBalanceHistorical(
+            final long balance, final EntityId token, final Range<Long> timestampRange) {
+        final var entity = domainBuilder
+                .entity()
+                .customize(e -> e.balance(balance)
+                        .timestampRange(timestampRange)
+                        .createdTimestamp(timestampRange.lowerEndpoint()))
+                .persist();
 
-        private final String name;
-        private final Object[] functionParameters;
-        private final Object[] expectedResultFields;
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new AccountBalance.Id(entity.getCreatedTimestamp(), EntityId.of(2)))
+                        .balance(balance))
+                .persist();
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new AccountBalance.Id(entity.getCreatedTimestamp(), entity.toEntityId()))
+                        .balance(balance))
+                .persist();
+
+        domainBuilder
+                .tokenBalance()
+                .customize(ab -> ab.id(new TokenBalance.Id(entity.getCreatedTimestamp(), entity.toEntityId(), token))
+                        .balance(balance))
+                .persist();
+
+        domainBuilder
+                .tokenTransfer()
+                .customize(ab -> ab.id(new TokenTransfer.Id(entity.getCreatedTimestamp(), entity.toEntityId(), token))
+                        .amount(100))
+                .persist();
+        return entity;
+    }
+
+    private Range<Long> setUpHistoricalContext(final long blockNumber) {
+        final var recordFile =
+                domainBuilder.recordFile().customize(f -> f.index(blockNumber)).persist();
+        testWeb3jService.setBlockType(BlockType.of(String.valueOf(blockNumber)));
+        final var historicalRange = Range.closedOpen(recordFile.getConsensusStart(), recordFile.getConsensusEnd());
+        testWeb3jService.setHistoricalRange(historicalRange);
+        return historicalRange;
+    }
+
+    private PrecompileTestContractHistorical.HederaToken createExpectedHederaToken(
+            final Entity tokenEntity, final Token token, final Entity treasury) {
+        final var expectedTokenKeys = getExpectedTokenKeys(tokenEntity, token);
+
+        final var expectedExpiry = new PrecompileTestContractHistorical.Expiry(
+                BigInteger.valueOf(tokenEntity.getExpirationTimestamp()).divide(BigInteger.valueOf(1_000_000_000L)),
+                Address.ZERO.toHexString(),
+                BigInteger.valueOf(tokenEntity.getAutoRenewPeriod()));
+        return new PrecompileTestContractHistorical.HederaToken(
+                token.getName(),
+                token.getSymbol(),
+                getAddressFromEvmAddress(treasury.getEvmAddress()),
+                tokenEntity.getMemo(),
+                token.getSupplyType().equals(TokenSupplyTypeEnum.FINITE),
+                BigInteger.valueOf(token.getMaxSupply()),
+                token.getFreezeDefault(),
+                expectedTokenKeys,
+                expectedExpiry);
+    }
+
+    private PrecompileTestContractHistorical.TokenInfo createExpectedTokenInfo(
+            PrecompileTestContractHistorical.HederaToken expectedHederaToken,
+            Token token,
+            Entity tokenEntity,
+            List<PrecompileTestContractHistorical.FixedFee> fixedFees,
+            List<PrecompileTestContractHistorical.FractionalFee> fractionalFees,
+            List<PrecompileTestContractHistorical.RoyaltyFee> royaltyFees) {
+        return new PrecompileTestContractHistorical.TokenInfo(
+                expectedHederaToken,
+                BigInteger.valueOf(token.getTotalSupply()),
+                tokenEntity.getDeleted(),
+                false,
+                false,
+                fixedFees,
+                fractionalFees,
+                royaltyFees,
+                LEDGER_ID);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileTest.java
@@ -2532,14 +2532,6 @@ class ContractCallServicePrecompileTest extends AbstractContractCallServiceOpcod
         return expectedTokenKeys;
     }
 
-    private String getAddressFromEntityId(EntityId entity) {
-        return EntityIdUtils.asHexedEvmAddress(new Id(entity.getShard(), entity.getRealm(), entity.getNum()));
-    }
-
-    private String getAddressFromEvmAddress(byte[] evmAddress) {
-        return Address.wrap(Bytes.wrap(evmAddress)).toHexString();
-    }
-
     private KeyValue getKeyValue(byte[] serializedKey) {
         try {
             final var key = Key.parseFrom(serializedKey);

--- a/hedera-mirror-web3/src/test/solidity_historical/PrecompileTestContractHistorical.sol
+++ b/hedera-mirror-web3/src/test/solidity_historical/PrecompileTestContractHistorical.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+import "./HederaTokenService.sol";
+import "./HederaResponseCodes.sol";
+
+contract PrecompileTestContractHistorical is HederaTokenService {
+
+
+    function isTokenAddress(address token) external returns (bool){
+        (int response,bool tokenFlag) = HederaTokenService.isToken(token);
+
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token isTokenAddress failed!");
+        }
+        return tokenFlag;
+    }
+
+    function isTokenFrozen(address token, address account) external returns (bool){
+        (int response,bool frozen) = HederaTokenService.isFrozen(token, account);
+
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token isFrozen failed!");
+        }
+        return frozen;
+    }
+
+    function isKycGranted(address token, address account) external returns (bool){
+        (int response,bool kycGranted) = HederaTokenService.isKyc(token, account);
+
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("Token isKyc failed!");
+        }
+        return kycGranted;
+    }
+
+    function getTokenDefaultFreeze(address token) external returns (bool) {
+        (int response,bool frozen) = HederaTokenService.getTokenDefaultFreezeStatus(token);
+
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("getTokenDefaultFreezeStatus failed!");
+        }
+        return frozen;
+    }
+
+    function getTokenDefaultKyc(address token) external returns (bool) {
+        (int response,bool kyc) = HederaTokenService.getTokenDefaultKycStatus(token);
+
+        if (response != HederaResponseCodes.SUCCESS) {
+            revert ("getTokenDefaultKycStatus failed!");
+        }
+        return kyc;
+    }
+
+    function getCustomFeesForToken(address token) external returns (
+        IHederaTokenService.FixedFee[] memory fixedFees,
+        IHederaTokenService.FractionalFee[] memory fractionalFees,
+        IHederaTokenService.RoyaltyFee[] memory royaltyFees) {
+        int responseCode;
+        (responseCode, fixedFees, fractionalFees, royaltyFees) = HederaTokenService.getTokenCustomFees(token);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ();
+        }
+    }
+
+    function getInformationForToken(address token) external returns (IHederaTokenService.TokenInfo memory tokenInfo) {
+        (int responseCode, IHederaTokenService.TokenInfo memory retrievedTokenInfo) = HederaTokenService.getTokenInfo(token);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ();
+        }
+
+        tokenInfo = retrievedTokenInfo;
+    }
+
+    function getInformationForFungibleToken(address token) external returns (IHederaTokenService.FungibleTokenInfo memory fungibleTokenInfo) {
+        (int responseCode, IHederaTokenService.FungibleTokenInfo memory retrievedTokenInfo) = HederaTokenService.getFungibleTokenInfo(token);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ();
+        }
+
+        fungibleTokenInfo = retrievedTokenInfo;
+    }
+
+    function getInformationForNonFungibleToken(address token, int64 serialNumber) external returns (IHederaTokenService.NonFungibleTokenInfo memory nonFungibleTokenInfo) {
+        (int responseCode, IHederaTokenService.NonFungibleTokenInfo memory retrievedTokenInfo) = HederaTokenService.getNonFungibleTokenInfo(token, serialNumber);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ();
+        }
+
+        nonFungibleTokenInfo = retrievedTokenInfo;
+    }
+
+    function getType(address token) external returns (int) {
+        (int statusCode, int tokenType) = HederaTokenService.getTokenType(token);
+
+        if (statusCode != HederaResponseCodes.SUCCESS) {
+            revert ("Token type appraisal failed!");
+        }
+        return tokenType;
+    }
+
+    function getExpiryInfoForToken(address token) external returns (
+        IHederaTokenService.Expiry memory expiry) {
+        (int responseCode,
+            IHederaTokenService.Expiry memory retrievedExpiry) = HederaTokenService.getTokenExpiryInfo(token);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert ();
+        }
+
+        expiry = retrievedExpiry;
+    }
+
+    function getTokenKeyPublic(address token, uint keyType) public returns (IHederaTokenService.KeyValue memory) {
+        (int responseCode, IHederaTokenService.KeyValue memory  key) = HederaTokenService.getTokenKey(token, keyType);
+        //"(bool,address,bytes,bytes,address)";
+
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert();
+        }
+
+        return key;
+    }
+
+    function htsGetApproved(address token, uint256 serialNumber) public returns (address approved) {
+        int _responseCode;
+        (_responseCode, approved) = HederaTokenService.getApproved(token, serialNumber);
+    }
+
+    function htsAllowance(address token, address owner, address spender) public returns (uint256 amount){
+        int _responseCode;
+        (_responseCode, amount) = HederaTokenService.allowance(token, owner, spender);
+    }
+
+    function htsIsApprovedForAll(address token, address owner, address operator) public returns (bool approved) {
+        int _responseCode;
+        (_responseCode, approved) = HederaTokenService.isApprovedForAll(token, owner, operator);
+    }
+
+    function callMissingPrecompile() public returns (bool success, bytes memory result) {
+        (success, result) = address(0x167).call(
+            abi.encodeWithSignature("fakeSignature()"));
+        require(success);
+    }
+
+    function hrcIsAssociated(address token) public returns (bool isAssociated) {
+        isAssociated = IHRC(token).isAssociated();
+    }
+}
+
+interface IHRC {
+    function isAssociated() external returns (bool associated);
+}


### PR DESCRIPTION
**Description**:
This Pr refactors `ContractCallServicePrecompileHistoricalTest` to use the web3j plugin.

This PR modifies:
`ContractCallServicePrecompileHistoricalTest` - refactor all methods to use the web3j plugin
`AbstractContractCallServiceTest` - extracted some common methods in it.
Added the solidity contract `PrecompileTestContractHistorical`.sol to solidity_historical folder

**Related issue(s)**:

Fixes #9072 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
