### PR TITLE
Deploy v0.113.0-rc1 to performance and mainnet-staging

### DIFF
--- a/clusters/mainnet-staging-na/common/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/common/helmrelease.yaml
@@ -10,14 +10,14 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: hedera-mirror-node
-      version: '0.112.1-rc1'
+      version: '0.113.0-rc1'
   dependsOn:
     - name: testkube
       namespace: testkube
   driftDetection:
-    mode: warn
+    mode: enabled
     ignore:
-      - paths: [ "" ]
+      - paths: [""]
         target:
           kind: (MutatingWebhookConfiguration|SGConfig|ValidatingWebhookConfiguration)
   install:

--- a/clusters/mainnet-staging-na/mainnet/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet/helmrelease.yaml
@@ -13,14 +13,14 @@ spec:
       valuesFiles:
         - values.yaml
         - values-prod.yaml
-      version: '0.112.1-rc1'
+      version: '0.113.0-rc1'
   dependsOn:
     - name: mirror
       namespace: common
   driftDetection:
-    mode: warn
+    mode: enabled
     ignore:
-      - paths: [ "" ]
+      - paths: [""]
         target:
           kind: (MutatingWebhookConfiguration|SGConfig|ValidatingWebhookConfiguration)
   install:

--- a/clusters/preprod/common/helmrelease.yaml
+++ b/clusters/preprod/common/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: hedera-mirror-node
-      version: '0.112.0-rc2'
+      version: '0.113.0-rc1'
   dependsOn:
     - name: testkube
       namespace: testkube

--- a/clusters/preprod/performance-citus/helmrelease.yaml
+++ b/clusters/preprod/performance-citus/helmrelease.yaml
@@ -14,12 +14,12 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.112.0-rc2'
+      version: '0.113.0-rc1'
   dependsOn:
     - name: mirror
       namespace: common
   driftDetection:
-    mode: warn
+    mode: enabled
   install:
     crds: CreateReplace
   interval: 90s
@@ -41,7 +41,6 @@ spec:
     importer:
       env:
         HEDERA_MIRROR_IMPORTER_NETWORK: "OTHER"
-        HEDERA_MIRROR_IMPORTER_PARSER_RECORD_ENTITY_PERSIST_ENTITYTRANSACTIONS: "false"
         HEDERA_MIRROR_IMPORTER_PARSER_RECORD_SIDECAR_ENABLED: "true"
     monitor:
       env:
@@ -57,7 +56,7 @@ spec:
       monitor:
         enabled: false
     test:
-      enabled: true
+      enabled: false
       config:
         hedera:
           mirror:

--- a/clusters/preprod/performance/helmrelease.yaml
+++ b/clusters/preprod/performance/helmrelease.yaml
@@ -13,12 +13,12 @@ spec:
       valuesFiles:
         - values.yaml
         - values-prod.yaml
-      version: '0.112.0-rc2'
+      version: '0.113.0-rc1'
   dependsOn:
     - name: mirror
       namespace: common
   driftDetection:
-    mode: warn
+    mode: enabled
   install:
     crds: CreateReplace
   interval: 90s
@@ -40,8 +40,6 @@ spec:
     importer:
       env:
         HEDERA_MIRROR_IMPORTER_NETWORK: "OTHER"
-        HEDERA_MIRROR_IMPORTER_PARSER_RECORD_BATCH_QUEUECAPACITY: "10"
-        HEDERA_MIRROR_IMPORTER_PARSER_RECORD_FREQUENCY: "20ms"
         HEDERA_MIRROR_IMPORTER_PARSER_RECORD_SIDECAR_ENABLED: "true"
     monitor:
       env:


### PR DESCRIPTION
**Description**:

* Deploy v0.113.0-rc1 to performance and performance-citus
* Deploy v0.113.0-rc1 to mainnet-staging v1 only
* Disable acceptance tests in performance-citus to match performance
* Enable drift detection in performance and mainnet-staging
* Remove some configuration that is now the default on main/tag

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
