### PR TITLE
Remove duplicated methods by introducing factories

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -281,10 +281,10 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
             final Boolean inheritAccountKey,
             final String contractId,
             final byte[] ed25519,
-            final byte[] ECDSA_secp256k1,
+            final byte[] ecdsaSecp256K1,
             final String delegatableContractId) {
         return keyValueFactory.getInstance(
-                inheritAccountKey, contractId, ed25519, ECDSA_secp256k1, delegatableContractId);
+                inheritAccountKey, contractId, ed25519, ecdsaSecp256K1, delegatableContractId);
     }
 
     protected <T> T getKeyValueForType(final KeyValueType keyValueType, String contractAddress) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/ContractCallTestUtil.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/ContractCallTestUtil.java
@@ -20,7 +20,6 @@ import static com.hedera.node.app.service.evm.utils.EthSigsUtils.recoverAddressF
 
 import com.google.protobuf.ByteString;
 import com.hederahashgraph.api.proto.java.Key;
-import java.util.Arrays;
 import java.util.function.ToLongFunction;
 import lombok.experimental.UtilityClass;
 import org.apache.tuweni.bytes.Bytes;
@@ -57,22 +56,24 @@ public class ContractCallTestUtil {
         58, 33, -52, -44, -10, 81, 99, 100, 6, -8, -94, -87, -112, 42, 42, 96, 75, -31, -5, 72, 13, -70, 101, -111, -1,
         77, -103, 47, -118, 107, -58, -85, -63, 55, -57
     };
-    public static final byte[] ECDSA_KEY = Arrays.copyOfRange(KEY_PROTO, 2, KEY_PROTO.length);
-    public static final Key KEY_WITH_ECDSA_TYPE =
-            Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(ECDSA_KEY)).build();
-    public static final byte[] ED25519_KEY = Arrays.copyOfRange(KEY_PROTO, 2, KEY_PROTO.length);
-    public static final Key KEY_WITH_ED_25519_TYPE =
-            Key.newBuilder().setEd25519(ByteString.copyFrom(ED25519_KEY)).build();
 
-    public static final byte[] NEW_ECDSA_KEY = new byte[] {
+    public static final byte[] ECDSA_KEY = new byte[] {
         2, 64, 59, -126, 81, -22, 0, 35, 67, -70, 110, 96, 109, 2, -8, 111, -112, -100, -87, -85, 66, 36, 37, -97, 19,
         68, -87, -110, -13, -115, 74, 86, 90
     };
 
-    public static final byte[] NEW_ED25519_KEY = new byte[] {
+    public static final byte[] ED25519_KEY = new byte[] {
         -128, -61, -12, 63, 3, -45, 108, 34, 61, -2, -83, -48, -118, 20, 84, 85, 85, 67, -125, 46, 49, 26, 17, -116, 27,
         25, 38, -95, 50, 77, 40, -38
     };
+
+    public static final Key KEY_WITH_ECDSA_TYPE =
+            Key.newBuilder().setECDSASecp256K1(ByteString.copyFrom(ECDSA_KEY)).build();
+    public static final Key KEY_WITH_ED_25519_TYPE =
+            Key.newBuilder().setEd25519(ByteString.copyFrom(ED25519_KEY)).build();
+
+    public static final long DEFAULT_TOKEN_EXPIRATION_SECONDS = 4_000_000_000L;
+    public static final long DEFAULT_TOKEN_EXPIRATION_PERIOD = 8_000_000L;
 
     public static final long EVM_V_34_BLOCK = 50L;
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/ExpiryFactory.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/ExpiryFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.utils;
+
+import java.lang.reflect.Constructor;
+import java.math.BigInteger;
+
+public class ExpiryFactory {
+
+    private static final String INNER_CLASS_NAME = "Expiry";
+    private static Class classType;
+    private static Constructor constructor;
+
+    public ExpiryFactory(final Class thatClassType) {
+        classType = thatClassType;
+    }
+
+    public <T> T getInstance(final BigInteger second, final String autoRenewAccount, final BigInteger autoRenewPeriod) {
+        try {
+            Class<?> innerClass;
+            for (Class<?> declaredClass : classType.getDeclaredClasses()) {
+                if (declaredClass.getSimpleName().equals(INNER_CLASS_NAME)) {
+                    innerClass = declaredClass;
+                    constructor = innerClass.getConstructor(BigInteger.class, String.class, BigInteger.class);
+                    break;
+                }
+            }
+
+            // Use reflection to create a new instance of the Expiry class
+            return (T) constructor.newInstance(second, autoRenewAccount, autoRenewPeriod);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to instantiate Expiry class", e);
+        }
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/HederaTokenFactory.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/HederaTokenFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.utils;
+
+import java.lang.reflect.Constructor;
+import java.math.BigInteger;
+import java.util.List;
+
+public class HederaTokenFactory {
+
+    private static final String INNER_CLASS_NAME = "HederaToken";
+    private static final String HELPER_CLASS_NAME = "Expiry";
+    private static Class classType;
+    private static Constructor constructor;
+
+    public HederaTokenFactory(final Class thatClassType) {
+        classType = thatClassType;
+    }
+
+    public <T, U, V> T getInstance(
+            final String name,
+            final String symbol,
+            final String treasury,
+            final String memo,
+            final Boolean tokenSupplyType,
+            final BigInteger maxSupply,
+            final Boolean freezeDefault,
+            final List<U> tokenKeys,
+            V expiry) {
+        try {
+            Class<?> innerClassExpiry = null;
+            for (Class<?> declaredClass : classType.getDeclaredClasses()) {
+                if (declaredClass.getSimpleName().equals(HELPER_CLASS_NAME)) {
+                    innerClassExpiry = declaredClass;
+                    break;
+                }
+            }
+
+            Class<?> innerClassTokenKey;
+            for (Class<?> declaredClass : classType.getDeclaredClasses()) {
+                if (declaredClass.getSimpleName().equals(INNER_CLASS_NAME)) {
+                    innerClassTokenKey = declaredClass;
+                    constructor = innerClassTokenKey.getConstructor(
+                            String.class,
+                            String.class,
+                            String.class,
+                            String.class,
+                            Boolean.class,
+                            BigInteger.class,
+                            Boolean.class,
+                            List.class,
+                            innerClassExpiry);
+                    break;
+                }
+            }
+
+            return (T) constructor.newInstance(
+                    name, symbol, treasury, memo, tokenSupplyType, maxSupply, freezeDefault, tokenKeys, expiry);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to instantiate Expiry class", e);
+        }
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/KeyValueFactory.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/KeyValueFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.utils;
+
+import java.lang.reflect.Constructor;
+
+public class KeyValueFactory {
+
+    private static final String INNER_CLASS_NAME = "KeyValue";
+    private static Class classType;
+    private static Constructor constructor;
+
+    public KeyValueFactory(final Class thatClassType) {
+        classType = thatClassType;
+    }
+
+    public <T> T getInstance(
+            final Boolean inheritAccountKey,
+            final String contractId,
+            final byte[] ed25519,
+            final byte[] ECDSA_secp256k1,
+            final String delegatableContractId) {
+        try {
+            Class<?> innerClass;
+            for (Class<?> declaredClass : classType.getDeclaredClasses()) {
+                if (declaredClass.getSimpleName().equals(INNER_CLASS_NAME)) {
+                    innerClass = declaredClass;
+                    constructor = innerClass.getConstructor(
+                            Boolean.class, String.class, byte[].class, byte[].class, String.class);
+                    break;
+                }
+            }
+
+            return (T) constructor.newInstance(
+                    inheritAccountKey, contractId, ed25519, ECDSA_secp256k1, delegatableContractId);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to instantiate Expiry class", e);
+        }
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/KeyValueFactory.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/KeyValueFactory.java
@@ -32,7 +32,7 @@ public class KeyValueFactory {
             final Boolean inheritAccountKey,
             final String contractId,
             final byte[] ed25519,
-            final byte[] ECDSA_secp256k1,
+            final byte[] ecdsaSecp256K1,
             final String delegatableContractId) {
         try {
             Class<?> innerClass;
@@ -46,7 +46,7 @@ public class KeyValueFactory {
             }
 
             return (T) constructor.newInstance(
-                    inheritAccountKey, contractId, ed25519, ECDSA_secp256k1, delegatableContractId);
+                    inheritAccountKey, contractId, ed25519, ecdsaSecp256K1, delegatableContractId);
         } catch (Exception e) {
             throw new RuntimeException("Unable to instantiate Expiry class", e);
         }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/TokenKeyFactory.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/TokenKeyFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.utils;
+
+import java.lang.reflect.Constructor;
+import java.math.BigInteger;
+
+public class TokenKeyFactory {
+
+    private static final String INNER_CLASS_NAME = "TokenKey";
+    private static final String HELPER_CLASS_NAME = "KeyValue";
+    private static Class classType;
+    private static Constructor constructor;
+
+    public TokenKeyFactory(final Class thatClassType) {
+        classType = thatClassType;
+    }
+
+    public <T, U> T getInstance(final BigInteger keyType, final U keyValue) {
+        try {
+            Class<?> innerClassKeyValue = null;
+            for (Class<?> declaredClass : classType.getDeclaredClasses()) {
+                if (declaredClass.getSimpleName().equals(HELPER_CLASS_NAME)) {
+                    innerClassKeyValue = declaredClass;
+                    break;
+                }
+            }
+
+            Class<?> innerClassTokenKey;
+            for (Class<?> declaredClass : classType.getDeclaredClasses()) {
+                if (declaredClass.getSimpleName().equals(INNER_CLASS_NAME)) {
+                    innerClassTokenKey = declaredClass;
+                    constructor = innerClassTokenKey.getConstructor(BigInteger.class, innerClassKeyValue);
+                    break;
+                }
+            }
+
+            return (T) constructor.newInstance(keyType, keyValue);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to instantiate Expiry class", e);
+        }
+    }
+}


### PR DESCRIPTION
**Description**:
The `web3j` library generates a lot of duplicated inner classes due to the same imports in multiple contracts. Example for these classes are: `TokenKey`, `HederaToken`, `Expiry`, `KeyValue`. With the current implementation there are a lot of helper methods that construct object for these classes and they are duplicated because of the return type, e.g. `ModificationPrecompileTestContract.Expiry`, `NestedCalls.Expiry`, etc. This PR aims to introduce factories that return the correct type depending of the caller class. Now the duplicated methods are removed and there are new common generic methods in the parent abstract class. The execution time of the integration tests remains the same after the refactoring in this PR.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/9222

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
