### PR TITLE
Fix error on calls with value with not existing sender alias

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorImpl.java
@@ -97,8 +97,15 @@ public class MirrorEvmTxProcessorImpl extends HederaEvmTxProcessor implements Mi
         store.wrap();
         if (store.getAccount(params.getSender().canonicalAddress(), OnMissing.DONT_THROW)
                 .isEmptyAccount()) {
-            final var senderAccount =
-                    Account.getDummySenderAccount(params.getSender().canonicalAddress());
+
+            final Account senderAccount;
+            if (isMirror(params.getSender().canonicalAddress())) {
+                senderAccount = Account.getDummySenderAccount(params.getSender().canonicalAddress());
+            } else {
+                senderAccount = Account.getDummySenderAccountWithAlias(
+                        params.getSender().canonicalAddress());
+            }
+
             store.updateAccount(senderAccount);
         }
         Address receiverAddress = determineReceiverAddress(params.getReceiver());
@@ -165,5 +172,9 @@ public class MirrorEvmTxProcessorImpl extends HederaEvmTxProcessor implements Mi
         } else {
             return canonical;
         }
+    }
+
+    private boolean isMirror(final Address address) {
+        return address == null || address.equals(Address.ZERO) || aliasManager.isMirror(address);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
@@ -39,12 +39,9 @@ import org.hyperledger.besu.datatypes.Address;
  * This model is used as a value in a special state (CachingStateFrame), used for speculative write operations. Object
  * immutability is required for this model in order to be used seamlessly in the state.
  * <p>
- * Differences with the original:
- * 1. Removed fields like memo, key, isReceiverSigRequired, isSmartContract
- * 2. Added field accountAddress for convenience
- * 3. Changed collection types to SortedMap and SortedSet
- * 4. Added constructors and set methods for creating new instances and achieve immutability
- * 6. Added factory method that returns empty instance
+ * Differences with the original: 1. Removed fields like memo, key, isReceiverSigRequired, isSmartContract 2. Added
+ * field accountAddress for convenience 3. Changed collection types to SortedMap and SortedSet 4. Added constructors and
+ * set methods for creating new instances and achieve immutability 6. Added factory method that returns empty instance
  * 7. Added isEmptyAccount() method
  */
 @Getter
@@ -146,8 +143,8 @@ public class Account extends HederaEvmAccount {
     }
 
     /**
-     * Create a partial account with only ID and balance values.
-     * Used for treasury accounts as those are the only fields we need.
+     * Create a partial account with only ID and balance values. Used for treasury accounts as those are the only fields
+     * we need.
      */
     public Account(Long entityId, Id id, long balance) {
         this(
@@ -175,8 +172,8 @@ public class Account extends HederaEvmAccount {
     }
 
     /**
-     * Create a partial account with only alias, ID and balance values.
-     * Used for treasury accounts as those are the only fields we need.
+     * Create a partial account with only alias, ID and balance values. Used for treasury accounts as those are the only
+     * fields we need.
      */
     public Account(ByteString alias, Long entityId, Id id, long balance) {
         this(
@@ -212,6 +209,14 @@ public class Account extends HederaEvmAccount {
                 0L, Id.fromGrpcAccount(EntityIdUtils.accountIdFromEvmAddress(senderAddress)), Long.MAX_VALUE);
     }
 
+    public static Account getDummySenderAccountWithAlias(Address senderAddress) {
+        return new Account(
+                ByteString.copyFrom(senderAddress.toArray()),
+                0L,
+                Id.fromGrpcAccount(EntityIdUtils.accountIdFromEvmAddress(senderAddress)),
+                Long.MAX_VALUE);
+    }
+
     public Account autoAssociate() {
         final int updatedNumAssociations = getNumAssociations() + 1;
         return toBuilder()
@@ -232,8 +237,16 @@ public class Account extends HederaEvmAccount {
         return balance != null && balance.get() != null ? balance.get() : 0L;
     }
 
+    public Account setBalance(long balance) {
+        return toBuilder().balance(() -> balance).build();
+    }
+
     public Long getOwnedNfts() {
         return ownedNfts != null ? ownedNfts.get() : 0L;
+    }
+
+    public Account setOwnedNfts(long newOwnedNfts) {
+        return toBuilder().ownedNfts(() -> newOwnedNfts).build();
     }
 
     public SortedMap<EntityNum, Long> getCryptoAllowances() {
@@ -244,16 +257,34 @@ public class Account extends HederaEvmAccount {
         return fungibleTokenAllowances != null ? fungibleTokenAllowances.get() : Collections.emptySortedMap();
     }
 
+    public Account setFungibleTokenAllowances(SortedMap<FcTokenAllowanceId, Long> fungibleTokenAllowances) {
+        return toBuilder()
+                .fungibleTokenAllowances(() -> fungibleTokenAllowances)
+                .build();
+    }
+
     public SortedSet<FcTokenAllowanceId> getApproveForAllNfts() {
         return approveForAllNfts != null ? approveForAllNfts.get() : Collections.emptySortedSet();
+    }
+
+    public Account setApproveForAllNfts(SortedSet<FcTokenAllowanceId> approveForAllNfts) {
+        return toBuilder().approveForAllNfts(() -> approveForAllNfts).build();
     }
 
     public Integer getNumAssociations() {
         return numAssociations != null ? numAssociations.get() : 0;
     }
 
+    public Account setNumAssociations(int numAssociations) {
+        return toBuilder().numAssociations(() -> numAssociations).build();
+    }
+
     public Integer getNumPositiveBalances() {
         return numPositiveBalances != null ? numPositiveBalances.get() : 0;
+    }
+
+    public Account setNumPositiveBalances(int newNumPositiveBalances) {
+        return toBuilder().numPositiveBalances(() -> newNumPositiveBalances).build();
     }
 
     public boolean isAutoAssociateEnabled() {
@@ -262,14 +293,6 @@ public class Account extends HederaEvmAccount {
 
     public boolean isEmptyAccount() {
         return this.equals(getEmptyAccount());
-    }
-
-    public Account setApproveForAllNfts(SortedSet<FcTokenAllowanceId> approveForAllNfts) {
-        return toBuilder().approveForAllNfts(() -> approveForAllNfts).build();
-    }
-
-    public Account setBalance(long balance) {
-        return toBuilder().balance(() -> balance).build();
     }
 
     public Account setCryptoAllowance(SortedMap<EntityNum, Long> cryptoAllowances) {
@@ -284,12 +307,6 @@ public class Account extends HederaEvmAccount {
         return toBuilder().expiry(expiry).build();
     }
 
-    public Account setFungibleTokenAllowances(SortedMap<FcTokenAllowanceId, Long> fungibleTokenAllowances) {
-        return toBuilder()
-                .fungibleTokenAllowances(() -> fungibleTokenAllowances)
-                .build();
-    }
-
     public Account setIsSmartContract(boolean isSmartContract) {
         return toBuilder().isSmartContract(isSmartContract).build();
     }
@@ -298,20 +315,8 @@ public class Account extends HederaEvmAccount {
         return toBuilder().maxAutoAssociations(maxAutoAssociations).build();
     }
 
-    public Account setNumAssociations(int numAssociations) {
-        return toBuilder().numAssociations(() -> numAssociations).build();
-    }
-
     public Account setNumTreasuryTitles(int numTreasuryTitles) {
         return toBuilder().numTreasuryTitles(numTreasuryTitles).build();
-    }
-
-    public Account setNumPositiveBalances(int newNumPositiveBalances) {
-        return toBuilder().numPositiveBalances(() -> newNumPositiveBalances).build();
-    }
-
-    public Account setOwnedNfts(long newOwnedNfts) {
-        return toBuilder().ownedNfts(() -> newOwnedNfts).build();
     }
 
     public Account setUsedAutoAssociations(int usedCount) {
@@ -321,8 +326,12 @@ public class Account extends HederaEvmAccount {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Account account = (Account) o;
         return getExpiry() == account.getExpiry()
                 && isDeleted() == account.isDeleted()

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/store/models/Account.java
@@ -41,8 +41,8 @@ import org.hyperledger.besu.datatypes.Address;
  * <p>
  * Differences with the original: 1. Removed fields like memo, key, isReceiverSigRequired, isSmartContract 2. Added
  * field accountAddress for convenience 3. Changed collection types to SortedMap and SortedSet 4. Added constructors and
- * set methods for creating new instances and achieve immutability 6. Added factory method that returns empty instance
- * 7. Added isEmptyAccount() method
+ * set methods for creating new instances and achieve immutability 5. Added factory method that returns empty instance
+ * 6. Added isEmptyAccount() method
  */
 @Getter
 public class Account extends HederaEvmAccount {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -81,6 +81,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -229,7 +230,7 @@ class MirrorEvmTxProcessorTest {
     }
 
     @ParameterizedTest
-    @MethodSource("provideIsEstimateParameters")
+    @ValueSource(booleans = {true, false})
     void assertSuccessExecutionWithNotExistingSenderAlias(boolean isEstimate) {
         givenValidMockWithoutGetOrCreate();
         when(evmProperties.getSemanticEvmVersion()).thenReturn(EVM_VERSION);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmTxProcessorTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.web3.evm.contracts.execution;
 
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_30;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_34;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_38;
@@ -27,6 +28,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.protobuf.ByteString;
 import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.evm.account.MirrorEvmContractAliases;
@@ -87,11 +89,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class MirrorEvmTxProcessorTest {
 
     private static final int MAX_STACK_SIZE = 1024;
+    private static final String EVM_ADDRESS = "0x6b175474e89094c44da98b954eedeac495271d0f";
+    private static final String FUNCTION_HASH = "0x8070450f";
     private final HederaEvmAccount sender = new HederaEvmAccount(Address.ALTBN128_ADD);
     private final HederaEvmAccount receiver = new HederaEvmAccount(Address.ALTBN128_MUL);
     private final Address receiverAddress = receiver.canonicalAddress();
     private final Address nativePrecompileAddress = Address.SHA256;
     private final Address invalidNativePrecompileAddress = Address.BLS12_G1MUL;
+    private HederaEvmAccount senderWithAlias;
 
     @Mock
     private PricesAndFeesProvider pricesAndFeesProvider;
@@ -136,14 +141,17 @@ class MirrorEvmTxProcessorTest {
     private TokenAccessor tokenAccessor;
 
     private MirrorEvmTxProcessorImpl mirrorEvmTxProcessor;
-
     private SemanticVersion mcpVersion;
     private SemanticVersion ccpVersion;
-    private static final String FUNCTION_HASH = "0x8070450f";
+
+    static Stream<Arguments> provideIsEstimateParameters() {
+        return Stream.of(Arguments.of(true), Arguments.of(false));
+    }
 
     @BeforeEach
     void setup() {
         setupGasCalculator();
+        setupSenderWithAlias();
         final var operationRegistry = new OperationRegistry();
         MainnetEVMs.registerShanghaiOperations(operationRegistry, gasCalculator, BigInteger.ZERO);
         operations.forEach(operationRegistry::put);
@@ -165,11 +173,17 @@ class MirrorEvmTxProcessorTest {
                 () -> {
                     mcpVersion = EVM_VERSION_0_38;
                     return new MessageCallProcessor(v38, new PrecompileContractRegistry());
+                },
+                EVM_VERSION,
+                () -> {
+                    mcpVersion = EVM_VERSION;
+                    return new MessageCallProcessor(v38, new PrecompileContractRegistry());
                 });
         Map<SemanticVersion, Provider<ContractCreationProcessor>> processorsMap = Map.of(
                 EVM_VERSION_0_30, () -> new ContractCreationProcessor(gasCalculator, v30, true, List.of(), 1),
                 EVM_VERSION_0_34, () -> new ContractCreationProcessor(gasCalculator, v34, true, List.of(), 1),
-                EVM_VERSION_0_38, () -> new ContractCreationProcessor(gasCalculator, v38, true, List.of(), 1));
+                EVM_VERSION_0_38, () -> new ContractCreationProcessor(gasCalculator, v38, true, List.of(), 1),
+                EVM_VERSION, () -> new ContractCreationProcessor(gasCalculator, v38, true, List.of(), 1));
 
         mirrorEvmTxProcessor = new MirrorEvmTxProcessorImpl(
                 worldState,
@@ -199,6 +213,32 @@ class MirrorEvmTxProcessorTest {
 
         final var params = ContractExecutionParameters.builder()
                 .sender(sender)
+                .receiver(receiver.canonicalAddress())
+                .gas(33_333L)
+                .value(1234L)
+                .callData(Bytes.EMPTY)
+                .isStatic(true)
+                .isEstimate(isEstimate)
+                .build();
+        final var result = ContractCallContext.run(ignored -> mirrorEvmTxProcessor.execute(params, params.getGas()));
+
+        assertThat(result)
+                .isNotNull()
+                .returns(true, HederaEvmTransactionProcessingResult::isSuccessful)
+                .returns(receiver.canonicalAddress(), r -> r.getRecipient().orElseThrow());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideIsEstimateParameters")
+    void assertSuccessExecutionWithNotExistingSenderAlias(boolean isEstimate) {
+        givenValidMockWithoutGetOrCreate();
+        when(evmProperties.getSemanticEvmVersion()).thenReturn(EVM_VERSION);
+        given(hederaEvmContractAliases.resolveForEvm(receiverAddress)).willReturn(receiverAddress);
+        given(pricesAndFeesProvider.currentGasPrice(any(), any())).willReturn(10L);
+        given(store.getAccount(sender.canonicalAddress(), OnMissing.DONT_THROW)).willReturn(Account.getEmptyAccount());
+
+        final var params = ContractExecutionParameters.builder()
+                .sender(senderWithAlias)
                 .receiver(receiver.canonicalAddress())
                 .gas(33_333L)
                 .value(1234L)
@@ -363,7 +403,8 @@ class MirrorEvmTxProcessorTest {
         given(gasCalculator.getZeroTierGasCost()).willReturn(0L);
     }
 
-    static Stream<Arguments> provideIsEstimateParameters() {
-        return Stream.of(Arguments.of(true), Arguments.of(false));
+    private void setupSenderWithAlias() {
+        senderWithAlias = new HederaEvmAccount(Address.ALTBN128_ADD);
+        senderWithAlias.setAlias(ByteString.copyFrom(EVM_ADDRESS.getBytes()));
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -436,6 +436,23 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
     }
 
     @Test
+    void ethCallWithValueAndNotExistingSenderAlias() {
+        // Given
+        final var receiverEntity = accountPersist();
+        final var receiverAddress = getAliasAddressFromEntity(receiverEntity);
+        final var notExistingSenderAlias = Address.fromHexString("0x6b175474e89094c44da98b954eedeac495271d0f");
+        final var serviceParameters =
+                getContractExecutionParametersWithValue(Bytes.EMPTY, notExistingSenderAlias, receiverAddress, 10L);
+
+        // When
+        final var result = contractExecutionService.processCall(serviceParameters);
+
+        // Then
+        assertThat(result).isEqualTo(HEX_PREFIX);
+        assertGasLimit(serviceParameters);
+    }
+
+    @Test
     void invalidFunctionSig() {
         // Given
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ERROR);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/AccountTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/store/models/AccountTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 class AccountTest {
     private static final byte[] mockCreate2Addr = unhex("aaaaaaaaaaaaaaaaaaaaaaaa9abcdefabcdefbbb");
+    private final Address testAlias = Address.fromHexString("0x6aF23eBbA9CbEd6A6a8cA16a6f9C8FAf7E8d8c90");
     private final long miscAccountNum = 12345;
     private final Id subjectId = new Id(0, 0, miscAccountNum);
     private final int numAssociations = 3;
@@ -158,6 +159,12 @@ class AccountTest {
                 .isTrue();
         assertThat(Account.getEmptyAccount().setMaxAutoAssociations(-1).isAutoAssociateEnabled())
                 .isTrue();
+    }
+
+    @Test
+    void getDummySenderWithAliasAsExpected() {
+        assertThat(Account.getDummySenderAccountWithAlias(testAlias).getAlias())
+                .isEqualTo(ByteString.copyFrom(testAlias.toArray()));
     }
 
     @Test


### PR DESCRIPTION
**Description**:
This PR aims to fix null error when a contract call is made with value and evm address as a sender. Where the evm address is not existing.

Couple of scenarios:

Currently when an empty from is passed. 
We are creating an Account.getDummySenderAccount(). that does not have alias

If the from is a not existing long zero address
We are creating an Account.getDummySenderAccount(long zero address) from it without alias.

**In the cases where evm address alias was passed as a from parameter. We were still creating a dummy account without alias. And subsequent account retrievals by alias were returning null causing the error since we did not create the account with that alias.**

**This pr adds a check.
Check if the from is an evm canonical address. Create the dummy account with that alias.
Otherwise create the dummy account as before without alias.**



This PR modifies:
`MirrorEvmTxProcessorImpl` - add a check to see is the from address is not existing and also a canonical evm address and it it is creates the dummy account with that alias.

`Account`.java - created new methods that creates dummy account with and alias

`MirrorEvmTxProcessorTest` - adds a test case for the error scenario.

`ContractCallServiceTest` - adds a test case for the error scenario.


**Related issue(s)**:

Fixes #9301

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
