### PR TITLE
Fix Stackgres PostgreSQL version (0.113)

### DIFF
--- a/charts/hedera-mirror/templates/stackgres/stackgres-config-coordinator.yaml
+++ b/charts/hedera-mirror/templates/stackgres/stackgres-config-coordinator.yaml
@@ -7,5 +7,5 @@ metadata:
   namespace: {{ include "hedera-mirror.namespace" . }}
 spec:
   postgresql.conf: {{ tpl (toYaml .Values.stackgres.coordinator.config) . | nindent 4 }}
-  postgresVersion: {{ .Values.stackgres.postgresVersion | quote }}
+  postgresVersion: {{ mustRegexReplaceAll "^(\\d+)(\\.\\d+)+" .Values.stackgres.postgresVersion "${1}" | quote }}
 {{- end -}}

--- a/charts/hedera-mirror/templates/stackgres/stackgres-config-worker.yaml
+++ b/charts/hedera-mirror/templates/stackgres/stackgres-config-worker.yaml
@@ -7,5 +7,5 @@ metadata:
   namespace: {{ include "hedera-mirror.namespace" . }}
 spec:
   postgresql.conf: {{ tpl (toYaml .Values.stackgres.worker.config) . | nindent 4 }}
-  postgresVersion: {{ .Values.stackgres.postgresVersion | quote }}
+  postgresVersion: {{ mustRegexReplaceAll "^(\\d+)(\\.\\d+)+" .Values.stackgres.postgresVersion "${1}" | quote }}
 {{- end -}}

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -327,7 +327,7 @@ stackgres:
       version: "1.6"
   nameOverride: citus
   podAntiAffinity: true
-  postgresVersion: 16
+  postgresVersion: "16.2"
   worker:
     config:
       autovacuum_max_workers: "2"

--- a/docs/runbook/stackgres-upgrade.md
+++ b/docs/runbook/stackgres-upgrade.md
@@ -29,7 +29,8 @@ After successful deployment of the upgraded Stackgres Helm chart, we need to per
    spec:
      maxRetries: 1
      op: securityUpgrade
-     priorityClassName: critical
+     scheduling:
+       priorityClassName: critical
      securityUpgrade:
        method: InPlace
      sgShardedCluster: mirror-citus


### PR DESCRIPTION
**Description**:

Cherry pick of #9312 to `release/0.113`

* Change `stackgres.postgresVersion` from latest `16` to `16.2`
* Fix `priorityClassName` in SGShardedDbOps
* Fix SGPostgresConfig to use major version from `stackgres.postgresVersion`

**Related issue(s)**:

Fixes #9311

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
