### PR TITLE
Disable drift detection in performance

### DIFF
--- a/clusters/preprod/common/helmrelease.yaml
+++ b/clusters/preprod/common/helmrelease.yaml
@@ -92,3 +92,5 @@ spec:
           cloud.google.com/neg: '{ "exposed_ports":{ "443":{"name": "mirrornode-preprod-new"} } }'
     zfs:
       enabled: true
+      worker:
+        initialDiskSize: 1024GB

--- a/clusters/preprod/common/helmrelease.yaml
+++ b/clusters/preprod/common/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: hedera-mirror-node
-      version: '0.113.0-rc1'
+      version: '0.113.1'
   dependsOn:
     - name: testkube
       namespace: testkube

--- a/clusters/preprod/common/helmrelease.yaml
+++ b/clusters/preprod/common/helmrelease.yaml
@@ -92,5 +92,7 @@ spec:
           cloud.google.com/neg: '{ "exposed_ports":{ "443":{"name": "mirrornode-preprod-new"} } }'
     zfs:
       enabled: true
+      coordinator:
+        initialDiskSize: 100GB
       worker:
         initialDiskSize: 1024GB

--- a/clusters/preprod/dev/helmrelease.yaml
+++ b/clusters/preprod/dev/helmrelease.yaml
@@ -62,8 +62,6 @@ spec:
             test:
               acceptance:
                 network: OTHER
-                feature:
-                  rejectToken: false
       enabled: true
     web3:
       env:

--- a/clusters/preprod/performance-citus/helmrelease.yaml
+++ b/clusters/preprod/performance-citus/helmrelease.yaml
@@ -50,6 +50,10 @@ spec:
     rest:
       monitor:
         enabled: false
+    stackgres:
+      worker:
+        persistentVolume:
+          size: 1000Gi
     test:
       enabled: false
       config:

--- a/clusters/preprod/performance-citus/helmrelease.yaml
+++ b/clusters/preprod/performance-citus/helmrelease.yaml
@@ -14,12 +14,12 @@ spec:
         - values.yaml
         - values-prod.yaml
         - values-v2.yml
-      version: '0.113.0-rc1'
+      version: '0.113.1'
   dependsOn:
     - name: mirror
       namespace: common
   driftDetection:
-    mode: enabled
+    mode: warn
   install:
     crds: CreateReplace
   interval: 90s
@@ -33,11 +33,6 @@ spec:
     - kind: Secret
       name: mirror
   values:
-    grpc:
-      resources:
-        requests:
-          cpu: 1000m
-          memory: 1024Mi
     importer:
       env:
         HEDERA_MIRROR_IMPORTER_NETWORK: "OTHER"

--- a/clusters/preprod/performance-citus/helmrelease.yaml
+++ b/clusters/preprod/performance-citus/helmrelease.yaml
@@ -51,6 +51,9 @@ spec:
       monitor:
         enabled: false
     stackgres:
+      coordinator:
+        persistentVolume:
+          size: 96Gi
       worker:
         persistentVolume:
           size: 1000Gi

--- a/clusters/preprod/performance/helmrelease.yaml
+++ b/clusters/preprod/performance/helmrelease.yaml
@@ -13,12 +13,12 @@ spec:
       valuesFiles:
         - values.yaml
         - values-prod.yaml
-      version: '0.113.0-rc1'
+      version: '0.113.1'
   dependsOn:
     - name: mirror
       namespace: common
   driftDetection:
-    mode: enabled
+    mode: warn
   install:
     crds: CreateReplace
   interval: 90s
@@ -32,11 +32,6 @@ spec:
     - kind: Secret
       name: mirror
   values:
-    grpc:
-      resources:
-        requests:
-          cpu: 1000m
-          memory: 1024Mi
     importer:
       env:
         HEDERA_MIRROR_IMPORTER_NETWORK: "OTHER"

--- a/clusters/preprod/staging-council/helmrelease.yaml
+++ b/clusters/preprod/staging-council/helmrelease.yaml
@@ -61,8 +61,6 @@ spec:
             test:
               acceptance:
                 network: OTHER
-                feature:
-                  rejectToken: false
       enabled: true
     web3:
       env:


### PR DESCRIPTION
**Description**:

* Bump performance to v0.113.1
* Disable drift detection in performance so reset works properly
* Remove grpc resource overrides that are now in 0.113
* Reduce initial disk size and pv size for citus

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
