### PR TITLE
Bump express from 4.20.0 to 4.21.0

### DIFF
--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -50,7 +50,7 @@
         "asn1js": "^3.0.5",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
-        "express": "^4.20.0",
+        "express": "^4.21.0",
         "express-http-context": "^1.2.4",
         "express-openapi-validator": "^5.3.5",
         "extend": "^3.0.2",
@@ -344,18 +344,18 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.649.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.649.0.tgz",
-      "integrity": "sha512-eM65Q2rz/5mGkxOtUrceboe6iru5TEii3n3kfD48MPRVF6OF2x+Wyj1w+tuYIkUXemEi5lm5EEmupMTTkW3hlw==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.650.0.tgz",
+      "integrity": "sha512-6ZfkDu2FMOtYPV1ah5vWMqFKNKEqlBQ3/NOVvLGscU1dR0ybbOwwm4ywWofZmz72uOts5NGqe12kzohb/AsGAA==",
       "inBundle": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.649.0",
-        "@aws-sdk/client-sts": "3.649.0",
+        "@aws-sdk/client-sso-oidc": "3.650.0",
+        "@aws-sdk/client-sts": "3.650.0",
         "@aws-sdk/core": "3.649.0",
-        "@aws-sdk/credential-provider-node": "3.649.0",
+        "@aws-sdk/credential-provider-node": "3.650.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.649.0",
         "@aws-sdk/middleware-expect-continue": "3.649.0",
         "@aws-sdk/middleware-flexible-checksums": "3.649.0",
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.649.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.649.0.tgz",
-      "integrity": "sha512-G6RZhG+yRdIlR069djAN/v4/Vd7CS8SDnUKkw32n7wJfcpoq0t+Lzcdh73kpIJ+/VslKYwMhbE5lCW+9+jDTdw==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.650.0.tgz",
+      "integrity": "sha512-YKm14gCMChD/jlCisFlsVqB8HJujR41bl4Fup2crHwNJxhD/9LTnzwMiVVlBqlXr41Sfa6fSxczX2AMP8NM14A==",
       "inBundle": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -462,15 +462,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.649.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.649.0.tgz",
-      "integrity": "sha512-yaKbOFLk1F1lqAAPUbpoN95pDxgqB/7Rd03yndtV+o3/QLK+etKcgzuIkqGpYycvi6YLYLCxkwPNFEg/NzpW6Q==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.650.0.tgz",
+      "integrity": "sha512-6J7IS0f8ovhvbIAZaynOYP+jPX8344UlTjwHxjaXHgFvI8axu3+NslKtEEV5oHLhgzDvrKbinsu5lgE2n4Sqng==",
       "inBundle": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "3.649.0",
-        "@aws-sdk/credential-provider-node": "3.649.0",
+        "@aws-sdk/credential-provider-node": "3.650.0",
         "@aws-sdk/middleware-host-header": "3.649.0",
         "@aws-sdk/middleware-logger": "3.649.0",
         "@aws-sdk/middleware-recursion-detection": "3.649.0",
@@ -511,20 +511,20 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.649.0"
+        "@aws-sdk/client-sts": "^3.650.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.649.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.649.0.tgz",
-      "integrity": "sha512-aKrLTPpA+Ew4JswWBGtoYT+LiA+uewKyCsYXwJtdjj20TY4qX9/fjJyEt39ETjMGE55UmQcVFUZWL2m9f/aiAg==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.650.0.tgz",
+      "integrity": "sha512-ISK0ZQYA7O5/WYgslpWy956lUBudGC9d7eL0FFbiL0j50N80Gx3RUv22ezvZgxJWE0W3DqNr4CE19sPYn4Lw8g==",
       "inBundle": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.649.0",
+        "@aws-sdk/client-sso-oidc": "3.650.0",
         "@aws-sdk/core": "3.649.0",
-        "@aws-sdk/credential-provider-node": "3.649.0",
+        "@aws-sdk/credential-provider-node": "3.650.0",
         "@aws-sdk/middleware-host-header": "3.649.0",
         "@aws-sdk/middleware-logger": "3.649.0",
         "@aws-sdk/middleware-recursion-detection": "3.649.0",
@@ -622,15 +622,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.649.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.649.0.tgz",
-      "integrity": "sha512-2CcvYEi76gSXsCTb3izRfUpyDWmX+uGhjBckj3Lt6I2Jh+dxF9AEQAoMhvO7LM12Gx8v3w2JEC+GOZOVO4uq/A==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.650.0.tgz",
+      "integrity": "sha512-x2M9buZxIsKuUbuDgkGHhAKYBpn0/rYdKlwuFuOhXyyAcnhvPj0lgNF2KE4ld/GF1mKr7FF/uV3G9lM6PFaYmA==",
       "inBundle": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.649.0",
         "@aws-sdk/credential-provider-http": "3.649.0",
         "@aws-sdk/credential-provider-process": "3.649.0",
-        "@aws-sdk/credential-provider-sso": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.650.0",
         "@aws-sdk/credential-provider-web-identity": "3.649.0",
         "@aws-sdk/types": "3.649.0",
         "@smithy/credential-provider-imds": "^3.2.1",
@@ -643,20 +643,20 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.649.0"
+        "@aws-sdk/client-sts": "^3.650.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.649.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.649.0.tgz",
-      "integrity": "sha512-5g0HhP9DQ3SCvU6pm3yLZz5SUYSL5TP0UGluZN2OMEJG9ZL+tSZSgH21PcEQmpltP0UdS7vvuq++bHv7Bdo9qQ==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.650.0.tgz",
+      "integrity": "sha512-uBra5YjzS/gWSekAogfqJfY6c+oKQkkou7Cjc4d/cpMNvQtF1IBdekJ7NaE1RfsDEz3uH1+Myd07YWZAJo/2Qw==",
       "inBundle": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.649.0",
         "@aws-sdk/credential-provider-http": "3.649.0",
-        "@aws-sdk/credential-provider-ini": "3.649.0",
+        "@aws-sdk/credential-provider-ini": "3.650.0",
         "@aws-sdk/credential-provider-process": "3.649.0",
-        "@aws-sdk/credential-provider-sso": "3.649.0",
+        "@aws-sdk/credential-provider-sso": "3.650.0",
         "@aws-sdk/credential-provider-web-identity": "3.649.0",
         "@aws-sdk/types": "3.649.0",
         "@smithy/credential-provider-imds": "^3.2.1",
@@ -686,12 +686,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.649.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.649.0.tgz",
-      "integrity": "sha512-1Fh0Ov7LAVlrEpZfHwvslzyWhT+FyFA8RnN56pF3rwypm9s/WbINKEJiEcTYCBAvD4b27iSC0AJzzHdEgkdsxA==",
+      "version": "3.650.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.650.0.tgz",
+      "integrity": "sha512-069nkhcwximbvyGiAC6Fr2G+yrG/p1S3NQ5BZ2cMzB1hgUKo6TvgFK7nriYI4ljMQ+UWxqPwIdTqiUmn2iJmhg==",
       "inBundle": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.649.0",
+        "@aws-sdk/client-sso": "3.650.0",
         "@aws-sdk/token-providers": "3.649.0",
         "@aws-sdk/types": "3.649.0",
         "@smithy/property-provider": "^3.1.4",
@@ -3235,21 +3235,21 @@
       }
     },
     "node_modules/@testcontainers/postgresql": {
-      "version": "10.13.0",
-      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-10.13.0.tgz",
-      "integrity": "sha512-wsZHOEkcAA2rszCeq5Jk/46FwjpuQCxx8dT41Ka7Pjk41WP41vgFptXeykQbd8qqIe8V7vaXcbuzprAec58V4g==",
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-10.13.1.tgz",
+      "integrity": "sha512-HAh/3uLAzAhOmzXsOE6hVxkvetczPnX/Zoyt+SgK7QotW98Npr1MDx8OKiaLGTJ8XkIvVvS4Ch6bl+frt4pnkQ==",
       "dev": true,
       "dependencies": {
-        "testcontainers": "^10.13.0"
+        "testcontainers": "^10.13.1"
       }
     },
     "node_modules/@testcontainers/redis": {
-      "version": "10.13.0",
-      "resolved": "https://registry.npmjs.org/@testcontainers/redis/-/redis-10.13.0.tgz",
-      "integrity": "sha512-X53vieFtbjgIZX6oo7M0bt+ow/94uYxEK34NXcdjx/zIH6jTEikXB9RC3GebAXFTJahTJWbyMKAm66XWp2tDhQ==",
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/@testcontainers/redis/-/redis-10.13.1.tgz",
+      "integrity": "sha512-pXg15o4oTRaEyb5xryQZUdePtoRId/+3TeU7vnUgDpqOmRacF8/7zL7jqs13uPh1uea6M7a8MDgHQM8j8kXZUg==",
       "dev": true,
       "dependencies": {
-        "testcontainers": "^10.13.0"
+        "testcontainers": "^10.13.1"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -4466,9 +4466,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.2.tgz",
-      "integrity": "sha512-HZoJwzC+rZ9lqEemTMiO0luOePoGYNBgsLLgegKR/cljiJvcDNhDZQkzC+NC5Oh0aHbdBNSOHpghwMuB5tqhjg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.3.tgz",
+      "integrity": "sha512-FjkNiU3AwTQNQkcxFOmDcCfoN1LjjtU+ofGJh5DymZZLTqdw2i/CzV7G0h3snvh6G8jrWtdmNSgZPH4L2VOAsQ==",
       "dev": true,
       "optional": true
     },
@@ -4483,14 +4483,14 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.2.1.tgz",
-      "integrity": "sha512-YTB47kHwBW9zSG8LD77MIBAAQXjU2WjAkMHeeb7hUplVs6+IoM5I7uEVQNPMB7lj9r8I76UMdoMkGnCodHOLqg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.3.0.tgz",
+      "integrity": "sha512-pVRWciewGUeCyKEuRxwv06M079r+fRjAQjBEK2P6OYGrO43O+Z0LrPZZEjlc4mB6C2RpZ9AxJ1s7NLEtOHO6eA==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "b4a": "^1.6.6",
-        "streamx": "^2.18.0"
+        "streamx": "^2.20.0"
       }
     },
     "node_modules/base64-js": {
@@ -5760,9 +5760,9 @@
       "inBundle": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.19",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.19.tgz",
-      "integrity": "sha512-kpLJJi3zxTR1U828P+LIUDZ5ohixyo68/IcYOHLqnbTPr/wdgn4i1ECvmALN9E16JPA6cvCG5UG79gVwVdEK5w==",
+      "version": "1.5.20",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.20.tgz",
+      "integrity": "sha512-74mdl6Fs1HHzK9SUX4CKFxAtAe3nUns48y79TskHNAG6fGOlLfyKA4j855x+0b5u8rWJIrlaG9tcTPstMlwjIw==",
       "dev": true
     },
     "node_modules/emitter-listener": {
@@ -6490,9 +6490,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.20.0.tgz",
-      "integrity": "sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "inBundle": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -6507,7 +6507,7 @@
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
         "merge-descriptors": "1.0.3",
@@ -6516,11 +6516,11 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.19.0",
-        "serve-static": "1.16.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -6612,21 +6612,6 @@
       "inBundle": true,
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "inBundle": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/express/node_modules/safe-buffer": {
@@ -6851,28 +6836,19 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "inBundle": true,
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
         "statuses": "2.0.1",
         "unpipe": "~1.0.0"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/finalhandler/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "inBundle": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10219,9 +10195,9 @@
       "dev": true
     },
     "node_modules/pump": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.1.tgz",
-      "integrity": "sha512-2ynnAmUu45oUSq51AQbeugLkMSKaz8FqVpZ6ykTqzOVkzXe8u/ezkGsYrFJqKZx+D9cVxoDrSbR7CeAwxFa5cQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -10790,54 +10766,15 @@
       "inBundle": true
     },
     "node_modules/serve-static": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.0.tgz",
-      "integrity": "sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "inBundle": true,
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/serve-static/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "inBundle": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/serve-static/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "inBundle": true
-    },
-    "node_modules/serve-static/node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-      "inBundle": true,
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -11498,15 +11435,6 @@
         }
       }
     },
-    "node_modules/swagger-stats/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "inBundle": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/swagger-stats/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11521,45 +11449,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/swagger-stats/node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-      "inBundle": true,
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/swagger-stats/node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "inBundle": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/swagger-stats/node_modules/send/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "inBundle": true
     },
     "node_modules/swagger-ui-dist": {
       "version": "5.17.14",
@@ -11631,9 +11520,9 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "10.13.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.13.0.tgz",
-      "integrity": "sha512-SDblQvirbJw1ZpenxaAairGtAesw5XMOCHLbRhTTUBJtBkZJGce8Vx/I8lXQxWIM8HRXsg3HILTHGQvYo4x7wQ==",
+      "version": "10.13.1",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.13.1.tgz",
+      "integrity": "sha512-JBbOhxmygj/ouH/47GnoVNt+c55Telh/45IjVxEbDoswsLchVmJiuKiw/eF6lE5i7LN+/99xsrSCttI3YRtirg==",
       "dev": true,
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -26,7 +26,7 @@
     "asn1js": "^3.0.5",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
-    "express": "^4.20.0",
+    "express": "^4.21.0",
     "express-http-context": "^1.2.4",
     "express-openapi-validator": "^5.3.5",
     "extend": "^3.0.2",
@@ -81,7 +81,8 @@
     },
     "micromatch": "^4.0.8",
     "swagger-stats": {
-      "path-to-regexp": "^8.1.0"
+      "path-to-regexp": "^8.1.0",
+      "send": "^0.19.0"
     }
   },
   "bundleDependencies": true


### PR DESCRIPTION
**Description**:

* Bump express from 4.20.0 to 4.21.0
* Bump send from 0.18.0 to 0.19.0

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
