### PR TITLE
Use express body parsers

### DIFF
--- a/hedera-mirror-rest/monitoring/server.js
+++ b/hedera-mirror-rest/monitoring/server.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import bodyParser from 'body-parser';
 import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
@@ -36,11 +35,11 @@ app.disable('x-powered-by');
 app.set('trust proxy', true);
 app.set('port', port);
 app.use(
-  bodyParser.urlencoded({
+  express.urlencoded({
     extended: false,
   })
 );
-app.use(bodyParser.json());
+app.use(express.json());
 app.use(compression());
 app.use(cors());
 

--- a/hedera-mirror-rest/server.js
+++ b/hedera-mirror-rest/server.js
@@ -19,7 +19,6 @@ import express from 'express';
 
 import {createTerminus} from '@godaddy/terminus';
 import {addAsync} from '@awaitjs/express';
-import bodyParser from 'body-parser';
 import cors from 'cors';
 import httpContext from 'express-http-context';
 import fs from 'fs';
@@ -104,11 +103,11 @@ if (isTestEnv()) {
 
 // middleware functions, Prior to v0.5 define after sets
 app.use(
-  bodyParser.urlencoded({
+  express.urlencoded({
     extended: false,
   })
 );
-app.use(bodyParser.json());
+app.use(express.json());
 app.use(cors());
 
 if (config.response.compression) {


### PR DESCRIPTION
**Description**:

Use the built-in express body parsers instead of the deprecated body-parser library

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
