### PR TITLE
Add negative scenarios for historical tests

### DIFF
--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -138,7 +138,7 @@ tasks.register("resolveSolidityHistorical", SolidityResolve::class) {
     group = "historical"
     description = "Resolves the historical solidity version $historicalSolidityVersion"
     sources = fileTree("src/testHistorical/solidity")
-    setAllowPaths(setOf("src/testHistorical/solidity"))
+    allowPaths = setOf("src/testHistorical/solidity")
 
     val packageJsonFile = "./build/node_modules/@openzeppelin/contracts/package.json"
     packageJson = file(packageJsonFile)

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -138,7 +138,7 @@ tasks.register("resolveSolidityHistorical", SolidityResolve::class) {
     group = "historical"
     description = "Resolves the historical solidity version $historicalSolidityVersion"
     sources = fileTree("src/testHistorical/solidity")
-    allowPaths = setOf("src/testHistorical/solidity")
+    setAllowPaths(setOf("src/testHistorical/solidity"))
 
     val packageJsonFile = "./build/node_modules/@openzeppelin/contracts/package.json"
     packageJson = file(packageJsonFile)
@@ -153,6 +153,7 @@ afterEvaluate {
         version = historicalSolidityVersion
         source = fileTree("src/testHistorical/solidity") { include("*.sol") }
         dependsOn("extractContracts")
+        dependsOn("resolveSolidityHistorical")
     }
 }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceHistoricalTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.service;
+
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SENDER_ALIAS;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SENDER_PUBLIC_KEY;
+
+import com.google.common.collect.Range;
+import com.hedera.mirror.common.domain.balance.AccountBalance;
+import com.hedera.mirror.common.domain.balance.TokenBalance;
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.common.domain.token.AbstractCustomFee;
+import com.hedera.mirror.common.domain.token.FallbackFee;
+import com.hedera.mirror.common.domain.token.FractionalFee;
+import com.hedera.mirror.common.domain.token.RoyaltyFee;
+import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
+import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
+import com.hedera.mirror.common.domain.token.TokenTypeEnum;
+import com.hedera.mirror.common.domain.transaction.RecordFile;
+import com.hedera.mirror.web3.viewmodel.BlockType;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+
+public abstract class AbstractContractCallServiceHistoricalTest extends AbstractContractCallServiceTest {
+
+    protected Range<Long> setUpHistoricalContext(final long blockNumber) {
+        final var recordFile = persistRecordFile(blockNumber);
+        return setupHistoricalStateInService(blockNumber, recordFile);
+    }
+
+    protected RecordFile persistRecordFile(final long blockNumber) {
+        return domainBuilder.recordFile().customize(f -> f.index(blockNumber)).persist();
+    }
+
+    protected Range<Long> setupHistoricalStateInService(final long blockNumber, final RecordFile recordFile) {
+        testWeb3jService.setBlockType(BlockType.of(String.valueOf(blockNumber)));
+        final var historicalRange = Range.closedOpen(recordFile.getConsensusStart(), recordFile.getConsensusEnd());
+        testWeb3jService.setHistoricalRange(historicalRange);
+        return historicalRange;
+    }
+
+    protected void setupHistoricalStateInService(final long blockNumber, final Range<Long> timestampRange) {
+        testWeb3jService.setBlockType(BlockType.of(String.valueOf(blockNumber)));
+        testWeb3jService.setHistoricalRange(timestampRange);
+    }
+
+    protected Pair<Entity, Entity> persistAccountTokenRelationshipHistorical(
+            final boolean isFrozen, final Range<Long> historicalRange) {
+        final var account = persistAccountEntityHistoricalWithAlias(historicalRange);
+        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        domainBuilder
+                .tokenAccountHistory()
+                .customize(ta -> ta.tokenId(tokenEntity.getId())
+                        .accountId(account.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .freezeStatus(isFrozen ? TokenFreezeStatusEnum.FROZEN : TokenFreezeStatusEnum.UNFROZEN)
+                        .associated(true)
+                        .timestampRange(historicalRange))
+                .persist();
+        return Pair.of(account, tokenEntity);
+    }
+
+    protected void persistTokenAccountFrozenRelationshipHistorical(
+            final Entity tokenEntity, final Entity accountEntity, final Range<Long> historicalRange) {
+        domainBuilder
+                .tokenAccountHistory()
+                .customize(ta -> ta.tokenId(tokenEntity.getId())
+                        .accountId(accountEntity.getId())
+                        .kycStatus(TokenKycStatusEnum.GRANTED)
+                        .freezeStatus(TokenFreezeStatusEnum.FROZEN)
+                        .associated(true)
+                        .timestampRange(historicalRange))
+                .persist();
+    }
+
+    protected Entity persistAccountEntityHistorical(final Range<Long> timestampRange) {
+        return domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.ACCOUNT)
+                        .deleted(false)
+                        .balance(1_000_000_000_000L)
+                        .timestampRange(timestampRange)
+                        .createdTimestamp(timestampRange.lowerEndpoint()))
+                .persist();
+    }
+
+    protected Entity persistAccountEntityNoEvmAddressHistorical(final Range<Long> timestampRange) {
+        return domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.ACCOUNT)
+                        .deleted(false)
+                        .evmAddress(null)
+                        .balance(1_000_000_000_000L)
+                        .timestampRange(timestampRange)
+                        .createdTimestamp(timestampRange.lowerEndpoint()))
+                .persist();
+    }
+
+    protected Entity persistAccountEntityHistoricalWithAlias(final Range<Long> timestampRange) {
+        return domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.ACCOUNT)
+                        .alias(SENDER_PUBLIC_KEY.toByteArray())
+                        .deleted(false)
+                        .evmAddress(SENDER_ALIAS.toArray())
+                        .balance(1_000_000_000_000L)
+                        .createdTimestamp(timestampRange.lowerEndpoint())
+                        .timestampRange(timestampRange))
+                .persist();
+    }
+
+    protected Entity persistAccountWithBalanceHistorical(final long balance, final Range<Long> timestampRange) {
+        final var entity = domainBuilder
+                .entity()
+                .customize(e -> e.balance(balance)
+                        .timestampRange(timestampRange)
+                        .createdTimestamp(timestampRange.lowerEndpoint()))
+                .persist();
+        persistAccountBalanceHistorical(entity.toEntityId(), balance, timestampRange);
+
+        return entity;
+    }
+
+    protected void persistAccountBalanceHistorical(
+            final EntityId entityId, final long balance, final Range<Long> timestampRange) {
+        // There needs to be an entry for account 0.0.2 in order for the account balance query to return the correct
+        // result
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new AccountBalance.Id(timestampRange.lowerEndpoint(), EntityId.of(2)))
+                        .balance(balance))
+                .persist();
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new AccountBalance.Id(timestampRange.lowerEndpoint(), entityId))
+                        .balance(balance))
+                .persist();
+    }
+
+    protected void persistTokenBalanceHistorical(
+            final EntityId accountId, final EntityId tokenId, final long balance, final Range<Long> timestampRange) {
+        // There needs to be an entry for account 0.0.2 in order for the token balance query to return the correct
+        // result
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new AccountBalance.Id(timestampRange.lowerEndpoint(), EntityId.of(2)))
+                        .balance(balance))
+                .persist();
+        domainBuilder
+                .tokenBalance()
+                .customize(ab -> ab.id(new TokenBalance.Id(timestampRange.lowerEndpoint(), accountId, tokenId))
+                        .balance(balance))
+                .persist();
+    }
+
+    protected Entity persistTokenEntityHistorical(final Range<Long> timestampRange) {
+        return domainBuilder
+                .entity()
+                .customize(e -> e.type(EntityType.TOKEN).timestampRange(timestampRange))
+                .persist();
+    }
+
+    protected void persistFungibleTokenHistorical(Entity tokenEntity, final Range<Long> timestampRange) {
+        domainBuilder
+                .tokenHistory()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .timestampRange(timestampRange)
+                        .createdTimestamp(timestampRange.lowerEndpoint()))
+                .persist();
+    }
+
+    protected Entity persistFungibleTokenHistorical(final Range<Long> timestampRange) {
+        final var entity = persistTokenEntityHistorical(timestampRange);
+        persistFungibleTokenHistorical(entity, timestampRange);
+        return entity;
+    }
+
+    protected Entity persistNftHistorical(final Range<Long> timestampRange) {
+        final var tokenEntity = persistTokenEntityHistorical(timestampRange);
+        domainBuilder
+                .tokenHistory()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
+                        .timestampRange(timestampRange))
+                .persist();
+        domainBuilder
+                .nftHistory()
+                .customize(n -> n.tokenId(tokenEntity.getId()).serialNumber(1L).timestampRange(timestampRange))
+                .persist();
+
+        return tokenEntity;
+    }
+
+    protected void persistTokenAllowanceHistorical(
+            final Entity tokenEntity,
+            final Entity owner,
+            final Entity spender,
+            final long amount,
+            final Range<Long> timestampRange) {
+        domainBuilder
+                .tokenAllowanceHistory()
+                .customize(a -> a.tokenId(tokenEntity.getId())
+                        .owner(owner.getNum())
+                        .spender(spender.getNum())
+                        .amount(amount)
+                        .amountGranted(amount)
+                        .timestampRange(timestampRange))
+                .persist();
+    }
+
+    protected void persistNftAllowanceHistorical(
+            final Entity tokenEntity, final Entity owner, final Entity spender, final Range<Long> timestampRange) {
+        domainBuilder
+                .nftAllowanceHistory()
+                .customize(a -> a.tokenId(tokenEntity.getId())
+                        .owner(owner.getNum())
+                        .spender(spender.getNum())
+                        .timestampRange(timestampRange))
+                .persist();
+    }
+
+    protected void persistCryptoAllowanceHistorical(
+            final Entity owner, final EntityId spender, final long amount, final Range<Long> timestampRange) {
+        domainBuilder
+                .cryptoAllowanceHistory()
+                .customize(ca -> ca.owner(owner.toEntityId().getId())
+                        .spender(spender.getId())
+                        .payerAccountId(owner.toEntityId())
+                        .amount(amount)
+                        .amountGranted(amount)
+                        .timestampRange(timestampRange))
+                .persist();
+    }
+
+    protected AbstractCustomFee persistCustomFeesWithFeeCollectorHistorical(
+            final Entity feeCollector,
+            final Entity tokenEntity,
+            final TokenTypeEnum tokenType,
+            final Range<Long> timestampRange) {
+        final var fixedFee = com.hedera.mirror.common.domain.token.FixedFee.builder()
+                .allCollectorsAreExempt(true)
+                .amount(domainBuilder.number())
+                .collectorAccountId(feeCollector.toEntityId())
+                .denominatingTokenId(tokenEntity.toEntityId())
+                .build();
+
+        final var fractionalFee = TokenTypeEnum.FUNGIBLE_COMMON.equals(tokenType)
+                ? FractionalFee.builder()
+                        .allCollectorsAreExempt(true)
+                        .collectorAccountId(feeCollector.toEntityId())
+                        .denominator(domainBuilder.number())
+                        .maximumAmount(domainBuilder.number())
+                        .minimumAmount(1L)
+                        .numerator(domainBuilder.number())
+                        .netOfTransfers(true)
+                        .build()
+                : null;
+
+        final var fallbackFee = FallbackFee.builder()
+                .amount(domainBuilder.number())
+                .denominatingTokenId(tokenEntity.toEntityId())
+                .build();
+
+        final var royaltyFee = TokenTypeEnum.NON_FUNGIBLE_UNIQUE.equals(tokenType)
+                ? RoyaltyFee.builder()
+                        .allCollectorsAreExempt(true)
+                        .collectorAccountId(feeCollector.toEntityId())
+                        .denominator(domainBuilder.number())
+                        .fallbackFee(fallbackFee)
+                        .numerator(domainBuilder.number())
+                        .build()
+                : null;
+
+        if (TokenTypeEnum.FUNGIBLE_COMMON.equals(tokenType)) {
+            return domainBuilder
+                    .customFeeHistory()
+                    .customize(f -> f.tokenId(tokenEntity.getId())
+                            .fixedFees(List.of(fixedFee))
+                            .fractionalFees(List.of(fractionalFee))
+                            .royaltyFees(new ArrayList<>())
+                            .timestampRange(timestampRange))
+                    .persist();
+        } else {
+            return domainBuilder
+                    .customFeeHistory()
+                    .customize(f -> f.tokenId(tokenEntity.getId())
+                            .fixedFees(List.of(fixedFee))
+                            .royaltyFees(List.of(royaltyFee))
+                            .fractionalFees(new ArrayList<>())
+                            .timestampRange(timestampRange))
+                    .persist();
+        }
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceOpcodeTracerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceOpcodeTracerTest.java
@@ -50,7 +50,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.web3j.tx.Contract;
 
-abstract class AbstractContractCallServiceOpcodeTracerTest extends AbstractContractCallServiceTest {
+abstract class AbstractContractCallServiceOpcodeTracerTest extends AbstractContractCallServiceHistoricalTest {
 
     @Resource
     protected ContractDebugService contractDebugService;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -183,24 +183,22 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                 value);
     }
 
-    protected Entity persistAccountEntity() {
+    protected Entity tokenEntityPersist() {
+        return domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
+    }
+
+    protected Entity accountEntityPersist() {
         return domainBuilder
                 .entity()
                 .customize(e -> e.type(EntityType.ACCOUNT).deleted(false).balance(1_000_000_000_000L))
                 .persist();
     }
 
-    protected void persistAssociation(final Entity token, final Entity account) {
-        domainBuilder
-                .tokenAccount()
-                .customize(ta -> ta.tokenId(token.getId())
-                        .accountId(account.getId())
-                        .kycStatus(TokenKycStatusEnum.GRANTED)
-                        .associated(true))
-                .persist();
+    protected void tokenAccountPersist(final Entity token, final Entity account) {
+        tokenAccountPersist(token, account.toEntityId().getId());
     }
 
-    protected void persistAssociation(final Entity token, final Long accountId) {
+    protected void tokenAccountPersist(final Entity token, final Long accountId) {
         domainBuilder
                 .tokenAccount()
                 .customize(ta -> ta.tokenId(token.getId())

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesHistoricalTest.java
@@ -16,8 +16,6 @@
 
 package com.hedera.mirror.web3.service;
 
-import static com.google.common.collect.Range.closedOpen;
-import static com.hedera.mirror.common.domain.entity.EntityType.ACCOUNT;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.toAddress;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.EVM_V_34_BLOCK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
@@ -38,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-public class ContractCallEvmCodesHistoricalTest extends AbstractContractCallServiceTest {
+public class ContractCallEvmCodesHistoricalTest extends AbstractContractCallServiceHistoricalTest {
     private RecordFile recordFileAfterEvm34;
 
     @BeforeEach
@@ -102,16 +100,8 @@ public class ContractCallEvmCodesHistoricalTest extends AbstractContractCallServ
     }
 
     private void senderPersistHistorical(RecordFile recordFileHistorical) {
-        final var senderHistorical = domainBuilder
-                .entity()
-                .customize(e -> e.type(ACCOUNT)
-                        .deleted(false)
-                        .balance(10000 * 100_000_000L)
-                        .createdTimestamp(recordFileHistorical.getConsensusStart())
-                        .timestampRange(closedOpen(
-                                recordFileHistorical.getConsensusStart(), recordFileHistorical.getConsensusEnd())))
-                .persist();
-
+        final var senderHistorical = accountEntityPersistHistorical(
+                Range.closedOpen(recordFileHistorical.getConsensusStart(), recordFileHistorical.getConsensusEnd()));
         testWeb3jService.setSender(toAddress(senderHistorical.toEntityId()).toHexString());
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenReadOnlyFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenReadOnlyFunctionsTest.java
@@ -27,9 +27,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.google.protobuf.ByteString;
-import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
-import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
@@ -46,7 +44,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallGetApprovedEmptySpenderStatic() throws Exception {
         final var treasuryEntityId = accountPersist();
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -70,7 +68,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallGetApprovedEmptySpenderNonStatic() throws Exception {
         final var treasuryEntityId = accountPersist();
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -338,7 +336,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallGetDecimalsStatic() throws Exception {
         final var decimals = 12;
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(ta -> ta.tokenId(tokenEntity.getId()).decimals(decimals))
@@ -354,7 +352,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallGetDecimalsNonStatic() throws Exception {
         final var decimals = 12;
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(ta -> ta.tokenId(tokenEntity.getId()).decimals(decimals))
@@ -371,7 +369,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallGetTotalSupplyStatic() throws Exception {
         final var totalSupply = 12345L;
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -390,7 +388,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallGetTotalSupplyNonStatic() throws Exception {
         final var totalSupply = 12345L;
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -409,7 +407,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallSymbolStatic() throws Exception {
         final var symbol = "HBAR";
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -427,7 +425,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallSymbolNonStatic() throws Exception {
         final var symbol = "HBAR";
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -530,7 +528,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallNameStatic() throws Exception {
         final var tokenName = "Hbars";
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -548,7 +546,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallNameNonStatic() throws Exception {
         final var tokenName = "Hbars";
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -619,7 +617,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
         final var ownerEntity = accountPersist();
         final byte[] kycKey = domainBuilder.key();
         final var metadata = "NFT_METADATA_URI";
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
 
         domainBuilder
                 .token()
@@ -649,7 +647,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
         final var ownerEntity = accountPersist();
         final byte[] kycKey = domainBuilder.key();
         final var metadata = "NFT_METADATA_URI";
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
 
         domainBuilder
                 .token()
@@ -677,7 +675,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallGetApprovedEmptySpenderRedirect() {
         final var treasuryEntityId = accountPersist();
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -797,7 +795,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallGetDecimalsRedirect() {
         final var decimals = 12;
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(ta -> ta.tokenId(tokenEntity.getId()).decimals(decimals))
@@ -811,7 +809,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallGetTotalSupplyRedirect() {
         final var totalSupply = 12345L;
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -828,7 +826,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallSymbolRedirect() {
         final var symbol = "HBAR";
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -880,7 +878,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     @Test
     void ethCallNameRedirect() {
         final var tokenName = "Hbars";
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -917,7 +915,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
         final var ownerEntity = accountPersist();
         final byte[] kycKey = domainBuilder.key();
         final var metadata = "NFT_METADATA_URI";
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
 
         domainBuilder
                 .token()
@@ -1069,7 +1067,7 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
     }
 
     private Token nftPersist() {
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         final var token = domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE))
@@ -1120,9 +1118,5 @@ class ContractCallServiceERCTokenReadOnlyFunctionsTest extends AbstractContractC
                         .serialNumber(1))
                 .persist();
         return token;
-    }
-
-    private Entity persistTokenEntity() {
-        return domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceHistoricalNegativeTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceHistoricalNegativeTest.java
@@ -19,6 +19,7 @@ package com.hedera.mirror.web3.service;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdFromEvmAddress;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.EVM_V_34_BLOCK;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.EVM_V_38_BLOCK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -55,7 +56,9 @@ class ContractCallServiceHistoricalNegativeTest extends AbstractContractCallServ
         final var functionCall = contract.call_isTokenAddress(getAddressFromEntity(tokenEntity));
 
         // Then
-        assertThatThrownBy(functionCall::send).isInstanceOf(MirrorEvmTransactionException.class);
+        assertThatThrownBy(functionCall::send)
+                .isInstanceOf(MirrorEvmTransactionException.class)
+                .hasMessage(INVALID_TRANSACTION.name());
     }
 
     // Tests TokenRepository and NftRepository

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceHistoricalNegativeTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceHistoricalNegativeTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.service;
+
+import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdFromEvmAddress;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.EVM_V_30_BLOCK;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.EVM_V_34_BLOCK;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.EVM_V_38_BLOCK;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.hedera.mirror.common.domain.token.TokenTypeEnum;
+import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
+import com.hedera.mirror.web3.web3j.generated.EvmCodesHistorical;
+import com.hedera.mirror.web3.web3j.generated.ModificationPrecompileTestContract;
+import com.hedera.mirror.web3.web3j.generated.ModificationPrecompileTestContract.AccountAmount;
+import com.hedera.mirror.web3.web3j.generated.ModificationPrecompileTestContract.TransferList;
+import com.hedera.mirror.web3.web3j.generated.PrecompileTestContractHistorical;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ContractCallServiceHistoricalNegativeTest extends AbstractContractCallServiceHistoricalTest {
+
+    @Test
+    void contractNotPersistedYetThrowsException() {
+        // Given
+        final var evm30RecordFile = persistRecordFile(EVM_V_30_BLOCK);
+        final var historicalRangeAfterEvm34 = setUpHistoricalContext(EVM_V_34_BLOCK);
+        final var tokenEntity = persistNftHistorical(historicalRangeAfterEvm34);
+
+        // Deploy the contract against block X, make the contract call against block (X-1) -> throw an exception as the
+        // contract does not exist yet.
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+        setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+
+        // When
+        final var functionCall = contract.call_isTokenAddress(getAddressFromEntity(tokenEntity));
+
+        // Then
+        assertThatThrownBy(functionCall::send).isInstanceOf(MirrorEvmTransactionException.class);
+    }
+
+    // Tests TokenRepository and NftRepository
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void tokenNotPersistedYetThrowsException(final boolean isNft) {
+        // Given
+        final var evm30RecordFile = persistRecordFile(EVM_V_30_BLOCK);
+        final var historicalRangeAfterEvm34 = setUpHistoricalContext(EVM_V_34_BLOCK);
+        final var tokenEntity = isNft
+                ? persistNftHistorical(historicalRangeAfterEvm34)
+                : persistFungibleTokenHistorical(historicalRangeAfterEvm34);
+
+        setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // Persist the token against block X, make the call against block (X-1) -> throw an exception as the token does
+        // not exist yet.
+        // When
+        final var functionCall = contract.call_isTokenAddress(getAddressFromEntity(tokenEntity));
+
+        // Then
+        assertThatThrownBy(functionCall::send).isInstanceOf(MirrorEvmTransactionException.class);
+    }
+
+    // Tests TokenAccountRepository
+    @Test
+    void tokenAccountRelationshipNotPersistedYetReturnsFalse() throws Exception {
+        // Given
+        final var evm30RecordFile = persistRecordFile(EVM_V_30_BLOCK);
+        final var evm30HistoricalRange = setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var historicalRangeAfterEvm34 = setUpHistoricalContext(EVM_V_34_BLOCK);
+        final var tokenEntity = persistTokenEntityHistorical(evm30HistoricalRange);
+        persistFungibleTokenHistorical(tokenEntity, evm30HistoricalRange);
+        final var accountEntity = persistAccountEntityHistoricalWithAlias(evm30HistoricalRange);
+        persistTokenAccountFrozenRelationshipHistorical(tokenEntity, accountEntity, historicalRangeAfterEvm34);
+
+        setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // Persist the token and the account in block (X-1), but the relationship in block X. The call against block
+        // (X-1)
+        // should fail as the association is not available yet.
+        // When
+        final var functionCall =
+                contract.call_isTokenFrozen(getAddressFromEntity(tokenEntity), getAddressFromEntity(accountEntity));
+
+        // Then
+        assertThat(functionCall.send()).isFalse();
+    }
+
+    // Tests TokenAllowanceRepository
+    @Test
+    void getAllowanceForFungibleTokenNotPersistedYetReturnsZero() throws Exception {
+        // Given
+        final var evm30RecordFile = persistRecordFile(EVM_V_30_BLOCK);
+        final var evm30HistoricalRange = setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var historicalRangeAfterEvm34 = setUpHistoricalContext(EVM_V_34_BLOCK);
+        final var amountGranted = 50L;
+        final var owner = persistAccountEntityHistorical(evm30HistoricalRange);
+        final var spender = persistAccountEntityHistorical(evm30HistoricalRange);
+        final var tokenEntity = persistTokenEntityHistorical(evm30HistoricalRange);
+        persistFungibleTokenHistorical(tokenEntity, evm30HistoricalRange);
+
+        // Persist the token and the accounts in block (X-1), but the token allowance in block X. The call against block
+        // (X-1) should fail as the allowance is not available yet.
+        persistTokenAllowanceHistorical(tokenEntity, owner, spender, amountGranted, historicalRangeAfterEvm34);
+
+        setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_htsAllowance(
+                getAddressFromEntity(tokenEntity), getAddressFromEntity(owner), getAddressFromEntity(spender));
+
+        // Then
+        assertThat(functionCall.send()).isEqualTo(BigInteger.ZERO);
+    }
+
+    // Tests NftAllowanceRepository
+    @Test
+    void getAllowanceForNftNotPersistedYetReturnsZero() throws Exception {
+        // Given
+        final var evm30RecordFile = persistRecordFile(EVM_V_30_BLOCK);
+        final var evm30HistoricalRange = setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var historicalRangeAfterEvm34 = setUpHistoricalContext(EVM_V_34_BLOCK);
+        final var owner = persistAccountEntityHistorical(evm30HistoricalRange);
+        final var spender = persistAccountEntityHistorical(evm30HistoricalRange);
+        final var tokenEntity = persistNftHistorical(evm30HistoricalRange);
+
+        // Persist the token and the accounts in block (X-1), but the nft allowance in block X. The call against block
+        // (X-1)
+        // should fail as the allowance is not available yet.
+        persistNftAllowanceHistorical(tokenEntity, owner, spender, historicalRangeAfterEvm34);
+
+        setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var functionCall = contract.call_htsAllowance(
+                getAddressFromEntity(tokenEntity), getAddressFromEntity(owner), getAddressFromEntity(spender));
+
+        // Then
+        assertThat(functionCall.send()).isEqualTo(BigInteger.ZERO);
+    }
+
+    // Tests CustomFeeRepository
+    @Test
+    void getFungibleTokenInfoCustomFeesNotPersistedYetReturnsZero() throws Exception {
+        // Given
+        final var evm30RecordFile = persistRecordFile(EVM_V_30_BLOCK);
+        final var evm30HistoricalRange = setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var historicalRangeAfterEvm34 = setUpHistoricalContext(EVM_V_34_BLOCK);
+
+        final var tokenEntity = persistFungibleTokenHistorical(evm30HistoricalRange);
+        final var feeCollector = persistAccountEntityHistorical(evm30HistoricalRange);
+
+        // Persist the token and the account in block (X-1), but the custom fees in block X. The call against block
+        // (X-1)
+        // should fail as the custom fees are not available yet.
+        persistCustomFeesWithFeeCollectorHistorical(
+                feeCollector, tokenEntity, TokenTypeEnum.FUNGIBLE_COMMON, historicalRangeAfterEvm34);
+
+        setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var result = contract.call_getInformationForFungibleToken(getAddressFromEntity(tokenEntity))
+                .send();
+
+        // Then
+        assertThat(result.tokenInfo.fixedFees).usingRecursiveComparison().isEqualTo(List.of());
+        assertThat(result.tokenInfo.fractionalFees).usingRecursiveComparison().isEqualTo(List.of());
+        assertThat(result.tokenInfo.royaltyFees).usingRecursiveComparison().isEqualTo(List.of());
+    }
+
+    // Tests CustomFeeRepository
+    @Test
+    void getNftInfoCustomFeesNotPersistedYetReturnsZero() throws Exception {
+        // Given
+        final var evm30RecordFile = persistRecordFile(EVM_V_30_BLOCK);
+        final var evm30HistoricalRange = setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var historicalRangeAfterEvm34 = setUpHistoricalContext(EVM_V_34_BLOCK);
+
+        final var tokenEntity = persistNftHistorical(evm30HistoricalRange);
+        final var feeCollector = persistAccountEntityHistorical(evm30HistoricalRange);
+
+        // Persist the token and the account in block (X-1), but the custom fees in block X. The call against block
+        // (X-1)
+        // should fail as the custom fees are not available yet.
+        persistCustomFeesWithFeeCollectorHistorical(
+                feeCollector, tokenEntity, TokenTypeEnum.NON_FUNGIBLE_UNIQUE, historicalRangeAfterEvm34);
+
+        setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
+
+        // When
+        final var result = contract.call_getInformationForToken(getAddressFromEntity(tokenEntity))
+                .send();
+
+        // Then
+        assertThat(result.fixedFees).usingRecursiveComparison().isEqualTo(List.of());
+        assertThat(result.fractionalFees).usingRecursiveComparison().isEqualTo(List.of());
+        assertThat(result.royaltyFees).usingRecursiveComparison().isEqualTo(List.of());
+    }
+
+    // Tests TokenBalanceRepository
+    @Test
+    void tokenBalanceNotPersistedYetThrowsException() {
+        // Given
+        final var evm38RecordFile = persistRecordFile(EVM_V_38_BLOCK);
+        final var evm38HistoricalRange = setupHistoricalStateInService(EVM_V_38_BLOCK, evm38RecordFile);
+        final var historicalRangeAfterEvm38 = setUpHistoricalContext(EVM_V_38_BLOCK + 1);
+
+        final var accountEntity = persistAccountEntityHistorical(evm38HistoricalRange);
+        final var receiverEntity = persistAccountEntityHistorical(evm38HistoricalRange);
+        final var tokenEntity = persistTokenEntityHistorical(evm38HistoricalRange);
+        domainBuilder
+                .tokenHistory()
+                .customize(t -> t.tokenId(tokenEntity.getId())
+                        .type(TokenTypeEnum.FUNGIBLE_COMMON)
+                        .kycKey(null)
+                        .treasuryAccountId(accountEntity.toEntityId())
+                        .timestampRange(evm38HistoricalRange))
+                .persist();
+        persistTokenBalanceHistorical(accountEntity.toEntityId(), tokenEntity.toEntityId(), 1L, evm38HistoricalRange);
+
+        // Persist the token, the account, balance1 in block (X-1) and balance2 in block X, where balance1 < balance2.
+        // The call against block (X-1)
+        // should fail with balance2, since the bigger balance is not available at this point.
+        persistTokenBalanceHistorical(
+                accountEntity.toEntityId(), tokenEntity.toEntityId(), 2L, historicalRangeAfterEvm38);
+
+        setupHistoricalStateInService(EVM_V_38_BLOCK, evm38HistoricalRange);
+        final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
+
+        // When
+        final var functionCall = contract.call_transferTokenExternal(
+                getAddressFromEntity(tokenEntity),
+                getAddressFromEntity(accountEntity),
+                getAddressFromEntity(receiverEntity),
+                BigInteger.valueOf(2));
+
+        // Then
+        assertThatThrownBy(functionCall::send).isInstanceOf(MirrorEvmTransactionException.class);
+    }
+
+    @Test
+    void transferWithNoPersistedCryptoAllowanceThrowsException() {
+        // Given
+        final var evm38RecordFile = persistRecordFile(EVM_V_38_BLOCK);
+        final var evm38HistoricalRange = setupHistoricalStateInService(EVM_V_38_BLOCK, evm38RecordFile);
+        final var historicalRangeAfterEvm38 = setUpHistoricalContext(EVM_V_38_BLOCK + 1);
+
+        final var sender = persistAccountEntityHistorical(evm38HistoricalRange);
+        final var receiver = persistAccountEntityHistorical(evm38HistoricalRange);
+
+        setupHistoricalStateInService(EVM_V_38_BLOCK, evm38HistoricalRange);
+        final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
+        final var contractAddress = Address.fromHexString(contract.getContractAddress());
+        final var contractEntityId = entityIdFromEvmAddress(contractAddress);
+
+        // The accounts are persisted against block (X-1) but the crypto allowance is persisted in
+        // block X, so the call against block (X-1) fails as there is no allowance yet.
+        persistCryptoAllowanceHistorical(sender, contractEntityId, 5L, historicalRangeAfterEvm38);
+
+        testWeb3jService.setSender(getAddressFromEntity(sender));
+        final var transferList = new TransferList(List.of(
+                new AccountAmount(getAddressFromEntity(sender), BigInteger.valueOf(-5L), true),
+                new AccountAmount(getAddressFromEntity(receiver), BigInteger.valueOf(5L), true)));
+
+        // When
+        final var functionCall = contract.call_cryptoTransferExternal(transferList, new ArrayList<>());
+
+        // Then
+        assertThatThrownBy(functionCall::send).isInstanceOf(MirrorEvmTransactionException.class);
+    }
+
+    // Tests AccountBalanceRepository
+    @Test
+    void accountBalanceNotPersistedYetReturnsPreviousBalance() throws Exception {
+        // Given
+        final var evm30RecordFile = persistRecordFile(EVM_V_30_BLOCK);
+        final var evm30HistoricalRange = setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var historicalRangeAfterEvm34 = setUpHistoricalContext(EVM_V_34_BLOCK);
+        final var feeCollector = persistAccountWithBalanceHistorical(100L, evm30HistoricalRange);
+
+        setupHistoricalStateInService(EVM_V_30_BLOCK, evm30RecordFile);
+        final var contract = testWeb3jService.deploy(EvmCodesHistorical::deploy);
+
+        // Persist the token, the account and the account balance in block 49. In block 50 enter another
+        // account balance. The call against block 49 should return the first balance as the second
+        // balance is not available at that point yet.
+        persistAccountBalanceHistorical(feeCollector.toEntityId(), 200L, historicalRangeAfterEvm34);
+
+        // When
+        final var result = contract.call_getAccountBalance(getAddressFromEntity(feeCollector))
+                .send();
+
+        // Then
+        assertThat(result).isEqualTo(BigInteger.valueOf(100L));
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileHistoricalTest.java
@@ -75,7 +75,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void isTokenFrozen(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var accountAndToken = persistAccountTokenRelationshipHistorical(true, historicalRange);
+        final var accountAndToken = accountTokenAndFrozenRelationshipPersistHistorical(historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -92,7 +92,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void isTokenFrozenWithAlias(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var accountAndToken = persistAccountTokenRelationshipHistorical(true, historicalRange);
+        final var accountAndToken = accountTokenAndFrozenRelationshipPersistHistorical(historicalRange);
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
         // When
@@ -108,10 +108,10 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void isKycGranted(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var account = persistAccountEntityHistorical(historicalRange);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
-        persistFungibleTokenHistorical(tokenEntity, historicalRange);
-        persistTokenRelationshipWithKycGrantedHistorical(tokenEntity, account, historicalRange);
+        final var account = accountEntityPersistHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        fungibleTokenPersistHistorical(tokenEntity, historicalRange);
+        tokenAccountFrozenRelationshipPersistHistorical(tokenEntity, account, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -128,10 +128,10 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void isKycGrantedWithAlias(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var account = persistAccountEntityHistoricalWithAlias(historicalRange);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
-        persistFungibleTokenHistorical(tokenEntity, historicalRange);
-        persistTokenRelationshipWithKycGrantedHistorical(tokenEntity, account, historicalRange);
+        final var account = accountEntityWithAliasPersistHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        fungibleTokenPersistHistorical(tokenEntity, historicalRange);
+        tokenAccountFrozenRelationshipPersistHistorical(tokenEntity, account, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -148,9 +148,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void isKycGrantedForNFT(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var account = persistAccountEntityHistorical(historicalRange);
-        final var tokenEntity = persistNftHistorical(historicalRange);
-        persistTokenRelationshipWithKycGrantedHistorical(tokenEntity, account, historicalRange);
+        final var account = accountEntityPersistHistorical(historicalRange);
+        final var tokenEntity = nftPersistHistorical(historicalRange);
+        tokenAccountFrozenRelationshipPersistHistorical(tokenEntity, account, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -167,9 +167,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void isKycGrantedForNFTWithAlias(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var account = persistAccountEntityHistoricalWithAlias(historicalRange);
-        final var tokenEntity = persistNftHistorical(historicalRange);
-        persistTokenRelationshipWithKycGrantedHistorical(tokenEntity, account, historicalRange);
+        final var account = accountEntityWithAliasPersistHistorical(historicalRange);
+        final var tokenEntity = nftPersistHistorical(historicalRange);
+        tokenAccountFrozenRelationshipPersistHistorical(tokenEntity, account, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -186,8 +186,8 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void isTokenAddress(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
-        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        fungibleTokenPersistHistorical(tokenEntity, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -203,7 +203,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void isTokenAddressNFT(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var tokenEntity = persistNftHistorical(historicalRange);
+        final var tokenEntity = nftPersistHistorical(historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -219,7 +219,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getDefaultKycToken(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -242,7 +242,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getDefaultKycNFT(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var tokenEntity = persistNftHistorical(historicalRange);
+        final var tokenEntity = nftPersistHistorical(historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -258,8 +258,8 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getTokenType(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
-        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        fungibleTokenPersistHistorical(tokenEntity, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -275,7 +275,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getTokenTypeNFT(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var tokenEntity = persistNftHistorical(historicalRange);
+        final var tokenEntity = nftPersistHistorical(historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
@@ -291,7 +291,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getTokenDefaultFreeze(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -314,7 +314,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getNFTDefaultFreeze(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -341,9 +341,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getCustomFeesForTokenWithFixedFee(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
-        persistFungibleTokenHistorical(tokenEntity, historicalRange);
-        final var collectorAccount = persistAccountEntityHistoricalWithAlias(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        fungibleTokenPersistHistorical(tokenEntity, historicalRange);
+        final var collectorAccount = accountEntityWithAliasPersistHistorical(historicalRange);
         final var fixedFee = com.hedera.mirror.common.domain.token.FixedFee.builder()
                 .amount(100L)
                 .collectorAccountId(collectorAccount.toEntityId())
@@ -381,9 +381,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getCustomFeesForTokenWithFractionalFee(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var collectorAccount = persistAccountEntityHistoricalWithAlias(historicalRange);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
-        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        final var collectorAccount = accountEntityWithAliasPersistHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        fungibleTokenPersistHistorical(tokenEntity, historicalRange);
         final var fractionalFee = FractionalFee.builder()
                 .collectorAccountId(collectorAccount.toEntityId())
                 .denominator(10L)
@@ -425,9 +425,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getCustomFeesForTokenWithRoyaltyFee(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var collectorAccount = persistAccountEntityHistoricalWithAlias(historicalRange);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
-        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        final var collectorAccount = accountEntityWithAliasPersistHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        fungibleTokenPersistHistorical(tokenEntity, historicalRange);
         final var royaltyFee = RoyaltyFee.builder()
                 .collectorAccountId(collectorAccount.toEntityId())
                 .denominator(10L)
@@ -473,7 +473,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         final var historicalRange = setUpHistoricalContext(blockNumber);
         final var expiryPeriod = 9999999999999L;
         final var autoRenewExpiry = 100000000L;
-        final var autoRenewAccount = persistAccountEntityHistorical(historicalRange);
+        final var autoRenewAccount = accountEntityPersistHistorical(historicalRange);
         final var tokenEntity = domainBuilder
                 .entity()
                 .customize(e -> e.type(EntityType.TOKEN)
@@ -482,7 +482,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                         .timestampRange(historicalRange)
                         .autoRenewPeriod(autoRenewExpiry))
                 .persist();
-        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        fungibleTokenPersistHistorical(tokenEntity, historicalRange);
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
 
         // When
@@ -504,8 +504,8 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getApproved(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var approvedAccount = persistAccountEntityHistoricalWithAlias(historicalRange);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
+        final var approvedAccount = accountEntityWithAliasPersistHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -537,10 +537,10 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
         final var amountGranted = 50L;
-        final var owner = persistAccountEntityHistorical(historicalRange);
-        final var spender = persistAccountEntityHistorical(historicalRange);
-        final var tokenEntity = persistTokenEntityHistorical(historicalRange);
-        persistFungibleTokenHistorical(tokenEntity, historicalRange);
+        final var owner = accountEntityPersistHistorical(historicalRange);
+        final var spender = accountEntityPersistHistorical(historicalRange);
+        final var tokenEntity = tokenEntityPersistHistorical(historicalRange);
+        fungibleTokenPersistHistorical(tokenEntity, historicalRange);
 
         domainBuilder
                 .tokenAllowance()
@@ -567,9 +567,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void isApprovedForAllNFT(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var owner = persistAccountEntityHistorical(historicalRange);
-        final var spender = persistAccountEntityHistorical(historicalRange);
-        final var tokenEntity = persistNftHistorical(historicalRange);
+        final var owner = accountEntityPersistHistorical(historicalRange);
+        final var spender = accountEntityPersistHistorical(historicalRange);
+        final var tokenEntity = nftPersistHistorical(historicalRange);
 
         domainBuilder
                 .nftAllowance()
@@ -603,7 +603,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                 .persist();
         final var treasury =
                 accountPersistWithBalanceHistorical(tokenSupply, tokenEntity.toEntityId(), historicalRange);
-        final var feeCollector = persistAccountEntityHistorical(historicalRange);
+        final var feeCollector = accountEntityPersistHistorical(historicalRange);
 
         final var token = domainBuilder
                 .token()
@@ -614,7 +614,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                         .totalSupply(tokenSupply))
                 .persist();
 
-        final var customFees = persistCustomFeesWithFeeCollectorHistorical(
+        final var customFees = customFeesWithFeeCollectorPersistHistorical(
                 feeCollector, tokenEntity, TokenTypeEnum.FUNGIBLE_COMMON, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
@@ -649,9 +649,9 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
 
-        final var owner = persistAccountEntityHistorical(historicalRange);
-        final var treasury = persistAccountEntityHistorical(historicalRange);
-        final var feeCollector = persistAccountEntityHistorical(historicalRange);
+        final var owner = accountEntityPersistHistorical(historicalRange);
+        final var treasury = accountEntityPersistHistorical(historicalRange);
+        final var feeCollector = accountEntityPersistHistorical(historicalRange);
         final var tokenEntity = domainBuilder
                 .entity()
                 .customize(e -> e.type(EntityType.TOKEN)
@@ -676,7 +676,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                         .createdTimestamp(historicalRange.lowerEndpoint()))
                 .persist();
 
-        final var customFees = persistCustomFeesWithFeeCollectorHistorical(
+        final var customFees = customFeesWithFeeCollectorPersistHistorical(
                 feeCollector, tokenEntity, TokenTypeEnum.NON_FUNGIBLE_UNIQUE, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
@@ -724,7 +724,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                 .persist();
         final var treasury =
                 accountPersistWithBalanceHistorical(tokenSupply, tokenEntity.toEntityId(), historicalRange);
-        final var feeCollector = persistAccountEntityHistorical(historicalRange);
+        final var feeCollector = accountEntityPersistHistorical(historicalRange);
 
         final var token = domainBuilder
                 .token()
@@ -735,7 +735,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                         .totalSupply(tokenSupply))
                 .persist();
 
-        final var customFees = persistCustomFeesWithFeeCollectorHistorical(
+        final var customFees = customFeesWithFeeCollectorPersistHistorical(
                 feeCollector, tokenEntity, TokenTypeEnum.FUNGIBLE_COMMON, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
@@ -764,8 +764,8 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
     void getTokenInfoNonFungible(long blockNumber) throws Exception {
         // Given
         final var historicalRange = setUpHistoricalContext(blockNumber);
-        final var treasury = persistAccountEntityHistorical(historicalRange);
-        final var feeCollector = persistAccountEntityHistorical(historicalRange);
+        final var treasury = accountEntityPersistHistorical(historicalRange);
+        final var feeCollector = accountEntityPersistHistorical(historicalRange);
         final var tokenEntity = domainBuilder
                 .entity()
                 .customize(e -> e.type(EntityType.TOKEN)
@@ -789,7 +789,7 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                         .createdTimestamp(historicalRange.lowerEndpoint()))
                 .persist();
 
-        final var customFees = persistCustomFeesWithFeeCollectorHistorical(
+        final var customFees = customFeesWithFeeCollectorPersistHistorical(
                 feeCollector, tokenEntity, TokenTypeEnum.NON_FUNGIBLE_UNIQUE, historicalRange);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContractHistorical::deploy);
@@ -1159,17 +1159,5 @@ class ContractCallServicePrecompileHistoricalTest extends AbstractContractCallSe
                 fractionalFees,
                 royaltyFees,
                 LEDGER_ID);
-    }
-
-    private void persistTokenRelationshipWithKycGrantedHistorical(
-            final Entity tokenEntity, final Entity account, final Range<Long> historicalRange) {
-        domainBuilder
-                .tokenAccount()
-                .customize(ta -> ta.tokenId(tokenEntity.getId())
-                        .accountId(account.getId())
-                        .kycStatus(TokenKycStatusEnum.GRANTED)
-                        .associated(true)
-                        .timestampRange(historicalRange))
-                .persist();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
@@ -79,9 +79,9 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void transferFrom() throws Exception {
         // Given
-        final var owner = persistAccountEntity();
-        final var spender = persistAccountEntity();
-        final var recipient = persistAccountEntity();
+        final var owner = accountEntityPersist();
+        final var spender = accountEntityPersist();
+        final var recipient = accountEntityPersist();
 
         final var tokenEntity =
                 domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
@@ -92,14 +92,14 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                         .treasuryAccountId(owner.toEntityId()))
                 .persist();
 
-        persistAssociation(tokenEntity, spender);
-        persistAssociation(tokenEntity, recipient);
+        tokenAccountPersist(tokenEntity, spender);
+        tokenAccountPersist(tokenEntity, recipient);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
         final var contractAddress = Address.fromHexString(contract.getContractAddress());
         final var contractEntityId = entityIdFromEvmAddress(contractAddress);
-        persistAssociation(tokenEntity, contractEntityId.getId());
+        tokenAccountPersist(tokenEntity, contractEntityId.getId());
 
         domainBuilder
                 .tokenAllowance()
@@ -125,16 +125,16 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @CsvSource({"1", "0"})
     void approve(final BigInteger allowance) throws Exception {
         // Given
-        final var spender = persistAccountEntity();
+        final var spender = accountEntityPersist();
         final var tokenEntity = persistFungibleToken();
 
-        persistAssociation(tokenEntity, spender);
+        tokenAccountPersist(tokenEntity, spender);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
         final var contractAddress = Address.fromHexString(contract.getContractAddress());
         final var contractEntityId = entityIdFromEvmAddress(contractAddress);
-        persistAssociation(tokenEntity, contractEntityId.getId());
+        tokenAccountPersist(tokenEntity, contractEntityId.getId());
 
         // When
         final var functionCall = contract.call_approveExternal(
@@ -149,8 +149,8 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @ValueSource(booleans = {true, false})
     void approveNFT(final Boolean approve) throws Exception {
         // Given
-        final var owner = persistAccountEntity();
-        final var spender = persistAccountEntity();
+        final var owner = accountEntityPersist();
+        final var spender = accountEntityPersist();
 
         final var tokenEntity =
                 domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
@@ -159,14 +159,14 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE))
                 .persist();
 
-        persistAssociation(tokenEntity, owner);
-        persistAssociation(tokenEntity, spender);
+        tokenAccountPersist(tokenEntity, owner);
+        tokenAccountPersist(tokenEntity, spender);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
         final var contractAddress = Address.fromHexString(contract.getContractAddress());
         final var contractEntityId = entityIdFromEvmAddress(contractAddress);
-        persistAssociation(tokenEntity, contractEntityId.getId());
+        tokenAccountPersist(tokenEntity, contractEntityId.getId());
 
         domainBuilder
                 .nft()
@@ -187,7 +187,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void setApprovalForAll() throws Exception {
         // Given
-        final var spender = persistAccountEntity();
+        final var spender = accountEntityPersist();
 
         final var tokenEntity =
                 domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
@@ -196,13 +196,13 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE))
                 .persist();
 
-        persistAssociation(tokenEntity, spender);
+        tokenAccountPersist(tokenEntity, spender);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
         final var contractAddress = Address.fromHexString(contract.getContractAddress());
         final var contractEntityId = entityIdFromEvmAddress(contractAddress);
-        persistAssociation(tokenEntity, contractEntityId.getId());
+        tokenAccountPersist(tokenEntity, contractEntityId.getId());
 
         domainBuilder
                 .nft()
@@ -222,7 +222,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @ValueSource(booleans = {true, false})
     void associateToken(final Boolean single) throws Exception {
         // Given
-        final var notAssociatedAccount = persistAccountEntity();
+        final var notAssociatedAccount = accountEntityPersist();
 
         final var tokenEntity =
                 domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
@@ -269,7 +269,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @ValueSource(booleans = {true, false})
     void dissociateToken(final Boolean single) throws Exception {
         // Given
-        final var associatedAccount = persistAccountEntity();
+        final var associatedAccount = accountEntityPersist();
 
         final var tokenEntity =
                 domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
@@ -278,7 +278,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))
                 .persist();
 
-        persistAssociation(tokenEntity, associatedAccount);
+        tokenAccountPersist(tokenEntity, associatedAccount);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
@@ -308,7 +308,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
 
         final var contractAddress = Address.fromHexString(contract.getContractAddress());
         final var contractEntityId = entityIdFromEvmAddress(contractAddress);
-        persistAssociation(tokenEntity, contractEntityId.getId());
+        tokenAccountPersist(tokenEntity, contractEntityId.getId());
 
         // When
         final var functionCall = contract.call_dissociateWithRedirect(getAddressFromEntity(tokenEntity));
@@ -321,15 +321,15 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void mintFungibleToken() throws Exception {
         // Given
-        final var treasury = persistAccountEntity();
-        final var tokenEntity = persistTokenEntity();
+        final var treasury = accountEntityPersist();
+        final var tokenEntity = tokenEntityPersist();
         final var token = domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
                         .type(TokenTypeEnum.FUNGIBLE_COMMON)
                         .treasuryAccountId(treasury.toEntityId()))
                 .persist();
-        persistAssociation(tokenEntity, treasury);
+        tokenAccountPersist(tokenEntity, treasury);
 
         final var totalSupply = token.getTotalSupply();
 
@@ -349,15 +349,15 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void mintNFT() throws Exception {
         // Given
-        final var treasury = persistAccountEntity();
-        final var tokenEntity = persistTokenEntity();
+        final var treasury = accountEntityPersist();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
                         .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
                         .treasuryAccountId(treasury.toEntityId()))
                 .persist();
-        persistAssociation(tokenEntity, treasury);
+        tokenAccountPersist(tokenEntity, treasury);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
@@ -376,15 +376,15 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void burnFungibleToken() throws Exception {
         // Given
-        final var treasury = persistAccountEntity();
-        final var tokenEntity = persistTokenEntity();
+        final var treasury = accountEntityPersist();
+        final var tokenEntity = tokenEntityPersist();
         final var token = domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
                         .type(TokenTypeEnum.FUNGIBLE_COMMON)
                         .treasuryAccountId(treasury.toEntityId()))
                 .persist();
-        persistAssociation(tokenEntity, treasury);
+        tokenAccountPersist(tokenEntity, treasury);
 
         final var totalSupply = token.getTotalSupply();
 
@@ -405,15 +405,15 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void burnNFT() throws Exception {
         // Given
-        final var treasury = persistAccountEntity();
-        final var tokenEntity = persistTokenEntity();
+        final var treasury = accountEntityPersist();
+        final var tokenEntity = tokenEntityPersist();
         final var token = domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
                         .type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE)
                         .treasuryAccountId(treasury.toEntityId()))
                 .persist();
-        persistAssociation(tokenEntity, treasury);
+        tokenAccountPersist(tokenEntity, treasury);
         final var totalSupply = token.getTotalSupply();
 
         domainBuilder
@@ -438,15 +438,15 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void wipeFungibleToken() throws Exception {
         // Given
-        final var owner = persistAccountEntity();
+        final var owner = accountEntityPersist();
 
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))
                 .persist();
 
-        persistAssociation(tokenEntity, owner);
+        tokenAccountPersist(tokenEntity, owner);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
@@ -462,15 +462,15 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void wipeNFT() throws Exception {
         // Given
-        final var owner = persistAccountEntity();
+        final var owner = accountEntityPersist();
 
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE))
                 .persist();
 
-        persistAssociation(tokenEntity, owner);
+        tokenAccountPersist(tokenEntity, owner);
         domainBuilder
                 .nft()
                 .customize(n -> n.tokenId(tokenEntity.getId()).serialNumber(1L).accountId(owner.toEntityId()))
@@ -490,15 +490,15 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void grantTokenKyc() throws Exception {
         // Given
-        final var accountWithoutGrant = persistAccountEntity();
+        final var accountWithoutGrant = accountEntityPersist();
 
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))
                 .persist();
 
-        persistAssociation(tokenEntity, accountWithoutGrant);
+        tokenAccountPersist(tokenEntity, accountWithoutGrant);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
@@ -514,15 +514,15 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void revokeTokenKyc() throws Exception {
         // Given
-        final var accountWithGrant = persistAccountEntity();
+        final var accountWithGrant = accountEntityPersist();
 
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))
                 .persist();
 
-        persistAssociation(tokenEntity, accountWithGrant);
+        tokenAccountPersist(tokenEntity, accountWithGrant);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
@@ -538,7 +538,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void deleteToken() throws Exception {
         // Given
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))
@@ -557,9 +557,9 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void freezeToken() throws Exception {
         // Given
-        final var accountWithoutFreeze = persistAccountEntity();
+        final var accountWithoutFreeze = accountEntityPersist();
         final var tokenEntity = persistFungibleToken();
-        persistAssociation(tokenEntity, accountWithoutFreeze);
+        tokenAccountPersist(tokenEntity, accountWithoutFreeze);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
@@ -575,7 +575,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void unfreezeToken() throws Exception {
         // Given
-        final var accountWithFreeze = persistAccountEntity();
+        final var accountWithFreeze = accountEntityPersist();
 
         final var tokenEntity = persistFungibleToken();
 
@@ -603,7 +603,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void pauseToken() throws Exception {
         // Given
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))
@@ -622,9 +622,9 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void unpauseToken() throws Exception {
         // Given
-        final var sender = persistAccountEntity();
+        final var sender = accountEntityPersist();
 
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -633,7 +633,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                         .pauseStatus(TokenPauseStatusEnum.PAUSED))
                 .persist();
 
-        persistAssociation(tokenEntity, sender);
+        tokenAccountPersist(tokenEntity, sender);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
@@ -686,7 +686,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         var value = 10000L * 100_000_000L;
 
         final var tokenForDenomination = persistFungibleToken();
-        final var feeCollector = persistAccountEntity();
+        final var feeCollector = accountEntityPersist();
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
@@ -766,7 +766,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         var value = 10000L * 100_000_000L;
 
         final var tokenForDenomination = persistFungibleToken();
-        final var feeCollector = persistAccountEntity();
+        final var feeCollector = accountEntityPersist();
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
@@ -811,10 +811,10 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void create2ContractAndTransferFromIt() throws Exception {
         // Given
-        final var sponsor = persistAccountEntity();
-        final var receiver = persistAccountEntity();
+        final var sponsor = accountEntityPersist();
+        final var receiver = accountEntityPersist();
         final var token = persistFungibleToken();
-        persistAssociation(token, sponsor);
+        tokenAccountPersist(token, sponsor);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
@@ -847,7 +847,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     void createFungibleTokenWithInheritKeysCall() throws Exception {
         // Given
         final var value = 10000 * 100_000_000L;
-        final var sender = persistAccountEntity();
+        final var sender = accountEntityPersist();
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
         // When
@@ -1049,13 +1049,13 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         // Given
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
         final var tokenEntity = persistFungibleToken();
-        final var sender = persistAccountEntity();
-        final var receiver = persistAccountEntity();
-        final var payer = persistAccountEntity();
+        final var sender = accountEntityPersist();
+        final var receiver = accountEntityPersist();
+        final var payer = accountEntityPersist();
 
-        persistAssociation(tokenEntity, payer);
-        persistAssociation(tokenEntity, sender);
-        persistAssociation(tokenEntity, receiver);
+        tokenAccountPersist(tokenEntity, payer);
+        tokenAccountPersist(tokenEntity, sender);
+        tokenAccountPersist(tokenEntity, receiver);
 
         // When
         testWeb3jService.setSender(getAliasFromEntity(payer));
@@ -1085,8 +1085,8 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     void transferNft(final String type) throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
-        final var sender = persistAccountEntity();
-        final var tokenEntity = persistTokenEntity();
+        final var sender = accountEntityPersist();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE))
@@ -1095,12 +1095,12 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                 .nft()
                 .customize(n -> n.tokenId(tokenEntity.getId()).serialNumber(1L).accountId(sender.toEntityId()))
                 .persist();
-        final var receiver = persistAccountEntity();
-        final var payer = persistAccountEntity();
+        final var receiver = accountEntityPersist();
+        final var payer = accountEntityPersist();
 
-        persistAssociation(tokenEntity, payer);
-        persistAssociation(tokenEntity, sender);
-        persistAssociation(tokenEntity, receiver);
+        tokenAccountPersist(tokenEntity, payer);
+        tokenAccountPersist(tokenEntity, sender);
+        tokenAccountPersist(tokenEntity, receiver);
 
         // When
         testWeb3jService.setSender(getAliasFromEntity(payer));
@@ -1130,8 +1130,8 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     void transferFromNft() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
-        final var sender = persistAccountEntity();
-        final var tokenEntity = persistTokenEntity();
+        final var sender = accountEntityPersist();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE))
@@ -1140,12 +1140,12 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                 .nft()
                 .customize(n -> n.tokenId(tokenEntity.getId()).serialNumber(1L).accountId(sender.toEntityId()))
                 .persist();
-        final var receiver = persistAccountEntity();
-        final var payer = persistAccountEntity();
+        final var receiver = accountEntityPersist();
+        final var payer = accountEntityPersist();
 
-        persistAssociation(tokenEntity, payer);
-        persistAssociation(tokenEntity, sender);
-        persistAssociation(tokenEntity, receiver);
+        tokenAccountPersist(tokenEntity, payer);
+        tokenAccountPersist(tokenEntity, sender);
+        tokenAccountPersist(tokenEntity, receiver);
 
         // When
         testWeb3jService.setSender(getAliasFromEntity(payer));
@@ -1169,9 +1169,9 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     void cryptoTransferHbars() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
-        final var sender = persistAccountEntity();
-        final var receiver = persistAccountEntity();
-        final var payer = persistAccountEntity();
+        final var sender = accountEntityPersist();
+        final var receiver = accountEntityPersist();
+        final var payer = accountEntityPersist();
 
         // When
         testWeb3jService.setSender(getAliasFromEntity(payer));
@@ -1192,14 +1192,14 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     void cryptoTransferToken() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
-        final var sender = persistAccountEntity();
+        final var sender = accountEntityPersist();
         final var tokenEntity = persistFungibleToken();
-        final var receiver = persistAccountEntity();
-        final var payer = persistAccountEntity();
+        final var receiver = accountEntityPersist();
+        final var payer = accountEntityPersist();
 
-        persistAssociation(tokenEntity, payer);
-        persistAssociation(tokenEntity, sender);
-        persistAssociation(tokenEntity, receiver);
+        tokenAccountPersist(tokenEntity, payer);
+        tokenAccountPersist(tokenEntity, sender);
+        tokenAccountPersist(tokenEntity, receiver);
 
         // When
         testWeb3jService.setSender(getAliasFromEntity(payer));
@@ -1224,14 +1224,14 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     void cryptoTransferHbarsAndToken() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
-        final var sender = persistAccountEntity();
+        final var sender = accountEntityPersist();
         final var tokenEntity = persistFungibleToken();
-        final var receiver = persistAccountEntity();
-        final var payer = persistAccountEntity();
+        final var receiver = accountEntityPersist();
+        final var payer = accountEntityPersist();
 
-        persistAssociation(tokenEntity, payer);
-        persistAssociation(tokenEntity, sender);
-        persistAssociation(tokenEntity, receiver);
+        tokenAccountPersist(tokenEntity, payer);
+        tokenAccountPersist(tokenEntity, sender);
+        tokenAccountPersist(tokenEntity, receiver);
 
         // When
         testWeb3jService.setSender(getAliasFromEntity(payer));
@@ -1259,8 +1259,8 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     void cryptoTransferNft() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
-        final var sender = persistAccountEntity();
-        final var tokenEntity = persistTokenEntity();
+        final var sender = accountEntityPersist();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE))
@@ -1269,12 +1269,12 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                 .nft()
                 .customize(n -> n.tokenId(tokenEntity.getId()).serialNumber(1L).accountId(sender.toEntityId()))
                 .persist();
-        final var receiver = persistAccountEntity();
-        final var payer = persistAccountEntity();
+        final var receiver = accountEntityPersist();
+        final var payer = accountEntityPersist();
 
-        persistAssociation(tokenEntity, payer);
-        persistAssociation(tokenEntity, sender);
-        persistAssociation(tokenEntity, receiver);
+        tokenAccountPersist(tokenEntity, payer);
+        tokenAccountPersist(tokenEntity, sender);
+        tokenAccountPersist(tokenEntity, receiver);
 
         // When
         testWeb3jService.setSender(getAliasFromEntity(payer));
@@ -1297,7 +1297,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void updateTokenInfo() throws Exception {
         // Given
-        final var treasuryAccount = persistAccountEntity();
+        final var treasuryAccount = accountEntityPersist();
         final var tokenWithAutoRenewPair =
                 persistTokenWithAutoRenewAndTreasuryAccounts(TokenTypeEnum.FUNGIBLE_COMMON, treasuryAccount);
 
@@ -1318,7 +1318,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     @Test
     void updateTokenExpiry() throws Exception {
         // Given
-        final var treasuryAccount = persistAccountEntity();
+        final var treasuryAccount = accountEntityPersist();
         final var tokenWithAutoRenewPair =
                 persistTokenWithAutoRenewAndTreasuryAccounts(TokenTypeEnum.FUNGIBLE_COMMON, treasuryAccount);
 
@@ -1354,7 +1354,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
     void updateTokenKey(final TokenTypeEnum tokenTypeEnum, final KeyValueType keyValueType) throws Exception {
         // Given
         final var allCasesKeyType = 0b1111111;
-        final var treasuryAccount = persistAccountEntity();
+        final var treasuryAccount = accountEntityPersist();
         final var tokenWithAutoRenewPair = persistTokenWithAutoRenewAndTreasuryAccounts(tokenTypeEnum, treasuryAccount);
 
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
@@ -1392,7 +1392,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
 
     private HederaToken populateHederaToken(
             final String contractAddress, final TokenTypeEnum tokenType, final EntityId treasuryAccountId) {
-        final var autoRenewAccount = persistAccountEntity();
+        final var autoRenewAccount = accountEntityPersist();
         final var tokenEntity = domainBuilder
                 .entity()
                 .customize(e -> e.type(EntityType.TOKEN).autoRenewAccountId(autoRenewAccount.getId()))
@@ -1423,7 +1423,7 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
 
     private Pair<Entity, Entity> persistTokenWithAutoRenewAndTreasuryAccounts(
             final TokenTypeEnum tokenType, final Entity treasuryAccount) {
-        final var autoRenewAccount = persistAccountEntity();
+        final var autoRenewAccount = accountEntityPersist();
         final var tokenToUpdateEntity = domainBuilder
                 .entity()
                 .customize(e -> e.type(EntityType.TOKEN).autoRenewAccountId(autoRenewAccount.getId()))
@@ -1470,12 +1470,8 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         };
     }
 
-    private Entity persistTokenEntity() {
-        return domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
-    }
-
     private Entity persistFungibleToken() {
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileReadonlyTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileReadonlyTest.java
@@ -107,8 +107,8 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void isTokenFrozen() throws Exception {
         // Given
-        final var account = persistAccountEntity();
-        final var tokenEntity = persistTokenEntity();
+        final var account = accountEntityPersist();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(
@@ -143,7 +143,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
                         .alias(SENDER_PUBLIC_KEY.toByteArray())
                         .evmAddress(SENDER_ALIAS.toArray()))
                 .persist();
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(
@@ -172,9 +172,9 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void isKycGranted() throws Exception {
         // Given
-        final var account = persistAccountEntity();
+        final var account = accountEntityPersist();
         final var tokenEntity = persistFungibleToken();
-        persistAssociation(tokenEntity, account);
+        tokenAccountPersist(tokenEntity, account);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContract::deploy);
 
@@ -197,7 +197,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
                         .evmAddress(SENDER_ALIAS.toArray()))
                 .persist();
         final var tokenEntity = persistFungibleToken();
-        persistAssociation(tokenEntity, account);
+        tokenAccountPersist(tokenEntity, account);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContract::deploy);
 
@@ -214,9 +214,9 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void isKycGrantedForNFT() throws Exception {
         // Given
-        final var account = persistAccountEntity();
+        final var account = accountEntityPersist();
         final var tokenEntity = persistNft();
-        persistAssociation(tokenEntity, account);
+        tokenAccountPersist(tokenEntity, account);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContract::deploy);
 
@@ -240,7 +240,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
                         .evmAddress(SENDER_ALIAS.toArray()))
                 .persist();
         final var tokenEntity = persistNft();
-        persistAssociation(tokenEntity, account);
+        tokenAccountPersist(tokenEntity, account);
 
         final var contract = testWeb3jService.deploy(PrecompileTestContract::deploy);
 
@@ -290,7 +290,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     void getDefaultKycToken() throws Exception {
         // Given
         domainBuilder.recordFile().customize(f -> f.index(0L)).persist();
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -312,7 +312,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void getDefaultKycNFT() throws Exception {
         // Given
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -370,7 +370,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void getTokenDefaultFreeze() throws Exception {
         // Given
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -392,7 +392,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void getNFTDefaultFreeze() throws Exception {
         // Given
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId())
@@ -492,7 +492,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void getCustomFeesForTokenWithFixedFee() throws Exception {
         // Given
-        final var collectorAccount = persistAccountEntity();
+        final var collectorAccount = accountEntityPersist();
         final var tokenEntity = persistFungibleToken();
         final var fixedFee = com.hedera.mirror.common.domain.token.FixedFee.builder()
                 .amount(100L)
@@ -530,7 +530,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void getCustomFeesForTokenWithFractionalFee() throws Exception {
         // Given
-        final var collectorAccount = persistAccountEntity();
+        final var collectorAccount = accountEntityPersist();
         final var tokenEntity = persistFungibleToken();
         final var fractionalFee = FractionalFee.builder()
                 .collectorAccountId(collectorAccount.toEntityId())
@@ -572,7 +572,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void getCustomFeesForTokenWithRoyaltyFee() throws Exception {
         // Given
-        final var collectorAccount = persistAccountEntity();
+        final var collectorAccount = accountEntityPersist();
         final var tokenEntity = persistFungibleToken();
         final var royaltyFee = RoyaltyFee.builder()
                 .collectorAccountId(collectorAccount.toEntityId())
@@ -618,7 +618,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
         // Given
         final var expiryPeriod = 9999999999999L;
         final var autoRenewExpiry = 100000000L;
-        final var autoRenewAccount = persistAccountEntity();
+        final var autoRenewAccount = accountEntityPersist();
         final var tokenEntity = domainBuilder
                 .entity()
                 .customize(e -> e.type(EntityType.TOKEN)
@@ -653,8 +653,8 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     void getAllowanceForToken() throws Exception {
         // Given
         final var amountGranted = 50L;
-        final var owner = persistAccountEntity();
-        final var spender = persistAccountEntity();
+        final var owner = accountEntityPersist();
+        final var spender = accountEntityPersist();
         final var tokenEntity = persistFungibleToken();
 
         domainBuilder
@@ -681,8 +681,8 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void isApprovedForAllNFT() throws Exception {
         // Given
-        final var owner = persistAccountEntity();
-        final var spender = persistAccountEntity();
+        final var owner = accountEntityPersist();
+        final var spender = accountEntityPersist();
         final var tokenEntity = persistNft();
 
         domainBuilder
@@ -708,8 +708,8 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void getFungibleTokenInfo() throws Exception {
         // Given
-        final var treasury = persistAccountEntity();
-        final var feeCollector = persistAccountEntity();
+        final var treasury = accountEntityPersist();
+        final var feeCollector = accountEntityPersist();
         final var tokenEntity =
                 domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
         final var token = domainBuilder
@@ -774,9 +774,9 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void getNonFungibleTokenInfo() throws Exception {
         // Given
-        final var owner = persistAccountEntity();
-        final var treasury = persistAccountEntity();
-        final var feeCollector = persistAccountEntity();
+        final var owner = accountEntityPersist();
+        final var treasury = accountEntityPersist();
+        final var feeCollector = accountEntityPersist();
         final var tokenEntity =
                 domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
         final var token = domainBuilder
@@ -852,8 +852,8 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @EnumSource(TokenTypeEnum.class)
     void getTokenInfo(final TokenTypeEnum tokenType) throws Exception {
         // Given
-        final var treasury = persistAccountEntity();
-        final var feeCollector = persistAccountEntity();
+        final var treasury = accountEntityPersist();
+        final var feeCollector = accountEntityPersist();
         final var tokenEntity =
                 domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
         final var token = domainBuilder
@@ -918,7 +918,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void nftInfoForInvalidSerialNo() {
         // Given
-        final var nftEntity = persistTokenEntity();
+        final var nftEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(nftEntity.getId()).type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE))
@@ -940,7 +940,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     @Test
     void tokenInfoForNonTokenAccount() {
         // Given
-        final var account = persistAccountEntity();
+        final var account = accountEntityPersist();
 
         final var contract = testWeb3jService.deploy(PrecompileTestContract::deploy);
 
@@ -1048,12 +1048,8 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
         };
     }
 
-    private Entity persistTokenEntity() {
-        return domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
-    }
-
     private Entity persistFungibleToken() {
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))
@@ -1063,7 +1059,7 @@ class ContractCallServicePrecompileReadonlyTest extends AbstractContractCallServ
     }
 
     private Entity persistNft() {
-        final var tokenEntity = persistTokenEntity();
+        final var tokenEntity = tokenEntityPersist();
         domainBuilder
                 .token()
                 .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.NON_FUNGIBLE_UNIQUE))

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/ContractCallTestUtil.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/ContractCallTestUtil.java
@@ -75,6 +75,8 @@ public class ContractCallTestUtil {
     };
 
     public static final long EVM_V_34_BLOCK = 50L;
+    public static final long EVM_V_30_BLOCK = EVM_V_34_BLOCK - 1;
+    public static final long EVM_V_38_BLOCK = 100L;
 
     /**
      * Checks if the *actual* gas usage is within 5-20% greater than the *expected* gas used from the initial call.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/ContractCallTestUtil.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/ContractCallTestUtil.java
@@ -75,7 +75,6 @@ public class ContractCallTestUtil {
     };
 
     public static final long EVM_V_34_BLOCK = 50L;
-    public static final long EVM_V_30_BLOCK = EVM_V_34_BLOCK - 1;
     public static final long EVM_V_38_BLOCK = 100L;
 
     /**

--- a/hedera-mirror-web3/src/testHistorical/solidity/EvmCodesHistorical.sol
+++ b/hedera-mirror-web3/src/testHistorical/solidity/EvmCodesHistorical.sol
@@ -22,4 +22,9 @@ contract EvmCodesHistorical {
     function getLatestBlockHash() public view returns (bytes32) {
         return blockhash(block.number);
     }
+
+    // External view function that retrieves the hbar balance of a given account
+    function getAccountBalance(address _owner) external view returns (uint) {
+        return _owner.balance;
+    }
 }

--- a/hedera-mirror-web3/src/testHistorical/solidity/ModificationPrecompileTestContractHistorical.sol
+++ b/hedera-mirror-web3/src/testHistorical/solidity/ModificationPrecompileTestContractHistorical.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.5.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+
+import "./HederaTokenService.sol";
+import "./HederaResponseCodes.sol";
+
+contract ModificationPrecompileTestContractHistorical is HederaTokenService {
+
+    function cryptoTransferExternal(IHederaTokenService.TransferList memory transferList, IHederaTokenService.TokenTransferList[] memory tokenTransfers) external
+    returns (int responseCode)
+    {
+        responseCode = HederaTokenService.cryptoTransfer(transferList, tokenTransfers);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert();
+        }
+    }
+
+}


### PR DESCRIPTION
**Description**:
This PR adds some new test related to the historical scenarios. They verify that the correct data is fetched having a particular historical timestamp. The tests are located in `ContractCallServiceHistoricalNegativeTest`.

A new abstract class is added - `AbstractContractCallServiceHistoricalTest`. It contains some common methods related to the historical data persist.

The methods in `AbstractContractCallServiceHistoricalTest` and `AbstractContractCallServiceTest` are named with <entity_type>persist instead of persist<entity_type> in order to use the IDE's auto suggest easily. The second approach would list too much methods as they all start with "p" and this makes the search harder, so I renamed some of the old methods.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/9317

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
