### PR TITLE
Bump Spring Framework from 6.1.12 to 6.1.13

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ extra.apply {
     set("nodeJsVersion", "18.18.0")
     set("protobufVersion", "3.25.3")
     set("reactorGrpcVersion", "1.2.4")
+    set("spring-framework.version", "6.1.13")
     set("vertxVersion", "4.5.10")
     set("tuweniVersion", "2.3.1")
 }


### PR DESCRIPTION
**Description**:

Bump Spring Framework from 6.1.12 to 6.1.13

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
