### PR TITLE
Bump express-open-validator from 5.3.5 to 5.3.6

### DIFF
--- a/hedera-mirror-rest/middleware/openapiHandler.js
+++ b/hedera-mirror-rest/middleware/openapiHandler.js
@@ -103,17 +103,16 @@ const serveSwaggerDocs = (app) => {
 };
 
 const openApiValidator = (app) => {
-  // Temporarily disable until express-openapi-validator updates vulnerable path-to-regexp dependency
-  // app.use(
-  //   OpenApiValidator.middleware({
-  //     apiSpec: path.resolve(process.cwd(), getSpecPath(1)),
-  //     ignoreUndocumented: true,
-  //     validateRequests: false,
-  //     validateResponses: {
-  //       allErrors: true,
-  //     },
-  //   })
-  // );
+  app.use(
+    OpenApiValidator.middleware({
+      apiSpec: path.resolve(process.cwd(), getSpecPath(1)),
+      ignoreUndocumented: true,
+      validateRequests: false,
+      validateResponses: {
+        allErrors: true,
+      },
+    })
+  );
 };
 
 export {getV1OpenApiObject, openApiValidator, serveSwaggerDocs};

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -52,7 +52,7 @@
         "cors": "^2.8.5",
         "express": "^4.21.0",
         "express-http-context": "^1.2.4",
-        "express-openapi-validator": "^5.3.5",
+        "express-openapi-validator": "^5.3.6",
         "extend": "^3.0.2",
         "ioredis": "^5.4.1",
         "ip-anonymize": "^0.1.0",
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.650.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.650.0.tgz",
-      "integrity": "sha512-6ZfkDu2FMOtYPV1ah5vWMqFKNKEqlBQ3/NOVvLGscU1dR0ybbOwwm4ywWofZmz72uOts5NGqe12kzohb/AsGAA==",
+      "version": "3.651.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.651.0.tgz",
+      "integrity": "sha512-37+kxxjnlOAUCb1aHpoLakW4XRG23HrkX8X3cEjxaFLQxorPUiMvfAYQEQQkYD5yggaG+5aM5GAhxkTUTqA5xw==",
       "inBundle": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -358,7 +358,7 @@
         "@aws-sdk/credential-provider-node": "3.650.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.649.0",
         "@aws-sdk/middleware-expect-continue": "3.649.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.649.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.651.0",
         "@aws-sdk/middleware-host-header": "3.649.0",
         "@aws-sdk/middleware-location-constraint": "3.649.0",
         "@aws-sdk/middleware-logger": "3.649.0",
@@ -755,15 +755,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.649.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.649.0.tgz",
-      "integrity": "sha512-8mzMBEA+Tk6rbrS8iqnXX119C6z+Id84cuzvUc6dAiYcbnOVbus8M4XKKsAFzGGXHCRc2gMwYhKdnoVz2ijaFA==",
+      "version": "3.651.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.651.0.tgz",
+      "integrity": "sha512-mGAOIjhNDcBK5+JD+W+Ky5YJL98jTNFTENJV/GiQ9t3CdqK3p02MNr/T6VwzEpzsJvJD23amogiEZeiqSQiibg==",
       "inBundle": true,
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-sdk/types": "3.649.0",
         "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/node-config-provider": "^3.1.5",
         "@smithy/protocol-http": "^4.1.1",
         "@smithy/types": "^3.4.0",
         "@smithy/util-utf8": "^3.0.0",
@@ -2519,23 +2520,23 @@
       }
     },
     "node_modules/@sinonjs/samsam": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
-      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/commons": "^3.0.1",
         "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
+        "type-detect": "^4.1.0"
       }
     },
-    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@sinonjs/text-encoding": {
@@ -4454,9 +4455,9 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.4.tgz",
-      "integrity": "sha512-7YyxitZEq0ey5loOF5gdo1fZQFF7290GziT+VbAJ+JbYTJYaPZwuEz2r/Nq23sm4fjyTgUf2uJI2gkT3xAuSYA==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz",
+      "integrity": "sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -4466,9 +4467,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.3.tgz",
-      "integrity": "sha512-FjkNiU3AwTQNQkcxFOmDcCfoN1LjjtU+ofGJh5DymZZLTqdw2i/CzV7G0h3snvh6G8jrWtdmNSgZPH4L2VOAsQ==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz",
+      "integrity": "sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==",
       "dev": true,
       "optional": true
     },
@@ -5760,9 +5761,9 @@
       "inBundle": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.20",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.20.tgz",
-      "integrity": "sha512-74mdl6Fs1HHzK9SUX4CKFxAtAe3nUns48y79TskHNAG6fGOlLfyKA4j855x+0b5u8rWJIrlaG9tcTPstMlwjIw==",
+      "version": "1.5.22",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.22.tgz",
+      "integrity": "sha512-tKYm5YHPU1djz0O+CGJ+oJIvimtsCcwR2Z9w7Skh08lUdyzXY5djods3q+z2JkWdb7tCcmM//eVavSRAiaPRNg==",
       "dev": true
     },
     "node_modules/emitter-listener": {
@@ -6546,9 +6547,9 @@
       }
     },
     "node_modules/express-openapi-validator": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-5.3.5.tgz",
-      "integrity": "sha512-C5lYJjRVOoP7kGYrGNaEoIFqA6dzb7iMJ9s4+OSJIMl6S8HT8cp/GObf8JrxNsiTYPNXMQv2fyLpwoBDRsDy9w==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-5.3.6.tgz",
+      "integrity": "sha512-T6ApZs7+UZFY/XFmpplkNgjkwIZ/mTJpn1eE58tKDYlyOugVkMj8AQlSozi+Kn5QiZHnuepWwMcEZs8/2wxwSA==",
       "inBundle": true,
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.0",
@@ -6563,7 +6564,7 @@
         "media-typer": "^1.1.0",
         "multer": "^1.4.5-lts.1",
         "ono": "^7.1.3",
-        "path-to-regexp": "^6.2.2"
+        "path-to-regexp": "^6.3.0"
       },
       "peerDependencies": {
         "express": "*"
@@ -6606,13 +6607,10 @@
       "inBundle": true
     },
     "node_modules/express-openapi-validator/node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "inBundle": true,
-      "engines": {
-        "node": ">=16"
-      }
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "inBundle": true
     },
     "node_modules/express/node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -9281,22 +9279,22 @@
       }
     },
     "node_modules/nise": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-6.0.1.tgz",
-      "integrity": "sha512-DAyWGPQEuJVlL2eqKw6gdZKT+E/jo/ZrjEUDAslJLluCz81nWy+KSYybNp3KFm887Yvp7hv12jSM82ld8BmLxg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^11.2.2",
-        "@sinonjs/text-encoding": "^0.7.2",
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
         "just-extend": "^6.2.0",
         "path-to-regexp": "^8.1.0"
       }
     },
     "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.3.1.tgz",
-      "integrity": "sha512-EVJO7nW5M/F5Tur0Rf2z/QoMo+1Ia963RiMtapiQrEWvY0iBUvADo8Beegwjpnle5BHkyHuoxSTW3jF43H1XRA==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.2.tgz",
+      "integrity": "sha512-4Bb+oqXZTSTZ1q27Izly9lv8B9dlV61CROxPiVtywwzv5SnytJqhvYe6FclHYuXml4cd1VHPo1zd5PmTeJozvA==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
@@ -11132,9 +11130,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.0.tgz",
-      "integrity": "sha512-ZGd1LhDeGFucr1CUCTBOS58ZhEendd0ttpGT3usTvosS4ntIwKN9LJFp+OeCSprsCPL14BXVRZlHGRY1V9PVzQ==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.1.tgz",
+      "integrity": "sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==",
       "dev": true,
       "dependencies": {
         "fast-fifo": "^1.3.2",
@@ -11442,13 +11440,10 @@
       "inBundle": true
     },
     "node_modules/swagger-stats/node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
-      "inBundle": true,
-      "engines": {
-        "node": ">=16"
-      }
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "inBundle": true
     },
     "node_modules/swagger-ui-dist": {
       "version": "5.17.14",
@@ -11566,9 +11561,9 @@
       "dev": true
     },
     "node_modules/text-decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
-      "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.0.tgz",
+      "integrity": "sha512-n1yg1mOj9DNpk3NeZOx7T6jchTbyJS3i3cucbNN6FcdPriMZx7NsgrGpWWdWZZGxD7ES1XB+3uoqHMgOKaN+fg==",
       "dev": true,
       "dependencies": {
         "b4a": "^1.6.4"

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -28,7 +28,7 @@
     "cors": "^2.8.5",
     "express": "^4.21.0",
     "express-http-context": "^1.2.4",
-    "express-openapi-validator": "^5.3.5",
+    "express-openapi-validator": "^5.3.6",
     "extend": "^3.0.2",
     "ioredis": "^5.4.1",
     "ip-anonymize": "^0.1.0",
@@ -76,12 +76,9 @@
   },
   "baseUrlPath": "/api/v1",
   "overrides": {
-    "express-openapi-validator": {
-      "path-to-regexp": "^8.1.0"
-    },
     "micromatch": "^4.0.8",
     "swagger-stats": {
-      "path-to-regexp": "^8.1.0",
+      "path-to-regexp": "^6.3.0",
       "send": "^0.19.0"
     }
   },


### PR DESCRIPTION
**Description**:

* Bump express-open-validator from `5.3.5` to `5.3.6` and remove override
* Downgrade path-to-regexp in swagger-stats to the newly patched `6.3.0`
* Re-enable Open API validator middleware

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
