### PR TITLE
Delete redundant web3j jars

### DIFF
--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -207,6 +207,17 @@ tasks.register<Copy>("moveAndCleanTestHistoricalFiles") {
     dependsOn(tasks.named("generateTestHistoricalContractWrappers"))
 }
 
+val deleteWeb3jJars =
+    tasks.register<Delete>("deleteWeb3jJars") {
+        description = "Deletes the web3 jars after they are no longer needed"
+        group = "historical"
+
+        val web3Jars = fileTree("build/libs") { include("web3*-${historicalSolidityVersion}*.jar") }
+        delete(web3Jars)
+
+        mustRunAfter(processTestHistoricalResources)
+    }
+
 afterEvaluate { tasks.named("resolveSolidity") { dependsOn("extractContracts") } }
 
 tasks.compileTestJava {
@@ -221,3 +232,5 @@ tasks.assemble {
     dependsOn(tasks.processTestResources)
     dependsOn(processTestHistoricalResources)
 }
+
+tasks.dockerBuild { dependsOn(deleteWeb3jJars) }

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -137,7 +137,6 @@ tasks.processTestResources {
 tasks.register("resolveSolidityHistorical", SolidityResolve::class) {
     group = "historical"
     description = "Resolves the historical solidity version $historicalSolidityVersion"
-    version = historicalSolidityVersion
     sources = fileTree("src/testHistorical/solidity")
     allowPaths = setOf("src/testHistorical/solidity")
 
@@ -207,17 +206,6 @@ tasks.register<Copy>("moveAndCleanTestHistoricalFiles") {
     dependsOn(tasks.named("generateTestHistoricalContractWrappers"))
 }
 
-val deleteWeb3jJars =
-    tasks.register<Delete>("deleteWeb3jJars") {
-        description = "Deletes the web3 jars after they are no longer needed"
-        group = "historical"
-
-        val web3Jars = fileTree("build/libs") { include("web3*-${historicalSolidityVersion}*.jar") }
-        delete(web3Jars)
-
-        mustRunAfter(processTestHistoricalResources)
-    }
-
 afterEvaluate { tasks.named("resolveSolidity") { dependsOn("extractContracts") } }
 
 tasks.compileTestJava {
@@ -232,5 +220,3 @@ tasks.assemble {
     dependsOn(tasks.processTestResources)
     dependsOn(processTestHistoricalResources)
 }
-
-tasks.dockerBuild { dependsOn(deleteWeb3jJars) }


### PR DESCRIPTION
**Description**:
Recently we added some gradle tasks for compiling historical contracts with older version of solidity - 0.8.7. After assemble task the build/libs directory is polluted with a couple of new 0.8.7-web3j*.jar jars and then running dockerBuild command fails encountering these jars.

This PR adds a new gradle task that deletes the problematic jars.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/9344

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
