### PR TITLE
Return empty contract results instead of code 404 when block not found

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/contracts/results/block-hash.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/block-hash.json
@@ -144,14 +144,11 @@
     },
     {
       "url": "/api/v1/contracts/results?block.hash=f39e30719c53716e35d25963e204b7ab840315c8b3f3a4df1ab1b3ad9d5bc7b9",
-      "responseStatus": 404,
+      "responseStatus": 200,
       "responseJson": {
-        "_status": {
-          "messages": [
-            {
-              "message": "Block not found"
-            }
-          ]
+        "results": [],
+        "links": {
+          "next": null
         }
       }
     }

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/block-number.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/block-number.json
@@ -284,14 +284,11 @@
     },
     {
       "url": "/api/v1/contracts/results?block.number=99",
-      "responseStatus": 404,
+      "responseStatus": 200,
       "responseJson": {
-        "_status": {
-          "messages": [
-            {
-              "message": "Block not found"
-            }
-          ]
+        "results": [],
+        "links": {
+          "next": null
         }
       }
     }

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/block-hash.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/block-hash.json
@@ -55,40 +55,64 @@
       }
     ]
   },
-  "urls": [
-    "/api/v1/contracts/0.0.5001/results?block.hash=eq:0x1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305312fcb305804a48baa41571e71c39c61",
-    "/api/v1/contracts/0.0.5001/results?block.hash=0x1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305312fcb305804a48baa41571e71c39c61",
-    "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=0x1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305312fcb305804a48baa41571e71c39c61",
-    "/api/v1/contracts/0.0.5001/results?block.hash=0x1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305",
-    "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=0x1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305",
-    "/api/v1/contracts/0.0.5001/results?block.hash=1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305312fcb305804a48baa41571e71c39c61",
-    "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305312fcb305804a48baa41571e71c39c61",
-    "/api/v1/contracts/0.0.5001/results?block.hash=1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305",
-    "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305"
-  ],
-  "responseStatus": 200,
-  "responseJson": {
-    "results": [
-      {
-        "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
-        "amount": 20,
-        "bloom": "0x0101",
-        "call_result": "0x0202",
-        "contract_id": "0.0.5001",
-        "created_contract_ids": [],
-        "error_message": null,
-        "from": "0x0000000000000000000000000000000000000065",
-        "function_parameters": "0x010102020303",
-        "gas_consumed": null,
-        "gas_limit": 1000,
-        "gas_used": 100,
-        "hash": "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
-        "timestamp": "187654.000123456",
-        "to": "0x0000000000000000000000000000000000001389"
+  "tests": [
+    {
+      "urls": [
+        "/api/v1/contracts/0.0.5001/results?block.hash=eq:0x1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305312fcb305804a48baa41571e71c39c61",
+        "/api/v1/contracts/0.0.5001/results?block.hash=0x1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305312fcb305804a48baa41571e71c39c61",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=0x1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305312fcb305804a48baa41571e71c39c61",
+        "/api/v1/contracts/0.0.5001/results?block.hash=0x1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=0x1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305",
+        "/api/v1/contracts/0.0.5001/results?block.hash=1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305312fcb305804a48baa41571e71c39c61",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305312fcb305804a48baa41571e71c39c61",
+        "/api/v1/contracts/0.0.5001/results?block.hash=1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=1eaf1abbd64bbcac7f473f0272671c66d3d1d64f584112b11cd4d2063e736305"
+      ],
+      "responseStatus": 200,
+      "responseJson": {
+        "results": [
+          {
+            "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+            "amount": 20,
+            "bloom": "0x0101",
+            "call_result": "0x0202",
+            "contract_id": "0.0.5001",
+            "created_contract_ids": [],
+            "error_message": null,
+            "from": "0x0000000000000000000000000000000000000065",
+            "function_parameters": "0x010102020303",
+            "gas_consumed": null,
+            "gas_limit": 1000,
+            "gas_used": 100,
+            "hash": "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            "timestamp": "187654.000123456",
+            "to": "0x0000000000000000000000000000000000001389"
+          }
+        ],
+        "links": {
+          "next": null
+        }
       }
-    ],
-    "links": {
-      "next": null
+    },
+    {
+      "urls": [
+        "/api/v1/contracts/0.0.5001/results?block.hash=eq:0x94810cb7affd56b2e31d405faa456d04f4d53f3c34b8270715a31d4447004e579f48599f3c793786d62fb3e5aec298c4",
+        "/api/v1/contracts/0.0.5001/results?block.hash=0x94810cb7affd56b2e31d405faa456d04f4d53f3c34b8270715a31d4447004e579f48599f3c793786d62fb3e5aec298c4",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=0x94810cb7affd56b2e31d405faa456d04f4d53f3c34b8270715a31d4447004e579f48599f3c793786d62fb3e5aec298c4",
+        "/api/v1/contracts/0.0.5001/results?block.hash=0x94810cb7affd56b2e31d405faa456d04f4d53f3c34b8270715a31d4447004e57",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=0x94810cb7affd56b2e31d405faa456d04f4d53f3c34b8270715a31d4447004e57",
+        "/api/v1/contracts/0.0.5001/results?block.hash=94810cb7affd56b2e31d405faa456d04f4d53f3c34b8270715a31d4447004e57",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=94810cb7affd56b2e31d405faa456d04f4d53f3c34b8270715a31d4447004e579f48599f3c793786d62fb3e5aec298c4",
+        "/api/v1/contracts/0.0.5001/results?block.hash=94810cb7affd56b2e31d405faa456d04f4d53f3c34b8270715a31d4447004e57",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.hash=94810cb7affd56b2e31d405faa456d04f4d53f3c34b8270715a31d4447004e57"
+      ],
+      "responseStatus": 200,
+      "responseJson": {
+        "results": [],
+        "links": {
+          "next": null
+        }
+      }
     }
-  }
+  ]
 }

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/block-number.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/block-number.json
@@ -67,36 +67,56 @@
       }
     ]
   },
-  "urls": [
-    "/api/v1/contracts/0.0.5001/results?block.number=eq:10",
-    "/api/v1/contracts/0.0.5001/results?block.number=10",
-    "/api/v1/contracts/0.0.5001/results?block.number=0xa",
-    "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.number=10",
-    "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.number=0xa"
-  ],
-  "responseStatus": 200,
-  "responseJson": {
-    "results": [
-      {
-        "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
-        "amount": 20,
-        "bloom": "0x0101",
-        "call_result": "0x0202",
-        "contract_id": "0.0.5001",
-        "created_contract_ids": [],
-        "error_message": null,
-        "from": "0x0000000000000000000000000000000000000065",
-        "function_parameters": "0x010102020303",
-        "gas_consumed": null,
-        "gas_limit": 1000,
-        "gas_used": 100,
-        "hash": "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
-        "timestamp": "1676540001.234390005",
-        "to": "0x0000000000000000000000000000000000001389"
+  "tests": [
+    {
+      "urls": [
+        "/api/v1/contracts/0.0.5001/results?block.number=eq:10",
+        "/api/v1/contracts/0.0.5001/results?block.number=10",
+        "/api/v1/contracts/0.0.5001/results?block.number=0xa",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.number=10",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.number=0xa"
+      ],
+      "responseStatus": 200,
+      "responseJson": {
+        "results": [
+          {
+            "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+            "amount": 20,
+            "bloom": "0x0101",
+            "call_result": "0x0202",
+            "contract_id": "0.0.5001",
+            "created_contract_ids": [],
+            "error_message": null,
+            "from": "0x0000000000000000000000000000000000000065",
+            "function_parameters": "0x010102020303",
+            "gas_consumed": null,
+            "gas_limit": 1000,
+            "gas_used": 100,
+            "hash": "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            "timestamp": "1676540001.234390005",
+            "to": "0x0000000000000000000000000000000000001389"
+          }
+        ],
+        "links": {
+          "next": null
+        }
       }
-    ],
-    "links": {
-      "next": null
+    },
+    {
+      "urls": [
+        "/api/v1/contracts/0.0.5001/results?block.number=eq:99",
+        "/api/v1/contracts/0.0.5001/results?block.number=99",
+        "/api/v1/contracts/0.0.5001/results?block.number=0x63",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.number=99",
+        "/api/v1/contracts/70f2b2914a2a4b783faefb75f459a580616fcb5e/results?block.number=0x63"
+      ],
+      "responseStatus": 200,
+      "responseJson": {
+        "results": [],
+        "links": {
+          "next": null
+        }
+      }
     }
-  }
+  ]
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR changes `/contracts/results` and `/contracts/{id}/results` to return empty contract results with code 200 when the block by `block.number=X` or `block.hash=X` query param doesn't exist.

**Related issue(s)**:

Fixes #9353 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
The bug was triggered because I added integration tests to cover 404 for the above scenarios. However it only failed after merging to main because in my PR branch openapi validator was disabled and only when it's enabled later and detects 404 is not a valid return code for the `/contracts/results` endpoint per our openapi spec.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
