### PR TITLE
Populate next link for endpoints with implicit timestamp range (0.113)

### DIFF
--- a/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp-notfound.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp-notfound.json
@@ -1,6 +1,5 @@
 {
   "description": "Account api calls for specific account using path and transaction timestamp lte filter",
-  "matrix": "bindTimestampRangeMatrix.js",
   "setup": {
     "accounts": [
       {

--- a/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/accounts/{id}/timestamp.json
@@ -183,10 +183,7 @@
       }
     ]
   },
-  "urls": [
-    "/api/v1/accounts/0.0.8?timestamp=gt:1234567890.000000006",
-    "/api/v1/accounts/0.0.KGNABD5L3ZGSRVUCSPDR7TONZSRY3D5OMEBKQMVTD2AC6JL72HMQ?timestamp=gt:1234567890.000000006"
-  ],
+  "urls": ["/api/v1/accounts/0.0.8?timestamp=gt:1234567890.000000006"],
   "responseStatus": 200,
   "responseJson": {
     "transactions": [
@@ -321,7 +318,10 @@
   },
   "responseJsonMatrix": {
     "bindTimestampRange=true": {
-      "transactions": []
+      "transactions": [],
+      "links": {
+        "next": "/api/v1/accounts/0.0.8?timestamp=gt:1234567890.000000006&timestamp=lt:1240270800.000000001"
+      }
     }
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/bind-timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/bind-timestamp.json
@@ -1,0 +1,194 @@
+{
+  "description": "Contract results api call for all contracts with bindTimestampRange",
+  "matrix": "bindTimestampRangeMatrix.js",
+  "setup": {
+    "contracts": [
+      {
+        "created_timestamp": "1720987654999123200",
+        "evm_address": "70f2b2914a2a4b783faefb75f459a580616fcb5e",
+        "file_id": "5002",
+        "key": [1, 1, 1],
+        "num": "5001",
+        "timestamp_range": "[1720987654999123300,)"
+      }
+    ],
+    "contractresults": [
+      {
+        "amount": 30,
+        "bloom": [5, 5],
+        "call_result": [6, 6],
+        "consensus_timestamp": "1720987654000123456",
+        "contract_id": 5001,
+        "created_contract_ids": [7001],
+        "error_message": "",
+        "function_parameters": [7, 7],
+        "function_result": [8, 8],
+        "gas_consumed": null,
+        "gas_limit": 1720987654,
+        "gas_used": 123,
+        "payer_account_id": 5000,
+        "sender_id": 8001,
+        "transaction_hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "transaction_nonce": 0
+      }
+    ],
+    "recordFiles": [
+      {
+        "index": 10,
+        "count": 1,
+        "hapi_version_major": "0",
+        "hapi_version_minor": "22",
+        "hapi_version_patch": "3",
+        "name": "2022-04-27T12_09_24.499938763Z.rcd",
+        "prev_hash": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "consensus_start": 1720987654000123450,
+        "consensus_end": 1720987654000123456,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+        "gas_used": 400000
+      }
+    ],
+    "ethereumtransactions": [
+      {
+        "consensus_timestamp": "1720987654000123456",
+        "hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "chain_id": "0x012a",
+        "max_fee_per_gas": "0x40",
+        "max_priority_fee_per_gas": "0x15",
+        "payer_account_id": 5000,
+        "signature_r": "0xb5c21ab4dfd336e30ac2106cad4aa8888b1873a99bce35d50f64d2ec2cc5f6d9",
+        "signature_s": "0x1092806a99727a20c31836959133301b65a2bfa980f9795522d21a254e629110",
+        "recovery_id": 1,
+        "nonce": 4,
+        "value": ["0x1e"]
+      }
+    ],
+    "transactions": [
+      {
+        "payerAccountId": "0.0.5000",
+        "nodeAccountId": "0.0.3",
+        "consensus_timestamp": "1720987654000123456",
+        "name": "CONTRACTCALL",
+        "type": "7",
+        "entity_id": "0.0.501"
+      },
+      {
+        "payerAccountId": "0.0.5000",
+        "nodeAccountId": "0.0.3",
+        "consensus_timestamp": "1",
+        "name": "CRYPTOTRANSFER",
+        "type": "7",
+        "entity_id": "0.0.401"
+      }
+    ]
+  },
+  "tests": [
+    {
+      "urls": [
+        "/api/v1/contracts/results?timestamp=gte:1720987654.000123456&order=asc"
+      ],
+      "responseStatus": 200,
+      "responseJson": {
+        "results": [
+          {
+            "access_list": "0x",
+            "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+            "amount": 30,
+            "block_gas_used": 400000,
+            "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+            "block_number": 10,
+            "bloom": "0x0505",
+            "call_result": "0x0606",
+            "chain_id": "0x12a",
+            "contract_id": "0.0.5001",
+            "created_contract_ids": ["0.0.7001"],
+            "error_message": null,
+            "failed_initcode": null,
+            "from": "0x0000000000000000000000000000000000001f41",
+            "function_parameters": "0x0707",
+            "gas_consumed": null,
+            "gas_limit": 1720987654,
+            "gas_price": "0x4a817c80",
+            "gas_used": 123,
+            "hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            "max_fee_per_gas": "0x40",
+            "max_priority_fee_per_gas": "0x15",
+            "nonce": 4,
+            "r": "0xb5c21ab4dfd336e30ac2106cad4aa8888b1873a99bce35d50f64d2ec2cc5f6d9",
+            "result": "SUCCESS",
+            "s": "0x1092806a99727a20c31836959133301b65a2bfa980f9795522d21a254e629110",
+            "status": "0x1",
+            "timestamp": "1720987654.000123456",
+            "to": "0x0000000000000000000000000000000000001389",
+            "transaction_index": 1,
+            "type": 2,
+            "v": 1
+          }
+        ],
+        "links": {
+          "next": null
+        }
+      },
+      "responseJsonMatrix": {
+        "bindTimestampRange=true": {
+          "links": {
+            "next": "/api/v1/contracts/results?order=asc&timestamp=gt:1726171654.000123455"
+          }
+        }
+      }
+    },
+    {
+      "urls": [
+        "/api/v1/contracts/results?timestamp=lte:1720987654.000123456&order=desc"
+      ],
+      "responseStatus": 200,
+      "responseJson": {
+        "results": [
+          {
+            "access_list": "0x",
+            "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+            "amount": 30,
+            "block_gas_used": 400000,
+            "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+            "block_number": 10,
+            "bloom": "0x0505",
+            "call_result": "0x0606",
+            "chain_id": "0x12a",
+            "contract_id": "0.0.5001",
+            "created_contract_ids": ["0.0.7001"],
+            "error_message": null,
+            "failed_initcode": null,
+            "from": "0x0000000000000000000000000000000000001f41",
+            "function_parameters": "0x0707",
+            "gas_consumed": null,
+            "gas_limit": 1720987654,
+            "gas_price": "0x4a817c80",
+            "gas_used": 123,
+            "hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            "max_fee_per_gas": "0x40",
+            "max_priority_fee_per_gas": "0x15",
+            "nonce": 4,
+            "r": "0xb5c21ab4dfd336e30ac2106cad4aa8888b1873a99bce35d50f64d2ec2cc5f6d9",
+            "result": "SUCCESS",
+            "s": "0x1092806a99727a20c31836959133301b65a2bfa980f9795522d21a254e629110",
+            "status": "0x1",
+            "timestamp": "1720987654.000123456",
+            "to": "0x0000000000000000000000000000000000001389",
+            "transaction_index": 1,
+            "type": 2,
+            "v": 1
+          }
+        ],
+        "links": {
+          "next": null
+        }
+      },
+      "responseJsonMatrix": {
+        "bindTimestampRange=true": {
+          "links": {
+            "next": "/api/v1/contracts/results?order=desc&timestamp=lt:1715803654.000123457"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/from-sender.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/from-sender.json
@@ -84,6 +84,32 @@
         "sender_id": 9001,
         "transaction_nonce": 0
       }
+    ],
+    "transactions": [
+      {
+        "payerAccountId": "0.0.5000",
+        "nodeAccountId": "0.0.3",
+        "consensus_timestamp": "1676540001234390005",
+        "name": "CONTRACTCALL",
+        "type": "7",
+        "entity_id": "0.0.9"
+      },
+      {
+        "payerAccountId": "0.0.5000",
+        "nodeAccountId": "0.0.3",
+        "consensus_timestamp": "1676540001234500005",
+        "name": "CONTRACTCALL",
+        "type": "7",
+        "entity_id": "0.0.9"
+      },
+      {
+        "payerAccountId": "0.0.5000",
+        "nodeAccountId": "0.0.3",
+        "consensus_timestamp": "1676540001234900005",
+        "name": "CONTRACTCALL",
+        "type": "7",
+        "entity_id": "0.0.9"
+      }
     ]
   },
   "tests": [

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/logs/bind-timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/logs/bind-timestamp.json
@@ -1,0 +1,116 @@
+{
+  "description": "Contracts logs api calls with bindTimestampRange=true",
+  "matrix": "bindTimestampRangeMatrix.js",
+  "setup": {
+    "recordFiles": [
+      {
+        "index": 1,
+        "consensus_start": 1639010141000000000,
+        "consensus_end": 1639010141500000000,
+        "hash": "fbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1a"
+      }
+    ],
+    "contractlogs": [
+      {
+        "consensus_timestamp": 1639010141000000000,
+        "contract_id": 1004,
+        "index": 0,
+        "topic0": [10],
+        "topic1": [11],
+        "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+        "transaction_index": 1
+      }
+    ],
+    "transactions": [
+      {
+        "charged_tx_fee": 0,
+        "payerAccountId": "0.0.9",
+        "nodeAccountId": "0.0.3",
+        "consensus_timestamp": 1369010102000000000,
+        "name": "CRYPTOUPDATEACCOUNT",
+        "type": "15",
+        "entity_id": "0.0.8"
+      }
+    ]
+  },
+  "tests": [
+    {
+      "urls": [
+        "/api/v1/contracts/results/logs?timestamp=gte:1639010141.000000000&order=asc"
+      ],
+      "responseStatus": 200,
+      "responseJson": {
+        "logs": [
+          {
+            "address": "0x00000000000000000000000000000000000003ec",
+            "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1a",
+            "block_number": 1,
+            "bloom": "0x0123",
+            "contract_id": "0.0.1004",
+            "data": "0x0000000000000000000000000000000000000000000000000000000000000123",
+            "index": 0,
+            "root_contract_id": null,
+            "timestamp": "1639010141.000000000",
+            "topics": [
+              "0x000000000000000000000000000000000000000000000000000000000000000a",
+              "0x000000000000000000000000000000000000000000000000000000000000000b",
+              "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+              "0xe8d47b56e8cdfa95f871b19d4f50a857217c44a95502b0811a350fec1500dd67"
+            ],
+            "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+            "transaction_index": 1
+          }
+        ],
+        "links": {
+          "next": null
+        }
+      },
+      "responseJsonMatrix": {
+        "bindTimestampRange=true": {
+          "links": {
+            "next": "/api/v1/contracts/results/logs?order=asc&timestamp=gte:1644194140.999999999&index=gt:0"
+          }
+        }
+      }
+    },
+    {
+      "urls": [
+        "/api/v1/contracts/results/logs?timestamp=lte:1639010141.000000000&order=desc"
+      ],
+      "responseStatus": 200,
+      "responseJson": {
+        "logs": [
+          {
+            "address": "0x00000000000000000000000000000000000003ec",
+            "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1a",
+            "block_number": 1,
+            "bloom": "0x0123",
+            "contract_id": "0.0.1004",
+            "data": "0x0000000000000000000000000000000000000000000000000000000000000123",
+            "index": 0,
+            "root_contract_id": null,
+            "timestamp": "1639010141.000000000",
+            "topics": [
+              "0x000000000000000000000000000000000000000000000000000000000000000a",
+              "0x000000000000000000000000000000000000000000000000000000000000000b",
+              "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+              "0xe8d47b56e8cdfa95f871b19d4f50a857217c44a95502b0811a350fec1500dd67"
+            ],
+            "transaction_hash": "0x9db63968721fc76815d11b0b97734669bf88ae3810e07c199924553f0548eb98",
+            "transaction_index": 1
+          }
+        ],
+        "links": {
+          "next": null
+        }
+      },
+      "responseJsonMatrix": {
+        "bindTimestampRange=true": {
+          "links": {
+            "next": "/api/v1/contracts/results/logs?order=desc&timestamp=lte:1633826141.000000001&index=lt:0"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/hedera-mirror-rest/__tests__/specs/contracts/results/order.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/results/order.json
@@ -100,6 +100,24 @@
         "nonce": 4,
         "value": ["0x1e"]
       }
+    ],
+    "transactions": [
+      {
+        "payerAccountId": "0.0.5000",
+        "nodeAccountId": "0.0.3",
+        "consensus_timestamp": "187654000123456",
+        "name": "ETHEREUMTRANSACTION",
+        "type": "50",
+        "entity_id": "0.0.9"
+      },
+      {
+        "payerAccountId": "0.0.5000",
+        "nodeAccountId": "0.0.3",
+        "consensus_timestamp": "987654000123456",
+        "name": "ETHEREUMTRANSACTION",
+        "type": "50",
+        "entity_id": "0.0.9"
+      }
     ]
   },
   "urls": ["/api/v1/contracts/results?order=asc"],
@@ -177,6 +195,83 @@
     ],
     "links": {
       "next": null
+    }
+  },
+  "responseJsonMatrix": {
+    "bindTimestampRange=true": {
+      "results": [
+        {
+          "access_list": "0x",
+          "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+          "amount": 20,
+          "block_gas_used": 400000,
+          "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+          "block_number": 10,
+          "bloom": "0x0101",
+          "call_result": "0x0202",
+          "chain_id": "0x12a",
+          "contract_id": "0.0.5001",
+          "created_contract_ids": [],
+          "error_message": "Not enough gas",
+          "failed_initcode": null,
+          "from": "0x0000000000000000000000000000000000001771",
+          "function_parameters": "0x0303",
+          "gas_consumed": null,
+          "gas_limit": 1234556,
+          "gas_price": "0x4a817c80",
+          "gas_used": 987,
+          "hash": "0x185602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "max_fee_per_gas": "0x55",
+          "max_priority_fee_per_gas": "0x3",
+          "nonce": 3,
+          "r": "0xb5c21ab4dfd336e30ac2106cad4aa8888b1873a99bce35d50f64d2ec2cc5f6d9",
+          "result": "SUCCESS",
+          "s": "0x1092806a99727a20c31836959133301b65a2bfa980f9795522d21a254e629110",
+          "status": "0x1",
+          "timestamp": "187654.000123456",
+          "to": "0x0000000000000000000000000000000000001389",
+          "transaction_index": 1,
+          "type": 2,
+          "v": 1
+        },
+        {
+          "access_list": "0x",
+          "address": "0x70f2b2914a2a4b783faefb75f459a580616fcb5e",
+          "amount": 30,
+          "block_gas_used": 400000,
+          "block_hash": "0xfbd921184e229e2051280d827ba3b31599117af7eafba65dc0e5a998b70c48c0492bf793a150769b1b4fb2c9b7cb4c1c",
+          "block_number": 10,
+          "bloom": "0x0505",
+          "call_result": "0x0606",
+          "chain_id": "0x12a",
+          "contract_id": "0.0.5001",
+          "created_contract_ids": ["0.0.7001"],
+          "error_message": null,
+          "failed_initcode": null,
+          "from": "0x0000000000000000000000000000000000001f41",
+          "function_parameters": "0x0707",
+          "gas_consumed": null,
+          "gas_limit": 987654,
+          "gas_price": "0x4a817c80",
+          "gas_used": 123,
+          "hash": "0x985602030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "max_fee_per_gas": "0x40",
+          "max_priority_fee_per_gas": "0x15",
+          "nonce": 4,
+          "r": "0xb5c21ab4dfd336e30ac2106cad4aa8888b1873a99bce35d50f64d2ec2cc5f6d9",
+          "result": "SUCCESS",
+          "s": "0x1092806a99727a20c31836959133301b65a2bfa980f9795522d21a254e629110",
+          "status": "0x1",
+          "timestamp": "987654.000123456",
+          "to": "0x0000000000000000000000000000000000001389",
+          "transaction_index": 1,
+          "type": 2,
+          "v": 1
+        }
+      ],
+      "links": {
+        "next": "/api/v1/contracts/results?order=asc&timestamp=gt:5371654.000123455"
+      }
     }
   }
 }

--- a/hedera-mirror-rest/__tests__/specs/transactions/timestamp.json
+++ b/hedera-mirror-rest/__tests__/specs/transactions/timestamp.json
@@ -194,7 +194,8 @@
     {
       "extendedDescription": [
         "when binding timestamp range, order=desc, and no upper bound in request, expect empty response, because there",
-        "are no transactions after the timestamp of 7 days before the fake time"
+        "are no transactions after the timestamp of 7 days before the fake time. Next link will be populated to query",
+        "the next 60 day period"
       ],
       "url": "/api/v1/transactions?timestamp=gte:1565779209.711927001&order=desc&limit=1",
       "responseStatus": 200,
@@ -247,7 +248,53 @@
         "bindTimestampRange=true": {
           "transactions": [],
           "links": {
+            "next": "/api/v1/transactions?timestamp=gte:1565779209.711927001&timestamp=lt:1565866200.000000001&order=desc&limit=1"
+          }
+        }
+      }
+    },
+    {
+      "extendedDescription": [
+        "when binding timestamp range, order=desc, and no upper bound in request, expect empty response, because there",
+        "are no transactions after the timestamp of 7 days before the fake time. Next link will not be populated since",
+        "the timestamp range falls within 60 days."
+      ],
+      "url": "/api/v1/transactions?timestamp=gt:1565866200.000000000&order=desc&limit=1",
+      "responseStatus": 200,
+      "responseJson": {
+        "transactions": [],
+        "links": {
+          "next": null
+        }
+      },
+      "responseJsonMatrix": {
+        "bindTimestampRange=true": {
+          "transactions": [],
+          "links": {
             "next": null
+          }
+        }
+      }
+    },
+    {
+      "extendedDescription": [
+        "when binding timestamp range, order=asc, and no upper bound in request, expect empty response, because there",
+        "are no transactions after the timestamp of 7 days before the fake time. Next link will be populated to query",
+        "the next 60 day period"
+      ],
+      "url": "/api/v1/transactions?timestamp=gt:1565779333.711927001&order=asc&limit=1",
+      "responseStatus": 200,
+      "responseJson": {
+        "transactions": [],
+        "links": {
+          "next": null
+        }
+      },
+      "responseJsonMatrix": {
+        "bindTimestampRange=true": {
+          "transactions": [],
+          "links": {
+            "next": "/api/v1/transactions?order=asc&limit=1&timestamp=gt:1570963333.711927001"
           }
         }
       }

--- a/hedera-mirror-rest/controllers/baseController.js
+++ b/hedera-mirror-rest/controllers/baseController.js
@@ -198,7 +198,7 @@ class BaseController {
    *
    * @param {Request} req
    * @param {*[]} rows
-   * @param {Bound}}[] bounds
+   * @param {Bound} bounds
    * @param {number} limit
    * @param {string} order
    * @return {string|null}
@@ -206,8 +206,9 @@ class BaseController {
   getPaginationLink(req, rows, bounds, limit, order) {
     const primaryBound = bounds.primary;
     const secondaryBound = bounds.secondary;
+    const isEnd = rows.length < limit;
 
-    if (rows.length < limit || (primaryBound.hasEqual() && secondaryBound.hasEqual())) {
+    if (!bounds.next && (isEnd || (primaryBound.hasEqual() && secondaryBound.hasEqual()))) {
       // fetched all matching rows or the query is for a specific combination
       return null;
     }
@@ -218,7 +219,7 @@ class BaseController {
       // the primary param has bound or no primary param at all
       // primary param should be exclusive when the secondary operator is eq
       lastValues[primaryBound.filterKey] = {
-        value: lastRow[primaryBound.viewModelKey],
+        value: !isEnd ? lastRow[primaryBound.viewModelKey] : bounds.next,
         inclusive: !secondaryBound.hasEqual(),
       };
     }

--- a/hedera-mirror-rest/controllers/bound.js
+++ b/hedera-mirror-rest/controllers/bound.js
@@ -31,6 +31,7 @@ class Bound {
     this.viewModelKey = !_.isNil(viewModelKey) ? viewModelKey : filterKey;
     this.equal = null;
     this.lower = null;
+    this.next = null;
     this.upper = null;
   }
 

--- a/hedera-mirror-rest/controllers/contractController.js
+++ b/hedera-mirror-rest/controllers/contractController.js
@@ -401,7 +401,7 @@ const optimizeTimestampFilters = async (timestampFilters, order) => {
   const filters = [];
 
   const {range, eqValues, neValues} = utils.parseTimestampFilters(timestampFilters, false, true, true, false, false);
-  const optimizedRange = eqValues.length === 0 ? await bindTimestampRange(range, order) : range;
+  const {range: optimizedRange, next} = eqValues.length === 0 ? await bindTimestampRange(range, order) : {range};
 
   if (optimizedRange?.begin) {
     filters.push({key: filterKeys.TIMESTAMP, operator: utils.opsMap.gte, value: optimizedRange.begin});
@@ -414,7 +414,7 @@ const optimizeTimestampFilters = async (timestampFilters, order) => {
   eqValues.forEach((value) => filters.push({key: filterKeys.TIMESTAMP, operator: utils.opsMap.eq, value}));
   neValues.forEach((value) => filters.push({key: filterKeys.TIMESTAMP, operator: utils.opsMap.ne, value}));
 
-  return filters;
+  return {filters, next};
 };
 
 class ContractController extends BaseController {
@@ -514,8 +514,8 @@ class ContractController extends BaseController {
       }
     }
 
-    const optimizedTimestampFilters =
-      contractId === undefined ? await optimizeTimestampFilters(timestampFilters, order) : timestampFilters;
+    const {filters: optimizedTimestampFilters, next} =
+      contractId === undefined ? await optimizeTimestampFilters(timestampFilters, order) : {filters: timestampFilters};
     for (const filter of optimizedTimestampFilters) {
       this.updateConditionsAndParamsWithInValues(
         filter,
@@ -546,6 +546,7 @@ class ContractController extends BaseController {
       params,
       order,
       limit,
+      next,
     };
   };
 
@@ -685,8 +686,9 @@ class ContractController extends BaseController {
       bounds.primary.parse({key: filterKeys.TIMESTAMP, operator: utils.opsMap.eq, value: rows[0].consensus_timestamp});
     } else if (contractId === undefined) {
       // Optimize timestamp filters only when there is no transaction hash and transaction id
-      const timestampFilters = await optimizeTimestampFilters(bounds.primary.getAllFilters(), order);
+      const {filters: timestampFilters, next} = await optimizeTimestampFilters(bounds.primary.getAllFilters(), order);
       bounds.primary = new Bound(filterKeys.TIMESTAMP);
+      query.bounds.next = next;
       for (const filter of timestampFilters) {
         bounds.primary.parse(filter);
       }
@@ -1058,7 +1060,7 @@ class ContractController extends BaseController {
       },
     };
     res.locals[responseDataLabel] = response;
-    const {conditions, params, order, limit, skip} = await this.extractContractResultsByIdQuery(filters);
+    const {conditions, params, order, limit, skip, next} = await this.extractContractResultsByIdQuery(filters);
     if (skip) {
       return;
     }
@@ -1088,11 +1090,12 @@ class ContractController extends BaseController {
         )
     );
 
+    const isEnd = response.results.length !== limit;
     const lastRow = _.last(response.results);
-    const lastContractResultTimestamp = lastRow.timestamp;
+    const lastContractResultTimestamp = !isEnd ? lastRow.timestamp : next;
     response.links.next = utils.getPaginationLink(
       req,
-      response.results.length !== limit,
+      isEnd && !next,
       {
         [filterKeys.TIMESTAMP]: lastContractResultTimestamp,
       },

--- a/hedera-mirror-rest/timestampRange.js
+++ b/hedera-mirror-rest/timestampRange.js
@@ -18,7 +18,7 @@ import {Range} from 'pg-range';
 
 import {orderFilterValues} from './constants';
 import config from './config';
-import {isTestEnv, nowInNs} from './utils';
+import {isTestEnv, nowInNs, nsToSecNs} from './utils';
 
 const queryConfig = config.query;
 
@@ -28,26 +28,27 @@ const queryConfig = config.query;
  *
  * @param {Range} range timestamp range, typically based on query parameters. Note the bounds should be '[]'
  * @param {string} order the order in the http request
- * @return {Range} fully bound timestamp range
+ * @return {Object} fully bound timestamp range and next timestamp
  */
 const bindTimestampRange = async (range, order) => {
   if (!queryConfig.bindTimestampRange) {
-    return range;
+    return {range};
   }
 
   const {maxTransactionsTimestampRangeNs} = queryConfig;
   const boundRange = Range(range?.begin ?? (await getFirstTransactionTimestamp()), range?.end ?? nowInNs(), '[]');
   if (boundRange.end - boundRange.begin + 1n <= maxTransactionsTimestampRangeNs) {
-    return boundRange;
+    return {range: boundRange};
   }
 
+  let next;
   if (order === orderFilterValues.DESC) {
-    boundRange.begin = boundRange.end - maxTransactionsTimestampRangeNs + 1n;
+    next = boundRange.begin = boundRange.end - maxTransactionsTimestampRangeNs + 1n;
   } else {
-    boundRange.end = boundRange.begin + maxTransactionsTimestampRangeNs - 1n;
+    next = boundRange.end = boundRange.begin + maxTransactionsTimestampRangeNs - 1n;
   }
 
-  return boundRange;
+  return {range: boundRange, next: nsToSecNs(next)};
 };
 
 /**
@@ -73,7 +74,7 @@ const getFirstTransactionTimestamp = (() => {
       logger.info(`First transaction's consensus timestamp is ${timestamp}`);
     }
 
-    return timestamp;
+    return BigInt(timestamp);
   };
 
   if (isTestEnv()) {

--- a/hedera-mirror-rest/transactions.js
+++ b/hedera-mirror-rest/transactions.js
@@ -423,7 +423,7 @@ const extractSqlFromTransactionsRequest = (filters) => {
 /**
  * @param filters The filters from the http request
  * @param timestampRange the timestamp range object
- * @return {Promise} the Promise for obtaining the results of the query
+ * @return {Object} the object for obtaining the results of the query
  */
 const getTransactionTimestamps = async (filters, timestampRange) => {
   if (timestampRange.eqValues.length > 1 || timestampRange.range?.isEmpty()) {
@@ -437,8 +437,11 @@ const getTransactionTimestamps = async (filters, timestampRange) => {
   const {accountQuery, creditDebitQuery, limit, limitQuery, order, resultTypeQuery, transactionTypeQuery, params} =
     result;
 
+  let nextTimestamp;
   if (timestampRange.eqValues.length === 0) {
-    timestampRange.range = await bindTimestampRange(timestampRange.range, order);
+    const {range, next} = await bindTimestampRange(timestampRange.range, order);
+    timestampRange.range = range;
+    nextTimestamp = next;
   }
 
   let [timestampQuery, timestampParams] = utils.buildTimestampQuery('t.consensus_timestamp', timestampRange);
@@ -456,7 +459,7 @@ const getTransactionTimestamps = async (filters, timestampRange) => {
   );
   const {rows} = await pool.queryQuietly(query, params);
 
-  return {limit, order, rows};
+  return {limit, order, nextTimestamp, rows};
 };
 
 /**
@@ -638,17 +641,25 @@ const keyMapper = (key) => {
  * @returns {Promise<{links: {next: String}, transactions: *}>}
  */
 const doGetTransactions = async (filters, req, timestampRange) => {
-  const {limit, order, rows: payerAndTimestamps} = await getTransactionTimestamps(filters, timestampRange);
+  const {
+    limit,
+    order,
+    nextTimestamp,
+    rows: payerAndTimestamps,
+  } = await getTransactionTimestamps(filters, timestampRange);
 
   const loader = (keys) => getTransactionsDetails(keys, order).then((result) => formatTransactionRows(result.rows));
 
   const transactions = await cache.get(payerAndTimestamps, loader, keyMapper);
 
+  const isEnd = transactions.length !== limit;
   const next = utils.getPaginationLink(
     req,
-    transactions.length !== limit,
+    isEnd && !nextTimestamp,
     {
-      [constants.filterKeys.TIMESTAMP]: transactions[transactions.length - 1]?.consensus_timestamp,
+      [constants.filterKeys.TIMESTAMP]: !isEnd
+        ? transactions[transactions.length - 1]?.consensus_timestamp
+        : nextTimestamp,
     },
     order
   );


### PR DESCRIPTION
**Description**:

Cherry pick of #9389 to `release/0.113`:

Populate next link for endpoints with implicit timestamp range

**Related issue(s)**:

Fixes #9380

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
