### PR TITLE
Increase RAM For Prometheus and PVC Size For Loki in Mainnet NA

### DIFF
--- a/clusters/mainnet-na/common/helmrelease.yaml
+++ b/clusters/mainnet-na/common/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
             external_url: https://mirrornode.grafana.net
       singleBinary:
         persistence:
-          size: 350Gi
+          size: 400Gi
         resources:
           limits:
             memory: 1Gi
@@ -66,9 +66,9 @@ spec:
           replicaExternalLabelName: __replica__
           resources:
             limits:
-              memory: 10Gi
+              memory: 10752Mi
             requests:
-              memory: 6Gi
+              memory: 10752Mi
     stackgres:
       enabled: true
     traefik:


### PR DESCRIPTION
* increase loki pvc to 400gb
* increase ram for prometheus to have requests and limits of 10752Mi