### PR TITLE
Implement `ContractBytecodeReadableKVState`

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
@@ -46,7 +46,7 @@ public class CommonEntityAccessor {
                 .orElseGet(() -> entityRepository.findByIdAndDeletedIsFalse(entityId.getId()));
     }
 
-    private Optional<Entity> getEntityByEvmAddressAndTimestamp(byte[] addressBytes, final Optional<Long> timestamp) {
+    public Optional<Entity> getEntityByEvmAddressAndTimestamp(byte[] addressBytes, final Optional<Long> timestamp) {
         return timestamp
                 .map(t -> entityRepository.findActiveByEvmAddressAndTimestamp(addressBytes, t))
                 .orElseGet(() -> entityRepository.findByEvmAddressAndDeletedIsFalse(addressBytes));

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
@@ -16,8 +16,6 @@
 
 package com.hedera.mirror.web3.state;
 
-import static com.hedera.services.utils.EntityIdUtils.toEntityId;
-
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
@@ -16,6 +16,8 @@
 
 package com.hedera.mirror.web3.state;
 
+import static com.hedera.services.utils.EntityIdUtils.toEntityId;
+
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
@@ -21,6 +21,7 @@ import static com.hedera.services.utils.EntityIdUtils.entityIdFromContractId;
 
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.state.contract.Bytecode;
+import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.web3.repository.ContractRepository;
@@ -79,8 +80,8 @@ public class ContractBytecodeReadableKVState extends ReadableKVStateBase<Contrac
                 return commonEntityAccessor
                         .getEntityByEvmAddressAndTimestamp(
                                 contractID.evmAddress().toByteArray(), Optional.empty())
-                        .get()
-                        .toEntityId();
+                        .map(Entity::toEntityId)
+                        .orElse(EntityId.EMPTY);
             }
         }
         return EntityId.EMPTY;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
@@ -16,34 +16,31 @@
 
 package com.hedera.mirror.web3.state;
 
-import static com.hedera.mirror.web3.state.Utils.convertContractIDToEntityId;
+import static com.hedera.services.utils.EntityIdUtils.toEntityId;
 
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.state.contract.Bytecode;
 import com.hedera.mirror.web3.repository.ContractRepository;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.spi.ReadableKVStateBase;
+import jakarta.annotation.Nonnull;
+import jakarta.inject.Named;
 import java.util.Collections;
 import java.util.Iterator;
-import org.jetbrains.annotations.NotNull;
 
+@Named
 public class ContractBytecodeReadableKVState extends ReadableKVStateBase<ContractID, Bytecode> {
-
-    private static final String KEY = "BYTECODE";
 
     private final ContractRepository contractRepository;
 
     protected ContractBytecodeReadableKVState(final ContractRepository contractRepository) {
-        super(KEY);
+        super("BYTECODE");
         this.contractRepository = contractRepository;
     }
 
     @Override
-    protected Bytecode readFromDataSource(@NotNull ContractID contractID) {
-        final var entityId = convertContractIDToEntityId(contractID);
-        if (entityId == null) {
-            return null;
-        }
+    protected Bytecode readFromDataSource(@Nonnull ContractID contractID) {
+        final var entityId = toEntityId(contractID);
 
         return contractRepository
                 .findRuntimeBytecode(entityId.getId())
@@ -52,7 +49,7 @@ public class ContractBytecodeReadableKVState extends ReadableKVStateBase<Contrac
                 .orElse(null);
     }
 
-    @NotNull
+    @Nonnull
     @Override
     protected Iterator<ContractID> iterateFromDataSource() {
         return Collections.emptyIterator();

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
@@ -45,9 +45,11 @@ public class ContractBytecodeReadableKVState extends ReadableKVStateBase<Contrac
             return null;
         }
 
-        final var runtimeCode = contractRepository.findRuntimeBytecode(entityId.getId());
-        final var runtimeBytes = runtimeCode.map(Bytes::wrap).orElse(null);
-        return runtimeBytes == null ? null : new Bytecode(runtimeBytes);
+        return contractRepository
+                .findRuntimeBytecode(entityId.getId())
+                .map(Bytes::wrap)
+                .map(Bytecode::new)
+                .orElse(null);
     }
 
     @NotNull

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
@@ -16,13 +16,13 @@
 
 package com.hedera.mirror.web3.state;
 
-import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdNumFromEvmAddress;
 import static com.hedera.mirror.web3.state.Utils.isMirror;
-import static com.hedera.services.utils.EntityIdUtils.toAddress;
+import static com.hedera.services.utils.EntityIdUtils.entityIdFromContractId;
 
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.state.contract.Bytecode;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.web3.repository.ContractRepository;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.spi.ReadableKVStateBase;
@@ -70,11 +70,11 @@ public class ContractBytecodeReadableKVState extends ReadableKVStateBase<Contrac
 
     private EntityId toEntityId(@Nonnull final com.hedera.hapi.node.base.ContractID contractID) {
         if (contractID.hasContractNum()) {
-            return EntityId.of(contractID.shardNum(), contractID.realmNum(), contractID.contractNum());
+            return entityIdFromContractId(contractID);
         } else if (contractID.hasEvmAddress()) {
-            final var evmAddress = toAddress(contractID.evmAddress());
+            final var evmAddress = contractID.evmAddress().toByteArray();
             if (isMirror(evmAddress)) {
-                return EntityId.of(entityIdNumFromEvmAddress(evmAddress));
+                return DomainUtils.fromEvmAddress(evmAddress);
             } else {
                 return commonEntityAccessor
                         .getEntityByEvmAddressAndTimestamp(

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
@@ -78,8 +78,7 @@ public class ContractBytecodeReadableKVState extends ReadableKVStateBase<Contrac
                 return DomainUtils.fromEvmAddress(evmAddress);
             } else {
                 return commonEntityAccessor
-                        .getEntityByEvmAddressAndTimestamp(
-                                contractID.evmAddress().toByteArray(), Optional.empty())
+                        .getEntityByEvmAddressAndTimestamp(evmAddress, Optional.empty())
                         .map(Entity::toEntityId)
                         .orElse(EntityId.EMPTY);
             }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
@@ -16,12 +16,10 @@
 
 package com.hedera.mirror.web3.state;
 
-import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdNumFromEvmAddress;
-import static com.hedera.mirror.web3.state.Utils.convertPbjBytesToBesuAddress;
+import static com.hedera.mirror.web3.state.Utils.convertContractIDToEntityId;
 
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.state.contract.Bytecode;
-import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.web3.repository.ContractRepository;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.spi.ReadableKVStateBase;
@@ -42,13 +40,8 @@ public class ContractBytecodeReadableKVState extends ReadableKVStateBase<Contrac
 
     @Override
     protected Bytecode readFromDataSource(@NotNull ContractID contractID) {
-        EntityId entityId;
-        if (contractID.hasContractNum()) {
-            entityId = EntityId.of(contractID.shardNum(), contractID.realmNum(), contractID.contractNum());
-        } else if (contractID.hasEvmAddress()) {
-            final var evmAddress = convertPbjBytesToBesuAddress(contractID.evmAddress());
-            entityId = EntityId.of(entityIdNumFromEvmAddress(evmAddress));
-        } else {
+        final var entityId = convertContractIDToEntityId(contractID);
+        if (entityId == null) {
             return null;
         }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVState.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state;
+
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.state.contract.Bytecode;
+import com.hedera.mirror.web3.repository.ContractRepository;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.state.spi.ReadableKVStateBase;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+
+public class ContractBytecodeReadableKVState extends ReadableKVStateBase<ContractID, Bytecode> {
+
+    private static final String KEY = "BYTECODE";
+
+    private final CommonEntityAccessor commonEntityAccessor;
+    private final ContractRepository contractRepository;
+
+    protected ContractBytecodeReadableKVState(
+            final CommonEntityAccessor commonEntityAccessor, final ContractRepository contractRepository) {
+        super(KEY);
+        this.commonEntityAccessor = commonEntityAccessor;
+        this.contractRepository = contractRepository;
+    }
+
+    @Override
+    protected Bytecode readFromDataSource(@NotNull ContractID contractID) {
+        final var contractEntity = commonEntityAccessor.get(contractID, Optional.empty());
+        if (contractEntity.isEmpty()) {
+            return null;
+        }
+
+        final var runtimeCode =
+                contractRepository.findRuntimeBytecode(contractEntity.get().getId());
+        final var runtimeBytes = runtimeCode.map(Bytes::wrap).orElse(null);
+        return runtimeBytes == null ? null : new Bytecode(runtimeBytes);
+    }
+
+    @NotNull
+    @Override
+    protected Iterator<ContractID> iterateFromDataSource() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public long size() {
+        return 0;
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
@@ -23,6 +23,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.time.Instant;
 import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
+import org.hyperledger.besu.datatypes.Address;
 
 @CustomLog
 @UtilityClass
@@ -51,5 +52,10 @@ public class Utils {
     public static Timestamp convertToTimestamp(final long timestamp) {
         var instant = Instant.ofEpochMilli(timestamp);
         return new Timestamp(instant.getEpochSecond(), instant.getNano());
+    }
+
+    public static Address convertPbjBytesToBesuAddress(final Bytes bytes) {
+        final var evmAddressBytes = bytes.toByteArray();
+        return Address.wrap(org.apache.tuweni.bytes.Bytes.wrap(evmAddressBytes));
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
@@ -19,8 +19,13 @@ package com.hedera.mirror.web3.state;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.pbj.runtime.ParseException;
+import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdNumFromEvmAddress;
+
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.time.Instant;
+import jakarta.annotation.Nullable;
 import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
 import org.hyperledger.besu.datatypes.Address;
@@ -57,5 +62,16 @@ public class Utils {
     public static Address convertPbjBytesToBesuAddress(final Bytes bytes) {
         final var evmAddressBytes = bytes.toByteArray();
         return Address.wrap(org.apache.tuweni.bytes.Bytes.wrap(evmAddressBytes));
+    }
+
+    @Nullable
+    public static EntityId convertContractIDToEntityId(final ContractID contractID) {
+        if (contractID.hasContractNum()) {
+            return EntityId.of(contractID.shardNum(), contractID.realmNum(), contractID.contractNum());
+        } else if (contractID.hasEvmAddress()) {
+            final var evmAddress = convertPbjBytesToBesuAddress(contractID.evmAddress());
+            return EntityId.of(entityIdNumFromEvmAddress(evmAddress));
+        }
+        return null;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
@@ -26,6 +26,7 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import jakarta.annotation.Nullable;
 import java.time.Instant;
+import java.util.Arrays;
 import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
 import org.hyperledger.besu.datatypes.Address;
@@ -35,6 +36,9 @@ import org.hyperledger.besu.datatypes.Address;
 public class Utils {
 
     public static final long DEFAULT_AUTO_RENEW_PERIOD = 7776000L;
+    public static final int EVM_ADDRESS_LEN = 20;
+    /* A placeholder to store the 12-byte of zeros prefix that marks an EVM address as a "mirror" address. */
+    private static final byte[] MIRROR_PREFIX = new byte[12];
 
     public static Key parseKey(final byte[] keyBytes) {
         try {
@@ -73,5 +77,17 @@ public class Utils {
             return EntityId.of(entityIdNumFromEvmAddress(evmAddress));
         }
         return null;
+    }
+
+    public boolean isMirror(final Address address) {
+        return isMirror(address.toArrayUnsafe());
+    }
+
+    public static boolean isMirror(final byte[] address) {
+        if (address.length != EVM_ADDRESS_LEN) {
+            return false;
+        }
+
+        return Arrays.equals(MIRROR_PREFIX, 0, 12, address, 0, 12);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
@@ -16,15 +16,10 @@
 
 package com.hedera.mirror.web3.state;
 
-import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdNumFromEvmAddress;
-
-import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.Timestamp;
-import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import jakarta.annotation.Nullable;
 import java.time.Instant;
 import java.util.Arrays;
 import lombok.CustomLog;
@@ -61,22 +56,6 @@ public class Utils {
     public static Timestamp convertToTimestamp(final long timestamp) {
         var instant = Instant.ofEpochMilli(timestamp);
         return new Timestamp(instant.getEpochSecond(), instant.getNano());
-    }
-
-    public static Address convertPbjBytesToBesuAddress(final Bytes bytes) {
-        final var evmAddressBytes = bytes.toByteArray();
-        return Address.wrap(org.apache.tuweni.bytes.Bytes.wrap(evmAddressBytes));
-    }
-
-    @Nullable
-    public static EntityId convertContractIDToEntityId(final ContractID contractID) {
-        if (contractID.hasContractNum()) {
-            return EntityId.of(contractID.shardNum(), contractID.realmNum(), contractID.contractNum());
-        } else if (contractID.hasEvmAddress()) {
-            final var evmAddress = convertPbjBytesToBesuAddress(contractID.evmAddress());
-            return EntityId.of(entityIdNumFromEvmAddress(evmAddress));
-        }
-        return null;
     }
 
     public boolean isMirror(final Address address) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
@@ -16,16 +16,16 @@
 
 package com.hedera.mirror.web3.state;
 
-import com.hedera.hapi.node.base.Key;
-import com.hedera.hapi.node.base.Timestamp;
-import com.hedera.pbj.runtime.ParseException;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdNumFromEvmAddress;
 
 import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import java.time.Instant;
 import jakarta.annotation.Nullable;
+import java.time.Instant;
 import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
 import org.hyperledger.besu.datatypes.Address;

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -17,7 +17,6 @@
 package com.hedera.services.utils;
 
 import static com.hedera.mirror.web3.evm.account.AccountAccessorImpl.EVM_ADDRESS_SIZE;
-import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdNumFromEvmAddress;
 import static com.hedera.node.app.service.evm.store.models.HederaEvmAccount.ECDSA_SECP256K1_ALIAS_SIZE;
 import static com.hedera.services.utils.BitPackUtils.numFromCode;
 import static java.lang.System.arraycopy;
@@ -202,19 +201,6 @@ public final class EntityIdUtils {
     public static Address toAddress(final com.hedera.pbj.runtime.io.buffer.Bytes bytes) {
         final var evmAddressBytes = bytes.toByteArray();
         return Address.wrap(org.apache.tuweni.bytes.Bytes.wrap(evmAddressBytes));
-    }
-
-    public static EntityId toEntityId(final com.hedera.hapi.node.base.ContractID contractID) {
-        if (contractID == null) {
-            return EntityId.EMPTY;
-        }
-        if (contractID.hasContractNum()) {
-            return EntityId.of(contractID.shardNum(), contractID.realmNum(), contractID.contractNum());
-        } else if (contractID.hasEvmAddress()) {
-            final var evmAddress = toAddress(contractID.evmAddress());
-            return EntityId.of(entityIdNumFromEvmAddress(evmAddress));
-        }
-        return EntityId.EMPTY;
     }
 
     private static long[] parseLongTriple(final String dotDelimited) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -17,6 +17,7 @@
 package com.hedera.services.utils;
 
 import static com.hedera.mirror.web3.evm.account.AccountAccessorImpl.EVM_ADDRESS_SIZE;
+import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdNumFromEvmAddress;
 import static com.hedera.node.app.service.evm.store.models.HederaEvmAccount.ECDSA_SECP256K1_ALIAS_SIZE;
 import static com.hedera.services.utils.BitPackUtils.numFromCode;
 import static java.lang.System.arraycopy;
@@ -196,6 +197,24 @@ public final class EntityIdUtils {
                 .realmNum(entityId.getRealm())
                 .tokenNum(entityId.getNum())
                 .build();
+    }
+
+    public static Address toAddress(final com.hedera.pbj.runtime.io.buffer.Bytes bytes) {
+        final var evmAddressBytes = bytes.toByteArray();
+        return Address.wrap(org.apache.tuweni.bytes.Bytes.wrap(evmAddressBytes));
+    }
+
+    public static EntityId toEntityId(final com.hedera.hapi.node.base.ContractID contractID) {
+        if (contractID == null) {
+            return EntityId.EMPTY;
+        }
+        if (contractID.hasContractNum()) {
+            return EntityId.of(contractID.shardNum(), contractID.realmNum(), contractID.contractNum());
+        } else if (contractID.hasEvmAddress()) {
+            final var evmAddress = toAddress(contractID.evmAddress());
+            return EntityId.of(entityIdNumFromEvmAddress(evmAddress));
+        }
+        return EntityId.EMPTY;
     }
 
     private static long[] parseLongTriple(final String dotDelimited) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVStateTest.java
@@ -16,18 +16,19 @@
 
 package com.hedera.mirror.web3.state;
 
+import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdNumFromEvmAddress;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.ContractID.ContractOneOfType;
 import com.hedera.hapi.node.state.contract.Bytecode;
-import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.web3.repository.ContractRepository;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.util.Optional;
+import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -37,44 +38,51 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ContractBytecodeReadableKVStateTest {
 
-    private static final ContractID CONTRACT_ID =
+    private static final ContractID CONTRACT_ID_WITH_NUM =
             new ContractID(1L, 0L, new OneOf<>(ContractOneOfType.CONTRACT_NUM, 1L));
-    private static final EntityId ENTITY_ID =
-            EntityId.of(CONTRACT_ID.shardNum(), CONTRACT_ID.realmNum(), CONTRACT_ID.contractNum());
+    private static final EntityId ENTITY_ID_WITH_NUM = EntityId.of(
+            CONTRACT_ID_WITH_NUM.shardNum(), CONTRACT_ID_WITH_NUM.realmNum(), CONTRACT_ID_WITH_NUM.contractNum());
     private static final Bytes BYTES = Bytes.fromBase64("123456");
     private static final Bytecode BYTECODE = new Bytecode(BYTES);
+    private static final String HEX = "0x00000000000000000000000000000000000004e4";
+    private static final Address ADDRESS = Address.fromHexString(HEX);
+    private static final ContractID CONTRACT_ID_WITH_EVM_ADDRESS =
+            new ContractID(1L, 0L, new OneOf<>(ContractOneOfType.EVM_ADDRESS, Bytes.wrap(ADDRESS.toArrayUnsafe())));
+    private static final EntityId ENTITY_ID_WITH_EVM_ADDRESS = EntityId.of(entityIdNumFromEvmAddress(ADDRESS));
 
     @InjectMocks
     private ContractBytecodeReadableKVState contractBytecodeReadableKVState;
 
     @Mock
-    private CommonEntityAccessor commonEntityAccessor;
-
-    @Mock
     private ContractRepository contractRepository;
 
     @Test
-    void whenContractEntityIsNullReturnNull() {
-        when(commonEntityAccessor.get(CONTRACT_ID, Optional.empty())).thenReturn(Optional.empty());
-        assertThat(contractBytecodeReadableKVState.get(CONTRACT_ID))
+    void whenContractIdAndEvmAddressAreNotSetReturnNull() {
+        assertThat(contractBytecodeReadableKVState.get(
+                        new ContractID(1L, 0L, new OneOf<>(ContractOneOfType.UNSET, null))))
                 .satisfies(slotValue -> assertThat(slotValue).isNull());
     }
 
     @Test
-    void whenContractEntityExistsReturnRuntimeBytecode() {
-        when(commonEntityAccessor.get(CONTRACT_ID, Optional.empty()))
-                .thenReturn(Optional.of(Entity.builder().id(ENTITY_ID.getId()).build()));
-        when(contractRepository.findRuntimeBytecode(ENTITY_ID.getId())).thenReturn(Optional.of(BYTES.toByteArray()));
-        assertThat(contractBytecodeReadableKVState.get(CONTRACT_ID))
+    void whenContractNumIsSetReturnRuntimeBytecode() {
+        when(contractRepository.findRuntimeBytecode(ENTITY_ID_WITH_NUM.getId()))
+                .thenReturn(Optional.of(BYTES.toByteArray()));
+        assertThat(contractBytecodeReadableKVState.get(CONTRACT_ID_WITH_NUM))
+                .satisfies(bytecode -> assertThat(bytecode).isEqualTo(BYTECODE));
+    }
+
+    @Test
+    void whenContractEvmAddressIsSetReturnRuntimeBytecode() {
+        when(contractRepository.findRuntimeBytecode(ENTITY_ID_WITH_EVM_ADDRESS.getId()))
+                .thenReturn(Optional.of(BYTES.toByteArray()));
+        assertThat(contractBytecodeReadableKVState.get(CONTRACT_ID_WITH_EVM_ADDRESS))
                 .satisfies(bytecode -> assertThat(bytecode).isEqualTo(BYTECODE));
     }
 
     @Test
     void whenContractRuntimeBytecodeIsNullReturnNull() {
-        when(commonEntityAccessor.get(CONTRACT_ID, Optional.empty()))
-                .thenReturn(Optional.of(Entity.builder().id(ENTITY_ID.getId()).build()));
-        when(contractRepository.findRuntimeBytecode(ENTITY_ID.getId())).thenReturn(Optional.empty());
-        assertThat(contractBytecodeReadableKVState.get(CONTRACT_ID))
+        when(contractRepository.findRuntimeBytecode(ENTITY_ID_WITH_NUM.getId())).thenReturn(Optional.empty());
+        assertThat(contractBytecodeReadableKVState.get(CONTRACT_ID_WITH_NUM))
                 .satisfies(bytecode -> assertThat(bytecode).isNull());
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVStateTest.java
@@ -89,7 +89,7 @@ class ContractBytecodeReadableKVStateTest {
 
     @Test
     void getExpectedSize() {
-        assertThat(contractBytecodeReadableKVState.size()).isEqualTo(0L);
+        assertThat(contractBytecodeReadableKVState.size()).isZero();
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVStateTest.java
@@ -27,6 +27,7 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.web3.repository.ContractRepository;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.Collections;
 import java.util.Optional;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
@@ -84,5 +85,15 @@ class ContractBytecodeReadableKVStateTest {
         when(contractRepository.findRuntimeBytecode(ENTITY_ID_WITH_NUM.getId())).thenReturn(Optional.empty());
         assertThat(contractBytecodeReadableKVState.get(CONTRACT_ID_WITH_NUM))
                 .satisfies(bytecode -> assertThat(bytecode).isNull());
+    }
+
+    @Test
+    void getExpectedSize() {
+        assertThat(contractBytecodeReadableKVState.size()).isEqualTo(0L);
+    }
+
+    @Test
+    void iterateFromDataSourceReturnsEmptyIterator() {
+        assertThat(contractBytecodeReadableKVState.iterateFromDataSource()).isEqualTo(Collections.emptyIterator());
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/ContractBytecodeReadableKVStateTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.ContractID.ContractOneOfType;
+import com.hedera.hapi.node.state.contract.Bytecode;
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.web3.repository.ContractRepository;
+import com.hedera.pbj.runtime.OneOf;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContractBytecodeReadableKVStateTest {
+
+    private static final ContractID CONTRACT_ID =
+            new ContractID(1L, 0L, new OneOf<>(ContractOneOfType.CONTRACT_NUM, 1L));
+    private static final EntityId ENTITY_ID =
+            EntityId.of(CONTRACT_ID.shardNum(), CONTRACT_ID.realmNum(), CONTRACT_ID.contractNum());
+    private static final Bytes BYTES = Bytes.fromBase64("123456");
+    private static final Bytecode BYTECODE = new Bytecode(BYTES);
+
+    @InjectMocks
+    private ContractBytecodeReadableKVState contractBytecodeReadableKVState;
+
+    @Mock
+    private CommonEntityAccessor commonEntityAccessor;
+
+    @Mock
+    private ContractRepository contractRepository;
+
+    @Test
+    void whenContractEntityIsNullReturnNull() {
+        when(commonEntityAccessor.get(CONTRACT_ID, Optional.empty())).thenReturn(Optional.empty());
+        assertThat(contractBytecodeReadableKVState.get(CONTRACT_ID))
+                .satisfies(slotValue -> assertThat(slotValue).isNull());
+    }
+
+    @Test
+    void whenContractEntityExistsReturnRuntimeBytecode() {
+        when(commonEntityAccessor.get(CONTRACT_ID, Optional.empty()))
+                .thenReturn(Optional.of(Entity.builder().id(ENTITY_ID.getId()).build()));
+        when(contractRepository.findRuntimeBytecode(ENTITY_ID.getId())).thenReturn(Optional.of(BYTES.toByteArray()));
+        assertThat(contractBytecodeReadableKVState.get(CONTRACT_ID))
+                .satisfies(bytecode -> assertThat(bytecode).isEqualTo(BYTECODE));
+    }
+
+    @Test
+    void whenContractRuntimeBytecodeIsNullReturnNull() {
+        when(commonEntityAccessor.get(CONTRACT_ID, Optional.empty()))
+                .thenReturn(Optional.of(Entity.builder().id(ENTITY_ID.getId()).build()));
+        when(contractRepository.findRuntimeBytecode(ENTITY_ID.getId())).thenReturn(Optional.empty());
+        assertThat(contractBytecodeReadableKVState.get(CONTRACT_ID))
+                .satisfies(bytecode -> assertThat(bytecode).isNull());
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/UtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/UtilsTest.java
@@ -17,13 +17,19 @@
 package com.hedera.mirror.web3.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hederahashgraph.api.proto.java.Key.KeyCase;
+import org.hyperledger.besu.datatypes.Address;
 import java.time.Instant;
+import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -84,5 +90,29 @@ class UtilsTest {
         // Then
         assertThat(result.seconds()).isEqualTo(expectedEpochSecond);
         assertThat(result.nanos()).isEqualTo(expectedNano);
+    }
+
+    @Test
+    void isMirrorAddressReturnsTrue() {
+        final var address = Address.fromHexString("0x00000000000000000000000000000000000004e4");
+        assertTrue(Utils.isMirror(address));
+    }
+
+    @Test
+    void isMirrorByteArrayAddressReturnsTrue() {
+        final var byteArrayAddress = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, -28};
+        assertTrue(Utils.isMirror(byteArrayAddress));
+    }
+
+    @Test
+    void isMirrorByteArrayAddressDoesNotStartWithZeroesReturnsFalse() {
+        final var byteArrayAddress = new byte[] {1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, -28};
+        assertFalse(Utils.isMirror(byteArrayAddress));
+    }
+
+    @Test
+    void isMirrorAddressLengthIncorrectReturnsFalse() {
+        byte[] address = new byte[] {0x01};
+        assertFalse(Utils.isMirror(address));
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/UtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/UtilsTest.java
@@ -18,16 +18,13 @@ package com.hedera.mirror.web3.state;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hederahashgraph.api.proto.java.Key.KeyCase;
-import org.hyperledger.besu.datatypes.Address;
 import java.time.Instant;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
@@ -43,6 +43,7 @@ import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.swirlds.common.utility.CommonUtils;
 import org.bouncycastle.util.encoders.Hex;
+import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -335,5 +336,51 @@ class EntityIdUtilsTest {
                 .tokenNum(3)
                 .build();
         assertEquals(expectedTokenId, EntityIdUtils.toTokenId(entityId));
+    }
+
+    @Test
+    void toEntityIdFromContractIdWithNum() {
+        final var contractId = com.hedera.hapi.node.base.ContractID.newBuilder()
+                .shardNum(1)
+                .realmNum(2)
+                .contractNum(3)
+                .build();
+
+        assertEquals(EntityId.of(1, 2, 3), EntityIdUtils.toEntityId(contractId));
+    }
+
+    @Test
+    void toEntityIdFromContractIdWithEvmAddress() {
+        final var address = Address.fromHexString("0x0000000000000000000000000000000000000001");
+        final var contractId = com.hedera.hapi.node.base.ContractID.newBuilder()
+                .shardNum(0)
+                .realmNum(0)
+                .evmAddress(Bytes.wrap(address.toArrayUnsafe()))
+                .build();
+
+        assertEquals(EntityId.of(0, 0, 1), EntityIdUtils.toEntityId(contractId));
+    }
+
+    @Test
+    void toEntityIdContractIdNull() {
+        assertEquals(EntityId.EMPTY, EntityIdUtils.toEntityId((com.hedera.hapi.node.base.ContractID) null));
+    }
+
+    @Test
+    void toEntityIdContractIdEmpty() {
+        final var contractId = com.hedera.hapi.node.base.ContractID.newBuilder()
+                .shardNum(0)
+                .realmNum(0)
+                .build();
+
+        assertEquals(EntityId.EMPTY, EntityIdUtils.toEntityId(contractId));
+    }
+
+    @Test
+    void toAddressFromPbjBytes() {
+        final var address = Address.fromHexString("0x0000000000000000000000000000000000000001");
+        final var pbjBytes = Bytes.fromHex("0000000000000000000000000000000000000001");
+
+        assertEquals(address, EntityIdUtils.toAddress(pbjBytes));
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
@@ -339,44 +339,6 @@ class EntityIdUtilsTest {
     }
 
     @Test
-    void toEntityIdFromContractIdWithNum() {
-        final var contractId = com.hedera.hapi.node.base.ContractID.newBuilder()
-                .shardNum(1)
-                .realmNum(2)
-                .contractNum(3)
-                .build();
-
-        assertEquals(EntityId.of(1, 2, 3), EntityIdUtils.toEntityId(contractId));
-    }
-
-    @Test
-    void toEntityIdFromContractIdWithEvmAddress() {
-        final var address = Address.fromHexString("0x0000000000000000000000000000000000000001");
-        final var contractId = com.hedera.hapi.node.base.ContractID.newBuilder()
-                .shardNum(0)
-                .realmNum(0)
-                .evmAddress(Bytes.wrap(address.toArrayUnsafe()))
-                .build();
-
-        assertEquals(EntityId.of(0, 0, 1), EntityIdUtils.toEntityId(contractId));
-    }
-
-    @Test
-    void toEntityIdContractIdNull() {
-        assertEquals(EntityId.EMPTY, EntityIdUtils.toEntityId((com.hedera.hapi.node.base.ContractID) null));
-    }
-
-    @Test
-    void toEntityIdContractIdEmpty() {
-        final var contractId = com.hedera.hapi.node.base.ContractID.newBuilder()
-                .shardNum(0)
-                .realmNum(0)
-                .build();
-
-        assertEquals(EntityId.EMPTY, EntityIdUtils.toEntityId(contractId));
-    }
-
-    @Test
     void toAddressFromPbjBytes() {
         final var address = Address.fromHexString("0x0000000000000000000000000000000000000001");
         final var pbjBytes = Bytes.fromHex("0000000000000000000000000000000000000001");


### PR DESCRIPTION
**Description**:
As part of the implementation for the reusable services we need to implement `ContractBytecodeReadableKVState`. It reads the contract's runtime bytecode and converts it to `Bytecode` PBJ type.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/9255

**Checklist**
- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
