### PR TITLE
feat: Use official web3j gradle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,7 +109,7 @@ dependencies {
         api("org.mockito:mockito-inline:5.2.0")
         api("software.amazon.awssdk:bom:2.28.11")
         api("uk.org.webcompere:system-stubs-jupiter:2.1.7")
-        api("org.web3j:core:4.12.0")
+        api("org.web3j:core:4.12.2")
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,7 +19,6 @@ plugins { `kotlin-dsl` }
 repositories {
     gradlePluginPortal()
     mavenCentral()
-    maven("https://jitpack.io")
 }
 
 dependencies {
@@ -53,7 +52,7 @@ dependencies {
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:5.1.0.4882")
     implementation("org.springframework.boot:spring-boot-gradle-plugin:3.3.4")
     implementation("org.testcontainers:postgresql:1.20.1")
-    implementation("com.github.kselveliev:web3j-gradle-plugin:4.12.0")
+    implementation("org.web3j:web3j-gradle-plugin:4.12.2")
 }
 
 val gitHook =


### PR DESCRIPTION
**Description**:
Use official web3j plugin

This pr adds
buildSrc - remove jitpack dependecy and use the official link of web3j plugin 4.12.2
updated web3j core to 4.12.2

**Related issue(s)**:

Fixes #9485 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
