### PR TITLE
Remove jetbrains annotation dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,6 @@ dependencies {
         api("org.gaul:s3proxy:2.3.0")
         api("org.hyperledger.besu:secp256k1:0.8.2")
         api("org.hyperledger.besu:evm:23.10.2")
-        api("org.jetbrains:annotations:25.0.0")
         api("org.mapstruct:mapstruct:$mapStructVersion")
         api("org.mapstruct:mapstruct-processor:$mapStructVersion")
         api("org.msgpack:jackson-dataformat-msgpack:0.9.8")

--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -28,6 +28,7 @@ plugins {
 configurations.all {
     exclude(group = "com.github.jnr") // Unused and has licensing issues
     exclude(group = "commons-logging", "commons-logging")
+    exclude(group = "org.jetbrains", module = "annotations")
     exclude(group = "org.slf4j", module = "slf4j-nop")
 }
 

--- a/hedera-mirror-common/build.gradle.kts
+++ b/hedera-mirror-common/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     api("org.apache.commons:commons-lang3")
     api("org.apache.tuweni:tuweni-bytes")
     api("org.apache.tuweni:tuweni-units")
-    api("org.jetbrains:annotations")
     api("org.springframework.boot:spring-boot-starter-data-jpa")
     testImplementation("org.hyperledger.besu:evm")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/scalar/GraphQlDuration.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/scalar/GraphQlDuration.java
@@ -27,9 +27,9 @@ import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
+import jakarta.annotation.Nonnull;
 import java.time.Duration;
 import java.util.Locale;
-import org.jetbrains.annotations.NotNull;
 
 public class GraphQlDuration implements Coercing<Duration, String> {
 
@@ -42,10 +42,10 @@ public class GraphQlDuration implements Coercing<Duration, String> {
 
     @Override
     public Duration parseLiteral(
-            @NotNull Value<?> input,
-            @NotNull CoercedVariables variables,
-            @NotNull GraphQLContext graphQLContext,
-            @NotNull Locale locale)
+            @Nonnull Value<?> input,
+            @Nonnull CoercedVariables variables,
+            @Nonnull GraphQLContext graphQLContext,
+            @Nonnull Locale locale)
             throws CoercingParseLiteralException {
         if (input instanceof StringValue str) {
             return Duration.parse(str.getValue());
@@ -54,8 +54,8 @@ public class GraphQlDuration implements Coercing<Duration, String> {
     }
 
     @Override
-    public @NotNull Duration parseValue(
-            @NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale)
+    public @Nonnull Duration parseValue(
+            @Nonnull Object input, @Nonnull GraphQLContext graphQLContext, @Nonnull Locale locale)
             throws CoercingParseValueException {
         if (input instanceof Duration duration) {
             return duration;
@@ -66,7 +66,7 @@ public class GraphQlDuration implements Coercing<Duration, String> {
     }
 
     @Override
-    public String serialize(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale)
+    public String serialize(@Nonnull Object input, @Nonnull GraphQLContext graphQLContext, @Nonnull Locale locale)
             throws CoercingSerializeException {
         if (input instanceof Duration duration) {
             return duration.toString();

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/scalar/GraphQlTimestamp.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/scalar/GraphQlTimestamp.java
@@ -27,9 +27,9 @@ import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
+import jakarta.annotation.Nonnull;
 import java.time.Instant;
 import java.util.Locale;
-import org.jetbrains.annotations.NotNull;
 
 public class GraphQlTimestamp implements Coercing<Instant, String> {
 
@@ -40,11 +40,11 @@ public class GraphQlTimestamp implements Coercing<Instant, String> {
             .build();
 
     @Override
-    public @NotNull Instant parseLiteral(
-            @NotNull Value<?> input,
-            @NotNull CoercedVariables variables,
-            @NotNull GraphQLContext graphQLContext,
-            @NotNull Locale locale)
+    public @Nonnull Instant parseLiteral(
+            @Nonnull Value<?> input,
+            @Nonnull CoercedVariables variables,
+            @Nonnull GraphQLContext graphQLContext,
+            @Nonnull Locale locale)
             throws CoercingParseLiteralException {
         if (input instanceof StringValue str) {
             return Instant.parse(str.getValue());
@@ -53,8 +53,8 @@ public class GraphQlTimestamp implements Coercing<Instant, String> {
     }
 
     @Override
-    public @NotNull Instant parseValue(
-            @NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale)
+    public @Nonnull Instant parseValue(
+            @Nonnull Object input, @Nonnull GraphQLContext graphQLContext, @Nonnull Locale locale)
             throws CoercingParseValueException {
         if (input instanceof Instant instant) {
             return instant;
@@ -65,7 +65,7 @@ public class GraphQlTimestamp implements Coercing<Instant, String> {
     }
 
     @Override
-    public String serialize(@NotNull Object input, @NotNull GraphQLContext graphQLContext, @NotNull Locale locale)
+    public String serialize(@Nonnull Object input, @Nonnull GraphQLContext graphQLContext, @Nonnull Locale locale)
             throws CoercingSerializeException {
         if (input instanceof Instant instant) {
             return instant.toString();

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/controller/GenericControllerAdvice.java
@@ -33,7 +33,6 @@ import com.hedera.mirror.web3.viewmodel.GenericErrorResponse;
 import com.hedera.mirror.web3.viewmodel.GenericErrorResponse.ErrorMessage;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
@@ -67,7 +66,7 @@ class GenericControllerAdvice extends ResponseEntityExceptionHandler {
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
-            public void addCorsMappings(@NotNull CorsRegistry registry) {
+            public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/api/v1/contracts/**").allowedOrigins("*");
             }
         };

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/OpcodesControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/OpcodesControllerTest.java
@@ -89,7 +89,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.hamcrest.core.StringContains;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -208,7 +207,7 @@ class OpcodesControllerTest {
                         })))));
     }
 
-    static Stream<Triple<EntityId, byte[], byte[]>> entityAddressCombinations(@Nullable EntityId entityId) {
+    static Stream<Triple<EntityId, byte[], byte[]>> entityAddressCombinations(EntityId entityId) {
         long entityIdNum = entityId == null ? 0L : entityId.getNum();
         // spotless:off
         Supplier<byte[]> validAlias = () -> new byte[]{

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractor.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractor.java
@@ -18,8 +18,8 @@ package com.hedera.mirror.web3.utils;
 
 import static com.hedera.mirror.web3.validation.HexValidator.HEX_PREFIX;
 
+import jakarta.annotation.Nonnull;
 import lombok.experimental.UtilityClass;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A utility class for extracting runtime bytecode from init bytecode of a smart contract.
@@ -47,7 +47,7 @@ public class RuntimeBytecodeExtractor {
         return HEX_PREFIX + runtimeBytecode; // Append "0x" prefix and return
     }
 
-    @NotNull
+    @Nonnull
     private static String getRuntimeBytecode(final String initBytecode) {
         // Find the first occurrence of "CODECOPY" (39)
         int codeCopyIndex = initBytecode.indexOf(CODECOPY);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/TransactionProviderEnum.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/TransactionProviderEnum.java
@@ -45,8 +45,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @Getter
 @RequiredArgsConstructor
@@ -64,31 +62,27 @@ public enum TransactionProviderEnum {
     private final byte[] hash = nextBytes(32);
     private final byte[] callData = nextBytes(256);
 
-    @NotNull
     private DomainBuilder domainBuilder = new DomainBuilder();
 
-    @NotNull
     private Consumer<TransactionProviderEnum> customizer = ignored -> {};
 
     @Setter
-    @Nullable
     private EntityId contractId;
 
     @Setter
-    private byte @Nullable [] contractEvmAddress;
+    private byte[] contractEvmAddress;
 
     @Setter
-    private byte @Nullable [] contractAlias;
+    private byte[] contractAlias;
 
     @Setter
-    @Nullable
     private EntityId payerAccountId;
 
     @Setter
-    private byte @Nullable [] payerEvmAddress;
+    private byte[] payerEvmAddress;
 
     @Setter
-    private byte @Nullable [] payerAlias;
+    private byte[] payerAlias;
 
     public TransactionProviderEnum customize(Consumer<TransactionProviderEnum> consumer) {
         this.customizer = consumer;


### PR DESCRIPTION
**Description**:

Enforce the use of standardized jakarta `@Nonnull` annotations.

* Remove jetbrains annotation dependency
* Exclude jetbrains annotation being pulled in via transitive dependencies

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
