### PR TITLE
Bump chart dependencies

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -80,12 +80,12 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install Stackgres
         run: |
           helm repo add stackgres https://stackgres.io/downloads/stackgres-k8s/stackgres/helm
-          helm install stackgres stackgres/stackgres-operator --version 1.11.0 --create-namespace -n stackgres
+          helm install stackgres stackgres/stackgres-operator --version 1.13.0 --create-namespace -n stackgres
 
       - name: Install ct
         uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1

--- a/buildSrc/src/main/kotlin/jooq-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/jooq-conventions.gradle.kts
@@ -137,7 +137,7 @@ abstract class PostgresService : BuildService<PostgresService.Params>, AutoClose
                     .readBytes()
             )
         container =
-            PostgreSQLContainer<Nothing>("postgres:14-alpine").apply {
+            PostgreSQLContainer<Nothing>("postgres:16-alpine").apply {
                 withCopyToContainer(initScript, "/docker-entrypoint-initdb.d/init.sh")
                 withUsername("postgres")
                 start()

--- a/charts/hedera-mirror-common/Chart.yaml
+++ b/charts/hedera-mirror-common/Chart.yaml
@@ -3,35 +3,35 @@ appVersion: 0.116.0-SNAPSHOT
 dependencies:
   - name: loki
     condition: loki.enabled
-    version: 5.47.2
+    version: 6.12.0
     repository: https://grafana.github.io/helm-charts
   - condition: prometheus-adapter.enabled
     name: prometheus-adapter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 4.9.1
+    version: 4.11.0
   - alias: prometheus
     condition: prometheus.enabled
     name: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    version: 57.2.0
+    version: 62.7.0
   - name: promtail
     condition: promtail.enabled
-    version: 6.15.5
+    version: 6.16.5
     repository: https://grafana.github.io/helm-charts
   - alias: stackgres
     condition: stackgres.enabled
     name: stackgres-operator
     repository: https://stackgres.io/downloads/stackgres-k8s/stackgres/helm/
-    version: 1.11.0
+    version: 1.13.0
   - condition: traefik.enabled
     name: traefik
     repository: https://helm.traefik.io/traefik
-    version: 26.1.0
+    version: 31.0.0
   - alias: zfs
     condition: zfs.enabled
     name: openebs
     repository: https://openebs.github.io/openebs
-    version: 4.0.1
+    version: 4.1.0
 description: Hedera Mirror Node common components installed globally for use across namespaces
 home: https://github.com/hashgraph/hedera-mirror-node
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-mirror-common/dashboards/hedera-mirror-rest.json
+++ b/charts/hedera-mirror-common/dashboards/hedera-mirror-rest.json
@@ -15,20 +15,14 @@
       }
     ]
   },
-  "description": "",
   "editable": false,
   "fiscalYearStartMonth": 0,
-  "gnetId": 3091,
   "graphTooltip": 0,
-  "id": 101,
+  "id": 57,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${prometheus}"
-      },
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -36,15 +30,7 @@
         "y": 0
       },
       "id": 30,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${prometheus}"
-          },
-          "refId": "A"
-        }
-      ],
+      "panels": [],
       "title": "Row title",
       "type": "row"
     },
@@ -94,13 +80,13 @@
         "y": 1
       },
       "id": 6,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "last"
@@ -108,10 +94,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "11.3.0-75826",
       "targets": [
         {
           "datasource": {
@@ -174,13 +162,13 @@
         "y": 1
       },
       "id": 1,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -188,10 +176,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "11.3.0-75826",
       "targets": [
         {
           "datasource": {
@@ -251,13 +241,13 @@
         "y": 1
       },
       "id": 4,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -265,10 +255,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "11.3.0-75826",
       "targets": [
         {
           "datasource": {
@@ -326,13 +318,13 @@
         "y": 1
       },
       "id": 21,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -340,10 +332,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "11.3.0-75826",
       "targets": [
         {
           "datasource": {
@@ -411,13 +405,13 @@
         "y": 1
       },
       "id": 3,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -425,10 +419,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "11.3.0-75826",
       "targets": [
         {
           "datasource": {
@@ -488,13 +484,13 @@
         "y": 1
       },
       "id": 2,
-      "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -502,10 +498,12 @@
           "fields": "",
           "values": false
         },
+        "showPercentChange": false,
         "text": {},
-        "textMode": "auto"
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "11.3.0-75826",
       "targets": [
         {
           "datasource": {
@@ -525,10 +523,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${prometheus}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -537,15 +531,6 @@
       },
       "id": 16,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${prometheus}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "HTTP",
       "type": "row"
     },
@@ -561,12 +546,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "hue",
@@ -618,7 +605,6 @@
         "y": 6
       },
       "id": 8,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [
@@ -637,7 +623,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "11.3.0-75826",
       "targets": [
         {
           "datasource": {
@@ -651,6 +637,21 @@
           "legendFormat": "{{ path }}",
           "range": true,
           "refId": "A",
+          "step": 10
+        },
+        {
+          "datasource": {
+            "uid": "${prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(api_request_total{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "1m",
+          "intervalFactor": 10,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B",
           "step": 10
         }
       ],
@@ -669,12 +670,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "hue",
@@ -726,7 +729,6 @@
         "y": 13
       },
       "id": 13,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [
@@ -745,7 +747,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "11.3.0-75826",
       "targets": [
         {
           "datasource": {
@@ -778,12 +780,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisGridShow": false,
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "hue",
@@ -839,7 +843,6 @@
         "y": 20
       },
       "id": 9,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [
@@ -858,7 +861,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.2.0-59542pre",
+      "pluginVersion": "11.3.0-75826",
       "targets": [
         {
           "datasource": {
@@ -891,8 +894,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -907,8 +909,6 @@
         "y": 27
       },
       "id": 28,
-      "interval": "",
-      "links": [],
       "maxDataPoints": 50,
       "options": {
         "displayMode": "gradient",
@@ -995,8 +995,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1015,7 +1014,6 @@
         "y": 34
       },
       "id": 7,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [
@@ -1104,8 +1102,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1124,7 +1121,6 @@
         "y": 41
       },
       "id": 20,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [
@@ -1178,8 +1174,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1194,8 +1189,6 @@
         "y": 48
       },
       "id": 23,
-      "interval": "",
-      "links": [],
       "maxDataPoints": 25,
       "options": {
         "displayMode": "gradient",
@@ -1236,10 +1229,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${prometheus}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1248,15 +1237,6 @@
       },
       "id": 18,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${prometheus}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Resources",
       "type": "row"
     },
@@ -1308,8 +1288,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1328,7 +1307,6 @@
         "y": 56
       },
       "id": 14,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [
@@ -1453,8 +1431,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1473,7 +1450,6 @@
         "y": 63
       },
       "id": 22,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [
@@ -1511,10 +1487,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${prometheus}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1523,15 +1495,6 @@
       },
       "id": 25,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${prometheus}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Logs",
       "type": "row"
     },
@@ -1583,8 +1546,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1638,6 +1600,10 @@
         "uid": "${loki}"
       },
       "description": "The log events",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 24,
@@ -1677,9 +1643,9 @@
       "type": "logs"
     }
   ],
+  "preload": false,
   "refresh": "1m",
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [
     "api",
     "application",
@@ -1690,15 +1656,18 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "text": "rest",
+          "value": "rest"
+        },
         "hide": 2,
         "name": "application",
         "query": "rest",
-        "skipUrlSync": false,
+        "skipUrlSync": true,
         "type": "constant"
       },
       {
         "current": {
-          "selected": false,
           "text": "",
           "value": ""
         },
@@ -1706,39 +1675,30 @@
         "hide": 2,
         "includeAll": false,
         "label": "Loki",
-        "multi": false,
         "name": "loki",
         "options": [],
         "query": "loki",
-        "queryValue": "",
         "refresh": 1,
         "regex": ".*(Loki|logs)$",
-        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "current": {
-          "selected": false,
           "text": "default",
           "value": "default"
         },
         "description": "Name of the Prometheus datasource to use",
-        "hide": 0,
         "includeAll": false,
         "label": "Prometheus",
-        "multi": false,
         "name": "prometheus",
         "options": [],
         "query": "prometheus",
-        "queryValue": "",
         "refresh": 1,
         "regex": ".*(?<!usage)",
-        "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -1752,7 +1712,6 @@
         },
         "definition": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\"}, cluster)",
         "description": "Kubernetes cluster",
-        "hide": 0,
         "includeAll": true,
         "label": "Cluster",
         "multi": true,
@@ -1764,13 +1723,11 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 5,
         "type": "query"
       },
       {
         "current": {
-          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -1779,10 +1736,8 @@
           "uid": "${prometheus}"
         },
         "definition": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\",cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
         "includeAll": true,
         "label": "Namespace",
-        "multi": false,
         "name": "namespace",
         "options": [],
         "query": {
@@ -1791,16 +1746,11 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 5,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "current": {
-          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -1809,10 +1759,8 @@
           "uid": "${prometheus}"
         },
         "definition": "label_values(nodejs_process_cpu_usage_percentage{container=\"$application\",cluster=~\"$cluster\",namespace=~\"$namespace\"}, pod)",
-        "hide": 0,
         "includeAll": true,
         "label": "Pod",
-        "multi": false,
         "name": "pod",
         "options": [],
         "query": {
@@ -1821,12 +1769,8 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 5,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       }
     ]
   },
@@ -1834,34 +1778,10 @@
     "from": "now-3h",
     "to": "now"
   },
-  "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
-  },
+  "timepicker": {},
   "timezone": "",
   "title": "Hedera / Mirror / REST API",
   "uid": "0vnSftR7z",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -4,9 +4,22 @@ global:
 labels: {}
 
 loki:
+  backend:
+    replicas: 0
+  chunksCache:
+    enabled: false
+  compactor:
+    replicas: 0
+  deploymentMode: SingleBinary
+  distributor:
+    replicas: 0
   enabled: true
   gateway:
     enabled: false
+  indexGateway:
+    replicas: 0
+  ingester:
+    replicas: 0
   loki:
     auth_enabled: false
     commonConfig:
@@ -26,16 +39,37 @@ loki:
           type: local
           local:
             directory: /rules
+      schema_config:
+        configs:
+          - from: "2022-01-11"
+            index:
+              prefix: loki_index_
+              period: 24h
+            object_store: filesystem
+            schema: v13
+            store: tsdb
       table_manager:
         retention_deletes_enabled: true
         retention_period: 1440h
+  lokiCanary:
+    enabled: false
   monitoring:
-    lokiCanary:
-      enabled: false
     selfMonitoring:
       enabled: false
       grafanaAgent:
         installOperator: false
+  querier:
+    replicas: 0
+  queryFrontend:
+    replicas: 0
+  queryScheduler:
+    replicas: 0
+  read:
+    replicas: 0
+  resultsCache:
+    enabled: false
+  ruler:
+    replicas: 0
   rules:
     - name: hedera-mirror-grpc
       rules:
@@ -143,12 +177,14 @@ loki:
     resources:
       limits:
         cpu: 200m
-        memory: 384Mi
+        memory: 512Mi
       requests:
-        cpu: 50m
-        memory: 64Mi
+        cpu: 100m
+        memory: 128Mi
   test:
     enabled: false
+  write:
+    replicas: 0
 
 networkPolicy:
   enabled: false
@@ -248,11 +284,11 @@ prometheus:
   kube-state-metrics:
     resources:
       limits:
+        cpu: 20m
+        memory: 128Mi
+      requests:
         cpu: 10m
         memory: 64Mi
-      requests:
-        cpu: 5m
-        memory: 16Mi
   # We disable these exporters because they either don't work in GKE or produce too many time series
   kubeApiServer:
     enabled: false
@@ -381,7 +417,7 @@ testkube:
     image:
       registry: docker.io
       repository: grafana/k6
-      tag: 0.50.0
+      tag: 0.53.0
   namespace: testkube
   test:
     config:

--- a/charts/hedera-mirror-graphql/values.yaml
+++ b/charts/hedera-mirror-graphql/values.yaml
@@ -308,7 +308,7 @@ test:
     pullPolicy: IfNotPresent
     pullSecrets: []
     repository: postman/newman
-    tag: 6.1.1-alpine
+    tag: 6.1.3-alpine
   postman: ""  # Custom postman.json in base64 encoding
   priorityClassName: ""
 

--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -296,7 +296,7 @@ test:
     pullPolicy: IfNotPresent
     pullSecrets: []
     repository: postman/newman
-    tag: 6.1.1-alpine
+    tag: 6.1.3-alpine
   postman: ""  # Custom postman.json in base64 encoding
   priorityClassName: ""
 

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -239,7 +239,7 @@ test:
     pullPolicy: IfNotPresent
     pullSecrets: []
     repository: postman/newman
-    tag: 6.1.1-alpine
+    tag: 6.1.3-alpine
   postman: ""  # Custom postman.json in base64 encoding
   priorityClassName: ""
 

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -291,7 +291,7 @@ test:
     pullPolicy: IfNotPresent
     pullSecrets: []
     repository: postman/newman
-    tag: 6.1.1-alpine
+    tag: 6.1.3-alpine
   postman: ""  # Custom postman.json in base64 encoding
   priorityClassName: ""
 

--- a/charts/hedera-mirror/Chart.yaml
+++ b/charts/hedera-mirror/Chart.yaml
@@ -29,11 +29,11 @@ dependencies:
     condition: postgresql.enabled
     name: postgresql-ha
     repository: https://charts.bitnami.com/bitnami
-    version: 14.0.0
+    version: 14.2.27
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 19.0.2
+    version: 20.1.2
   - alias: rest
     condition: rest.enabled
     name: hedera-mirror-rest

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -175,7 +175,6 @@ postgresql:
     extraEnvVarsSecret: mirror-passwords
     image:
       debug: true
-      tag: 14.11.0-debian-12-r8
     initdbScriptsCM: "{{ .Release.Name }}-init"
     maxConnections: 200
     password: ""  # Randomly generated if left blank

--- a/charts/marketplace/gcp/release.sh
+++ b/charts/marketplace/gcp/release.sh
@@ -2,7 +2,7 @@
 set -ex
 
 if [[ "$#" -lt 1 ]]; then
-    echo "You must provide the Mirror Node image tag (e.g. 0.14.0)"
+    echo "You must provide the Mirror Node image tag (e.g. 0.116.0)"
     exit 1
 fi
 
@@ -21,7 +21,7 @@ fi
 target_tag="${target_tag#v}" # Strip v prefix if present
 target_tag_minor="${target_tag%\.*}"
 bats_tag="1.11.0"
-postgresql_tag="14.11.0-debian-12-r8"
+postgresql_tag="16.4.0-debian-12-r14"
 registry="gcr.io/mirror-node-public/hedera-mirror-node"
 
 function retag() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   db:
-    image: postgres:14-alpine
+    image: postgres:16-alpine
     environment:
       PGDATA: /var/lib/postgresql/data
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256

--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -10,7 +10,7 @@ requirements that the Hedera managed mirror node uses. This is for a database wi
 by many external clients. If operators store less data or only have a few internal clients then potentially some of
 these requirements can be relaxed.
 
-- PostgreSQL 14+
+- PostgreSQL 16+
 - 10 vCPUs
 - 40 GiB memory
 - 1-55 TiB

--- a/docs/importer/README.md
+++ b/docs/importer/README.md
@@ -86,7 +86,7 @@ should be able to ingest one month's worth of mainnet data in less than 1.5 days
 
 - Resource allocation
 
-  Run a PostgreSQL 14 instance with at least 4 vCPUs and 16 GB memory.
+  Run a PostgreSQL 16 instance with at least 4 vCPUs and 16 GB memory.
 
 - Configuration:
 

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/CommonTestConfiguration.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/CommonTestConfiguration.java
@@ -99,7 +99,7 @@ public class CommonTestConfiguration {
     @Bean(POSTGRESQL)
     @ServiceConnection("postgresql")
     PostgreSQLContainer<?> postgresql() {
-        var imageName = v2 ? "gcr.io/mirrornode/citus:12.1.1" : "postgres:14-alpine";
+        var imageName = v2 ? "gcr.io/mirrornode/citus:12.1.1" : "postgres:16-alpine";
         var dockerImageName = DockerImageName.parse(imageName).asCompatibleSubstituteFor("postgres");
         var logger = LoggerFactory.getLogger(PostgreSQLContainer.class);
         var excluded = "terminating connection due to unexpected postmaster exit";

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/config/SpecTestConfig.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/config/SpecTestConfig.java
@@ -49,7 +49,7 @@ public class SpecTestConfig {
     @Bean(POSTGRESQL)
     @ServiceConnection("postgresql")
     PostgreSQLContainer<?> postgresqlOverride(Network postgresqlNetwork) {
-        var imageName = v2 ? "gcr.io/mirrornode/citus:12.1.1" : "postgres:14-alpine";
+        var imageName = v2 ? "gcr.io/mirrornode/citus:12.1.1" : "postgres:16-alpine";
         var dockerImageName = DockerImageName.parse(imageName).asCompatibleSubstituteFor("postgres");
         var logger = LoggerFactory.getLogger(PostgreSQLContainer.class);
         var excluded = "terminating connection due to unexpected postmaster exit";

--- a/hedera-mirror-rest/__tests__/integrationDbOps.js
+++ b/hedera-mirror-rest/__tests__/integrationDbOps.js
@@ -34,7 +34,7 @@ const ownerPassword = 'mirror_node_pass';
 const readOnlyUser = 'mirror_rest';
 const readOnlyPassword = 'mirror_rest_pass';
 const workerId = process.env.JEST_WORKER_ID;
-const v1DatabaseImage = 'postgres:14-alpine';
+const v1DatabaseImage = 'postgres:16-alpine';
 const v2DatabaseImage = 'gcr.io/mirrornode/citus:12.1.1';
 
 const cleanupSql = fs.readFileSync(

--- a/hedera-mirror-rosetta/test/db/db.go
+++ b/hedera-mirror-rosetta/test/db/db.go
@@ -204,7 +204,7 @@ func createPostgresDb(pool *dockertest.Pool, network *dockertest.Network) (*dock
 	options := &dockertest.RunOptions{
 		Name:       getDbHostname(network.Network),
 		Repository: "postgres",
-		Tag:        "14-alpine",
+		Tag:        "16-alpine",
 		Env:        env,
 		Mounts:     []string{filepath.Clean(path.Join(moduleRoot, initScript)) + ":/docker-entrypoint-initdb.d/init.sh"},
 		Networks:   []*dockertest.Network{network},


### PR DESCRIPTION
**Description**:

* Add a `Total` line to REST API RPS graph
* Bump various chart dependencies
* Bump Loki from 2.9.6 to 3.1.1
* Bump Stackgres from 1.11 to 1.13
* Bump Traefik from 2.11.0 to 3.1.2
* Change default PostgreSQL from 14 to 16
* Verify Kubernetes 1.31 support

**Related issue(s)**:

Fixes #9146
Fixes #9094

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
