### PR TITLE
Add token readable kv state

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -16,6 +16,7 @@
 
 package com.hedera.hapi.node.state.token;
 
+import static com.hedera.mirror.web3.utils.Suppliers.areSuppliersEqual;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -396,33 +397,11 @@ public record Token(
         if (decimals != thatObj.decimals) {
             return false;
         }
-        if (totalSupplySupplier == null && thatObj.totalSupplySupplier != null) {
+        if (!areSuppliersEqual(totalSupplySupplier, thatObj.totalSupplySupplier)) {
             return false;
         }
-        if (totalSupplySupplier != null && thatObj.totalSupplySupplier == null) {
+        if (!areSuppliersEqual(treasuryAccountIdSupplier, thatObj.treasuryAccountIdSupplier)) {
             return false;
-        }
-        if (totalSupplySupplier != null && !totalSupplySupplier.get().equals(thatObj.totalSupplySupplier.get())) {
-            return false;
-        }
-        if (treasuryAccountIdSupplier == null && thatObj.treasuryAccountIdSupplier != null) {
-            return false;
-        }
-        if (treasuryAccountIdSupplier != null && thatObj.treasuryAccountIdSupplier == null) {
-            return false;
-        }
-        if (treasuryAccountIdSupplier != null) {
-            AccountID thisAccountId = treasuryAccountIdSupplier.get();
-            AccountID thatAccountId = thatObj.treasuryAccountIdSupplier.get();
-
-            // If both retrieved account IDs are null, continue without returning true
-            if (thisAccountId == null && thatAccountId == null) {
-                // Both are null, but we don't return true yet; we continue checking
-            } else if (thisAccountId == null || thatAccountId == null) {
-                return false; // One is null, and the other is not
-            } else if (!thisAccountId.equals(thatAccountId)) {
-                return false; // They are not equal
-            }
         }
         if (adminKey == null && thatObj.adminKey != null) {
             return false;
@@ -484,24 +463,8 @@ public record Token(
         if (supplyType != null && !supplyType.equals(thatObj.supplyType)) {
             return false;
         }
-        if (autoRenewAccountIdSupplier == null && thatObj.autoRenewAccountIdSupplier != null) {
+        if (!areSuppliersEqual(autoRenewAccountIdSupplier, thatObj.autoRenewAccountIdSupplier)) {
             return false;
-        }
-        if (autoRenewAccountIdSupplier != null && thatObj.autoRenewAccountIdSupplier == null) {
-            return false;
-        }
-        if (autoRenewAccountIdSupplier != null) {
-            AccountID thisAccountId = autoRenewAccountIdSupplier.get();
-            AccountID thatAccountId = thatObj.autoRenewAccountIdSupplier.get();
-
-            // If both retrieved account IDs are null, continue without returning true
-            if (thisAccountId == null && thatAccountId == null) {
-                // Both are null, but we don't return true yet; we continue checking
-            } else if (thisAccountId == null || thatAccountId == null) {
-                return false; // One is null, and the other is not
-            } else if (!thisAccountId.equals(thatAccountId)) {
-                return false; // They are not equal
-            }
         }
         if (autoRenewSeconds != thatObj.autoRenewSeconds) {
             return false;

--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -508,10 +508,7 @@ public record Token(
         if (metadataKey == null && thatObj.metadataKey != null) {
             return false;
         }
-        if (metadataKey != null && !metadataKey.equals(thatObj.metadataKey)) {
-            return false;
-        }
-        return true;
+        return metadataKey == null || metadataKey.equals(thatObj.metadataKey);
     }
     /**
      * Convenience method to check if the tokenId has a value
@@ -1706,7 +1703,7 @@ public record Token(
          * @return builder to continue building with
          */
         public Builder metadata(@Nonnull Bytes metadata) {
-            this.metadata = metadata != null ? metadata : Bytes.EMPTY;
+            this.metadata = metadata;
             return this;
         }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -1209,6 +1209,7 @@ public record Token(
          * @param metadataKey                 <b>(28)</b> The key which can change the metadata of a token
          *                                    (token definition and individual NFTs).
          */
+        @SuppressWarnings("java:S107")
         public Builder(
                 TokenID tokenId,
                 String name,

--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -134,7 +134,7 @@ public record Token(
      *                 tokens can be at most a few billions or millions, respectively. For example, it could match
      *                 Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
      *                 It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
-     * @param totalSupply<b>(5)</b> The total supply of this token wrapped in a Supplier.
+     * @param totalSupply <b>(5)</b> The total supply of this token wrapped in a Supplier.
      * @param treasuryAccountId <b>(6)</b> The treasury account id of this token wrapped in a Supplier.
      * @param adminKey <b>(7)</b> (Optional) The admin key of this token. If this key is set, the token is mutable.
      *                 A mutable token can be modified.
@@ -236,15 +236,6 @@ public record Token(
     }
 
     /**
-     * Return a new builder for building a model object. This is just a shortcut for <code>new Model.Builder()</code>.
-     *
-     * @return a new builder
-     */
-    public static Builder newBuilder() {
-        return new Builder();
-    }
-
-    /**
      * Override the default hashCode method for
      * all other objects to make hashCode
      */
@@ -254,10 +245,10 @@ public record Token(
         if (tokenId != null && !tokenId.equals(DEFAULT.tokenId)) {
             result = 31 * result + tokenId.hashCode();
         }
-        if (!name.equals(DEFAULT.name)) {
+        if (name != null && !name.equals(DEFAULT.name)) {
             result = 31 * result + name.hashCode();
         }
-        if (!symbol.equals(DEFAULT.symbol)) {
+        if (symbol != null && !symbol.equals(DEFAULT.symbol)) {
             result = 31 * result + symbol.hashCode();
         }
         if (decimals != DEFAULT.decimals) {
@@ -317,7 +308,7 @@ public record Token(
         if (expirationSecond != DEFAULT.expirationSecond) {
             result = 31 * result + Long.hashCode(expirationSecond);
         }
-        if (!memo.equals(DEFAULT.memo)) {
+        if (memo != null && !memo.equals(DEFAULT.memo)) {
             result = 31 * result + memo.hashCode();
         }
         if (maxSupply != DEFAULT.maxSupply) {
@@ -339,7 +330,7 @@ public record Token(
                 result = 31 * result;
             }
         }
-        if (!metadata.equals(DEFAULT.metadata)) {
+        if (metadata != null && !metadata.equals(DEFAULT.metadata)) {
             result = 31 * result + metadata.hashCode();
         }
         if (metadataKey != null && !metadataKey.equals(DEFAULT.metadataKey)) {
@@ -375,10 +366,16 @@ public record Token(
         if (tokenId != null && !tokenId.equals(thatObj.tokenId)) {
             return false;
         }
-        if (!name.equals(thatObj.name)) {
+        if (name == null && thatObj.name != null) {
             return false;
         }
-        if (!symbol.equals(thatObj.symbol)) {
+        if (name != null && !name.equals(thatObj.name)) {
+            return false;
+        }
+        if (symbol == null && thatObj.symbol != null) {
+            return false;
+        }
+        if (symbol != null && !symbol.equals(thatObj.symbol)) {
             return false;
         }
         if (decimals != thatObj.decimals) {
@@ -479,7 +476,10 @@ public record Token(
         if (expirationSecond != thatObj.expirationSecond) {
             return false;
         }
-        if (!memo.equals(thatObj.memo)) {
+        if (memo == null && thatObj.memo != null) {
+            return false;
+        }
+        if (memo != null && !memo.equals(thatObj.memo)) {
             return false;
         }
         if (maxSupply != thatObj.maxSupply) {
@@ -499,15 +499,20 @@ public record Token(
             return false;
         }
 
-        if (!metadata.equals(thatObj.metadata)) {
+        if (metadata == null && thatObj.metadata != null) {
+            return false;
+        }
+        if (metadata != null && !metadata.equals(thatObj.metadata)) {
             return false;
         }
         if (metadataKey == null && thatObj.metadataKey != null) {
             return false;
         }
-        return metadataKey == null || metadataKey.equals(thatObj.metadataKey);
+        if (metadataKey != null && !metadataKey.equals(thatObj.metadataKey)) {
+            return false;
+        }
+        return true;
     }
-
     /**
      * Convenience method to check if the tokenId has a value
      *
@@ -1013,6 +1018,14 @@ public record Token(
                 metadataKey);
     }
 
+    /**
+     * Return a new builder for building a model object. This is just a shortcut for <code>new Model.Builder()</code>.
+     *
+     * @return a new builder
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
     /**
      * Builder class for easy creation, ideal for clean code where performance is not critical. In critical performance
      * paths use the constructor directly.
@@ -1526,7 +1539,7 @@ public record Token(
         }
 
         /**
-         * <b>(14)</b> The flag indicating if this token is deleted.
+         * <b>(15)</b> The flag indicating if this token is deleted.
          *
          * @param deleted value to set
          * @return builder to continue building with
@@ -1537,7 +1550,7 @@ public record Token(
         }
 
         /**
-         * <b>(15)</b> The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
+         * <b>(16)</b> The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
          * If it has been omitted during token creation, FUNGIBLE_COMMON type is used.
          *
          * @param tokenType value to set
@@ -1549,7 +1562,7 @@ public record Token(
         }
 
         /**
-         * <b>(16)</b> The supply type of this token.A token can have either INFINITE or FINITE supply type.
+         * <b>(17)</b> The supply type of this token.A token can have either INFINITE or FINITE supply type.
          * If it has been omitted during token creation, INFINITE type is used.
          *
          * @param supplyType value to set
@@ -1561,7 +1574,7 @@ public record Token(
         }
 
         /**
-         * <b>(17)</b> The id of the account (if any) that the network will attempt to charge for the
+         * <b>(18)</b> The id of the account (if any) that the network will attempt to charge for the
          * token's auto-renewal upon expiration.
          *
          * @param autoRenewAccountId value to set
@@ -1573,7 +1586,7 @@ public record Token(
         }
 
         /**
-         * <b>(17)</b> The id of the account (if any) that the network will attempt to charge for the
+         * <b>(18)</b> The id of the account (if any) that the network will attempt to charge for the
          * token's auto-renewal upon expiration.
          *
          * @param autoRenewAccountIdSupplier value to set
@@ -1585,7 +1598,7 @@ public record Token(
         }
 
         /**
-         * <b>(18)</b> The number of seconds the network should automatically extend the token's expiration by, if the
+         * <b>(19)</b> The number of seconds the network should automatically extend the token's expiration by, if the
          * token has a valid auto-renew account, and is not deleted upon expiration.
          * If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
          * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
@@ -1599,7 +1612,7 @@ public record Token(
         }
 
         /**
-         * <b>(19)</b> The expiration time of the token, in seconds since the epoch.
+         * <b>(20)</b> The expiration time of the token, in seconds since the epoch.
          *
          * @param expirationSecond value to set
          * @return builder to continue building with
@@ -1610,7 +1623,7 @@ public record Token(
         }
 
         /**
-         * <b>(20)</b> An optional description of the token with UTF-8 encoding up to 100 bytes.
+         * <b>(21)</b> An optional description of the token with UTF-8 encoding up to 100 bytes.
          *
          * @param memo value to set
          * @return builder to continue building with
@@ -1621,7 +1634,7 @@ public record Token(
         }
 
         /**
-         * <b>(21)</b> The maximum supply of this token.
+         * <b>(22)</b> The maximum supply of this token.
          *
          * @param maxSupply value to set
          * @return builder to continue building with
@@ -1632,7 +1645,7 @@ public record Token(
         }
 
         /**
-         * <b>(22)</b> The flag indicating if this token is paused.
+         * <b>(23)</b> The flag indicating if this token is paused.
          *
          * @param paused value to set
          * @return builder to continue building with
@@ -1643,7 +1656,7 @@ public record Token(
         }
 
         /**
-         * <b>(23)</b> The flag indicating if this token has accounts associated to it that are frozen by default.
+         * <b>(24)</b> The flag indicating if this token has accounts associated to it that are frozen by default.
          *
          * @param accountsFrozenByDefault value to set
          * @return builder to continue building with
@@ -1654,7 +1667,7 @@ public record Token(
         }
 
         /**
-         * <b>(24)</b> The flag indicating if this token has accounts associated with it that are KYC granted by default.
+         * <b>(25)</b> The flag indicating if this token has accounts associated with it that are KYC granted by default.
          *
          * @param accountsKycGrantedByDefault value to set
          * @return builder to continue building with
@@ -1665,7 +1678,7 @@ public record Token(
         }
 
         /**
-         * <b>(25)</b> (Optional) The custom fees of this token.
+         * <b>(26)</b> (Optional) The custom fees of this token.
          *
          * @param customFees value to set
          * @return builder to continue building with
@@ -1693,7 +1706,7 @@ public record Token(
          * @return builder to continue building with
          */
         public Builder metadata(@Nonnull Bytes metadata) {
-            this.metadata = metadata;
+            this.metadata = metadata != null ? metadata : Bytes.EMPTY;
             return this;
         }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -123,7 +123,11 @@ public record Token(
     public static final JsonCodec<Token> JSON = new com.hedera.hapi.node.state.token.codec.TokenJsonCodec();
 
     /** Default instance with all fields set to default values */
-    public static final Token DEFAULT = newBuilder().build();
+    public static final Token DEFAULT = newBuilder()
+            .totalSupply(0L)
+            .autoRenewAccountId((AccountID) null)
+            .treasuryAccountId((AccountID) null)
+            .build();
     /**
      * Create a pre-populated Token.
      *
@@ -254,16 +258,19 @@ public record Token(
         if (decimals != DEFAULT.decimals) {
             result = 31 * result + Integer.hashCode(decimals);
         }
-        if (totalSupplySupplier != null
-                && DEFAULT.totalSupplySupplier != null
-                && !totalSupplySupplier.get().equals(DEFAULT.totalSupplySupplier.get())) {
-            result = 31 * result + Long.hashCode(totalSupplySupplier.get());
+        if (totalSupplySupplier != null) {
+            if (DEFAULT.totalSupplySupplier == null) {
+                result = 31 * result + Long.hashCode(totalSupplySupplier.get());
+            } else if (!totalSupplySupplier.get().equals(DEFAULT.totalSupplySupplier.get())) {
+                result = 31 * result + Long.hashCode(totalSupplySupplier.get());
+            }
         }
-        if (treasuryAccountIdSupplier != null
-                && treasuryAccountIdSupplier.get() != null
-                && DEFAULT.treasuryAccountIdSupplier != null
-                && !treasuryAccountIdSupplier.get().equals(DEFAULT.treasuryAccountIdSupplier.get())) {
-            result = 31 * result + treasuryAccountIdSupplier.get().hashCode();
+        if (treasuryAccountIdSupplier != null && treasuryAccountIdSupplier.get() != null) {
+            if (DEFAULT.treasuryAccountIdSupplier == null) {
+                result = 31 * result + treasuryAccountIdSupplier.get().hashCode();
+            } else if (!treasuryAccountIdSupplier.get().equals(DEFAULT.treasuryAccountIdSupplier.get())) {
+                result = 31 * result + treasuryAccountIdSupplier.get().hashCode();
+            }
         }
         if (adminKey != null && !adminKey.equals(DEFAULT.adminKey)) {
             result = 31 * result + adminKey.hashCode();
@@ -298,11 +305,12 @@ public record Token(
         if (supplyType != null && !supplyType.equals(DEFAULT.supplyType)) {
             result = 31 * result + Integer.hashCode(supplyType.protoOrdinal());
         }
-        if (autoRenewAccountIdSupplier != null
-                && autoRenewAccountIdSupplier.get() != null
-                && DEFAULT.autoRenewAccountIdSupplier != null
-                && !autoRenewAccountIdSupplier.equals(DEFAULT.autoRenewAccountIdSupplier)) {
-            result = 31 * result + autoRenewAccountIdSupplier.get().hashCode();
+        if (autoRenewAccountIdSupplier != null && autoRenewAccountIdSupplier.get() != null) {
+            if (DEFAULT.autoRenewAccountIdSupplier == null) {
+                result = 31 * result + autoRenewAccountIdSupplier.get().hashCode();
+            } else if (!autoRenewAccountIdSupplier.get().equals(DEFAULT.autoRenewAccountIdSupplier.get())) {
+                result = 31 * result + autoRenewAccountIdSupplier.get().hashCode();
+            }
         }
         if (autoRenewSeconds != DEFAULT.autoRenewSeconds) {
             result = 31 * result + Long.hashCode(autoRenewSeconds);

--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -608,7 +608,6 @@ public record Token(
      * @throws NullPointerException if treasuryAccountId is null
      */
     public @Nonnull AccountID treasuryAccountIdOrThrow() {
-
         return treasuryAccountIdSupplier == null
                 ? requireNonNull(null, "Field treasuryAccountId is null")
                 : requireNonNull(treasuryAccountIdSupplier.get(), "Field treasuryAccountId is null");

--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -259,17 +259,20 @@ public record Token(
             result = 31 * result + Integer.hashCode(decimals);
         }
         if (totalSupplySupplier != null) {
-            if (DEFAULT.totalSupplySupplier == null) {
-                result = 31 * result + Long.hashCode(totalSupplySupplier.get());
-            } else if (!totalSupplySupplier.get().equals(DEFAULT.totalSupplySupplier.get())) {
-                result = 31 * result + Long.hashCode(totalSupplySupplier.get());
+            Long currentValue = totalSupplySupplier.get();
+            Long defaultValue = (DEFAULT.totalSupplySupplier != null) ? DEFAULT.totalSupplySupplier.get() : null;
+
+            if (currentValue != null && !currentValue.equals(defaultValue)) {
+                result = 31 * result + Long.hashCode(currentValue);
             }
         }
         if (treasuryAccountIdSupplier != null && treasuryAccountIdSupplier.get() != null) {
-            if (DEFAULT.treasuryAccountIdSupplier == null) {
-                result = 31 * result + treasuryAccountIdSupplier.get().hashCode();
-            } else if (!treasuryAccountIdSupplier.get().equals(DEFAULT.treasuryAccountIdSupplier.get())) {
-                result = 31 * result + treasuryAccountIdSupplier.get().hashCode();
+            Object currentValue = treasuryAccountIdSupplier.get();
+            Object defaultValue =
+                    DEFAULT.treasuryAccountIdSupplier != null ? DEFAULT.treasuryAccountIdSupplier.get() : null;
+
+            if (!currentValue.equals(defaultValue)) {
+                result = 31 * result + currentValue.hashCode();
             }
         }
         if (adminKey != null && !adminKey.equals(DEFAULT.adminKey)) {
@@ -306,10 +309,12 @@ public record Token(
             result = 31 * result + Integer.hashCode(supplyType.protoOrdinal());
         }
         if (autoRenewAccountIdSupplier != null && autoRenewAccountIdSupplier.get() != null) {
-            if (DEFAULT.autoRenewAccountIdSupplier == null) {
-                result = 31 * result + autoRenewAccountIdSupplier.get().hashCode();
-            } else if (!autoRenewAccountIdSupplier.get().equals(DEFAULT.autoRenewAccountIdSupplier.get())) {
-                result = 31 * result + autoRenewAccountIdSupplier.get().hashCode();
+            Object currentValue = autoRenewAccountIdSupplier.get();
+            Object defaultValue =
+                    DEFAULT.autoRenewAccountIdSupplier != null ? DEFAULT.autoRenewAccountIdSupplier.get() : null;
+
+            if (!currentValue.equals(defaultValue)) {
+                result = 31 * result + currentValue.hashCode();
             }
         }
         if (autoRenewSeconds != DEFAULT.autoRenewSeconds) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -387,7 +387,7 @@ public record Token(
         if (totalSupplySupplier != null && thatObj.totalSupplySupplier == null) {
             return false;
         }
-        if (totalSupplySupplier != null && totalSupplySupplier.get().equals(thatObj.totalSupplySupplier.get())) {
+        if (totalSupplySupplier != null && !totalSupplySupplier.get().equals(thatObj.totalSupplySupplier.get())) {
             return false;
         }
         if (treasuryAccountIdSupplier == null && thatObj.treasuryAccountIdSupplier != null) {
@@ -397,7 +397,7 @@ public record Token(
             return false;
         }
         if (treasuryAccountIdSupplier != null
-                && treasuryAccountIdSupplier.get().equals(thatObj.treasuryAccountIdSupplier.get())) {
+                && !treasuryAccountIdSupplier.get().equals(thatObj.treasuryAccountIdSupplier.get())) {
             return false;
         }
         if (adminKey == null && thatObj.adminKey != null) {
@@ -467,7 +467,7 @@ public record Token(
             return false;
         }
         if (autoRenewAccountIdSupplier != null
-                && autoRenewAccountIdSupplier.get().equals(thatObj.autoRenewAccountIdSupplier.get())) {
+                && !autoRenewAccountIdSupplier.get().equals(thatObj.autoRenewAccountIdSupplier.get())) {
             return false;
         }
         if (autoRenewSeconds != thatObj.autoRenewSeconds) {
@@ -1733,5 +1733,39 @@ public record Token(
             this.metadataKey = builder.build();
             return this;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "Token{" + "tokenId="
+                + tokenId + ", name='"
+                + name + '\'' + ", symbol='"
+                + symbol + '\'' + ", decimals="
+                + decimals + ", totalSupplySupplier="
+                + (totalSupplySupplier != null ? totalSupplySupplier.get() : "null") + ", treasuryAccountIdSupplier="
+                + (treasuryAccountIdSupplier != null ? treasuryAccountIdSupplier.get() : "null") + ", adminKey="
+                + adminKey + ", kycKey="
+                + kycKey + ", freezeKey="
+                + freezeKey + ", wipeKey="
+                + wipeKey + ", supplyKey="
+                + supplyKey + ", feeScheduleKey="
+                + feeScheduleKey + ", pauseKey="
+                + pauseKey + ", lastUsedSerialNumber="
+                + lastUsedSerialNumber + ", deleted="
+                + deleted + ", tokenType="
+                + tokenType + ", supplyType="
+                + supplyType + ", autoRenewAccountIdSupplier="
+                + (autoRenewAccountIdSupplier != null ? autoRenewAccountIdSupplier.get() : "null")
+                + ", autoRenewSeconds="
+                + autoRenewSeconds + ", expirationSecond="
+                + expirationSecond + ", memo='"
+                + memo + '\'' + ", maxSupply="
+                + maxSupply + ", paused="
+                + paused + ", accountsFrozenByDefault="
+                + accountsFrozenByDefault + ", accountsKycGrantedByDefault="
+                + accountsKycGrantedByDefault + ", customFeesSupplier="
+                + (customFeesSupplier != null ? customFeesSupplier.get() : "null") + ", metadata="
+                + metadata + ", metadataKey="
+                + metadataKey + '}';
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -1122,53 +1122,80 @@ public record Token(
         /**
          * Create a pre-populated Builder.
          *
-         * @param tokenId <b>(1)</b> The unique entity id of this token.
-         * @param name <b>(2)</b> The human-readable name of this token. Need not be unique. Maximum length allowed is 100 bytes.
-         * @param symbol <b>(3)</b> The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is 100 bytes.
-         * @param decimals <b>(4)</b> The number of decimal places of this token. If decimals are 8 or 11, then the number of whole
-         *                 tokens can be at most a few billions or millions, respectively. For example, it could match
-         *                 Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
-         *                 It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
-         * @param totalSupplySupplier <b>(5)</b> The total supply of this token wrapped in a Supplier.
-         * @param treasuryAccountIdSupplier <b>(6)</b> The treasury account id of this token wrapped in a Supplier.
-         * @param adminKey <b>(7)</b> (Optional) The admin key of this token. If this key is set, the token is mutable.
-         *                 A mutable token can be modified.
-         *                 If this key is not set on token creation, it cannot be modified.
-         * @param kycKey <b>(8)</b> (Optional) The kyc key of this token.
-         *               If this key is not set on token creation, it can only be set if the token has admin key set.
-         * @param freezeKey <b>(9)</b> (Optional) The freeze key of this token. This key is needed for freezing the token.
-         *                  If this key is not set on token creation, it can only be set if the token has admin key set.
-         * @param wipeKey <b>(10)</b> (Optional) The wipe key of this token. This key is needed for wiping the token.
-         *                If this key is not set on token creation, it can only be set if the token has admin key set.
-         * @param supplyKey <b>(11)</b> (Optional) The supply key of this token. This key is needed for minting or burning token.
-         *                  If this key is not set on token creation, it can only be set if the token has admin key set.
-         * @param feeScheduleKey <b>(12)</b> (Optional) The fee schedule key of this token. This key should be set, in order to make any
-         *                       changes to the custom fee schedule.
-         *                       If this key is not set on token creation, it can only be set if the token has admin key set.
-         * @param pauseKey <b>(13)</b> (Optional) The pause key of this token. This key is needed for pausing the token.
-         *                 If this key is not set on token creation, it can only be set if the token has admin key set.
-         * @param lastUsedSerialNumber <b>(14)</b> The last used serial number of this token.
-         * @param deleted <b>(15)</b> The flag indicating if this token is deleted.
-         * @param tokenType <b>(16)</b> The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
-         *                  If it has been omitted during token creation, FUNGIBLE_COMMON type is used.
-         * @param supplyType <b>(17)</b> The supply type of this token.A token can have either INFINITE or FINITE supply type.
-         *                   If it has been omitted during token creation, INFINITE type is used.
-         * @param autoRenewAccountIdSupplier <b>(18)</b> The id of the account (if any) that the network will attempt to charge for the
-         *  *                           token's auto-renewal upon expiration wrapped in a Supplier.
-         * @param autoRenewSeconds <b>(19)</b> The number of seconds the network should automatically extend the token's expiration by, if the
-         *                         token has a valid auto-renew account, and is not deleted upon expiration.
-         *                         If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
-         *                         The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
-         * @param expirationSecond <b>(20)</b> The expiration time of the token, in seconds since the epoch.
-         * @param memo <b>(21)</b> An optional description of the token with UTF-8 encoding up to 100 bytes.
-         * @param maxSupply <b>(22)</b> The maximum supply of this token.
-         * @param paused <b>(23)</b> The flag indicating if this token is paused.
-         * @param accountsFrozenByDefault <b>(24)</b> The flag indicating if this token has accounts associated to it that are frozen by default.
-         * @param accountsKycGrantedByDefault <b>(25)</b> The flag indicating if this token has accounts associated with it that are KYC granted by default.
-         * @param customFeesSupplier <b>(26)</b> (Optional) The custom fees of this token wrapped in a Supplier.
-         * @param metadata <b>(27)</b> Metadata of the created token definition
-         * @param metadataKey <b>(28)</b> The key which can change the metadata of a token
-         *                    (token definition and individual NFTs).
+         * @param tokenId                     <b>(1)</b> The unique entity id of this token.
+         * @param name                        <b>(2)</b> The human-readable name of this token. Need not be unique.
+         *                                    Maximum length allowed is 100 bytes.
+         * @param symbol                      <b>(3)</b> The human-readable symbol for the token. It is not necessarily
+         *                                    unique. Maximum length allowed is 100 bytes.
+         * @param decimals                    <b>(4)</b> The number of decimal places of this token. If decimals are 8
+         *                                    or 11, then the number of whole
+         *                                    tokens can be at most a few billions or millions, respectively. For
+         *                                    example, it could match Bitcoin (21 million whole tokens with 8 decimals)
+         *                                    or hbars (50 billion whole tokens with 8 decimals). It could even match
+         *                                    Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
+         * @param totalSupplySupplier         <b>(5)</b> The total supply of this token wrapped in a Supplier.
+         * @param treasuryAccountIdSupplier   <b>(6)</b> The treasury account id of this token wrapped in a Supplier.
+         * @param adminKey                    <b>(7)</b> (Optional) The admin key of this token. If this key is set, the
+         *                                    token is mutable.
+         *                                    A mutable token can be modified. If this key is not set on token creation,
+         *                                    it cannot be modified.
+         * @param kycKey                      <b>(8)</b> (Optional) The kyc key of this token.
+         *                                    If this key is not set on token creation, it can only be set if the token
+         *                                    has admin key set.
+         * @param freezeKey                   <b>(9)</b> (Optional) The freeze key of this token. This key is needed for
+         *                                    freezing the token.
+         *                                    If this key is not set on token creation, it can only be set if the token
+         *                                    has admin key set.
+         * @param wipeKey                     <b>(10)</b> (Optional) The wipe key of this token. This key is needed for
+         *                                    wiping the token.
+         *                                    If this key is not set on token creation, it can only be set if the token
+         *                                    has admin key set.
+         * @param supplyKey                   <b>(11)</b> (Optional) The supply key of this token. This key is needed
+         *                                    for minting or burning token.
+         *                                    If this key is not set on token creation, it can only be set if the token
+         *                                    has admin key set.
+         * @param feeScheduleKey              <b>(12)</b> (Optional) The fee schedule key of this token. This key should
+         *                                    be set, in order to make any
+         *                                    changes to the custom fee schedule. If this key is not set on token
+         *                                    creation, it can only be set if the token has admin key set.
+         * @param pauseKey                    <b>(13)</b> (Optional) The pause key of this token. This key is needed for
+         *                                    pausing the token.
+         *                                    If this key is not set on token creation, it can only be set if the token
+         *                                    has admin key set.
+         * @param lastUsedSerialNumber        <b>(14)</b> The last used serial number of this token.
+         * @param deleted                     <b>(15)</b> The flag indicating if this token is deleted.
+         * @param tokenType                   <b>(16)</b> The type of this token. A token can be either FUNGIBLE_COMMON
+         *                                    or NON_FUNGIBLE_UNIQUE.
+         *                                    If it has been omitted during token creation, FUNGIBLE_COMMON type is
+         *                                    used.
+         * @param supplyType                  <b>(17)</b> The supply type of this token.A token can have either INFINITE
+         *                                    or FINITE supply type.
+         *                                    If it has been omitted during token creation, INFINITE type is used.
+         * @param autoRenewAccountIdSupplier  <b>(18)</b> The id of the account (if any) that the network will attempt
+         *                                    to charge for the
+         *                                    *                           token's auto-renewal upon expiration wrapped
+         *                                    in a Supplier.
+         * @param autoRenewSeconds            <b>(19)</b> The number of seconds the network should automatically extend
+         *                                    the token's expiration by, if the
+         *                                    token has a valid auto-renew account, and is not deleted upon expiration.
+         *                                    If this is not provided in a allowed range on token creation, the
+         *                                    transaction will fail with INVALID_AUTO_RENEWAL_PERIOD. The default values
+         *                                    for the minimum period and maximum period are 30 days and 90 days,
+         *                                    respectively.
+         * @param expirationSecond            <b>(20)</b> The expiration time of the token, in seconds since the epoch.
+         * @param memo                        <b>(21)</b> An optional description of the token with UTF-8 encoding up to
+         *                                    100 bytes.
+         * @param maxSupply                   <b>(22)</b> The maximum supply of this token.
+         * @param paused                      <b>(23)</b> The flag indicating if this token is paused.
+         * @param accountsFrozenByDefault     <b>(24)</b> The flag indicating if this token has accounts associated to
+         *                                    it that are frozen by default.
+         * @param accountsKycGrantedByDefault <b>(25)</b> The flag indicating if this token has accounts associated with
+         *                                    it that are KYC granted by default.
+         * @param customFeesSupplier          <b>(26)</b> (Optional) The custom fees of this token wrapped in a
+         *                                    Supplier.
+         * @param metadata                    <b>(27)</b> Metadata of the created token definition
+         * @param metadataKey                 <b>(28)</b> The key which can change the metadata of a token
+         *                                    (token definition and individual NFTs).
          */
         public Builder(
                 TokenID tokenId,
@@ -1300,7 +1327,8 @@ public record Token(
         }
 
         /**
-         * <b>(3)</b> The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is 100 bytes.
+         * <b>(3)</b> The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is
+         * 100 bytes.
          *
          * @param symbol value to set
          * @return builder to continue building with
@@ -1312,9 +1340,9 @@ public record Token(
 
         /**
          * <b>(4)</b> The number of decimal places of this token. If decimals are 8 or 11, then the number of whole
-         * tokens can be at most a few billions or millions, respectively. For example, it could match
-         * Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
-         * It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
+         * tokens can be at most a few billions or millions, respectively. For example, it could match Bitcoin (21
+         * million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals). It could even match
+         * Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
          *
          * @param decimals value to set
          * @return builder to continue building with
@@ -1348,8 +1376,8 @@ public record Token(
 
         /**
          * <b>(6)</b> The treasury account id of this token. This account receives the initial supply of
-         * tokens as well as the tokens from the Token Mint operation once executed. The balance
-         * of the treasury account is decreased when the Token Burn operation is executed.
+         * tokens as well as the tokens from the Token Mint operation once executed. The balance of the treasury account
+         * is decreased when the Token Burn operation is executed.
          *
          * @param treasuryAccountId value to set
          * @return builder to continue building with
@@ -1361,8 +1389,8 @@ public record Token(
 
         /**
          * <b>(6)</b> The treasury account id of this token. This account receives the initial supply of
-         * tokens as well as the tokens from the Token Mint operation once executed. The balance
-         * of the treasury account is decreased when the Token Burn operation is executed.
+         * tokens as well as the tokens from the Token Mint operation once executed. The balance of the treasury account
+         * is decreased when the Token Burn operation is executed.
          *
          * @param treasuryAccountIdSupplier value to set
          * @return builder to continue building with
@@ -1374,8 +1402,7 @@ public record Token(
 
         /**
          * <b>(7)</b> (Optional) The admin key of this token. If this key is set, the token is mutable.
-         * A mutable token can be modified.
-         * If this key is not set on token creation, it cannot be modified.
+         * A mutable token can be modified. If this key is not set on token creation, it cannot be modified.
          *
          * @param adminKey value to set
          * @return builder to continue building with
@@ -1387,8 +1414,7 @@ public record Token(
 
         /**
          * <b>(7)</b> (Optional) The admin key of this token. If this key is set, the token is mutable.
-         * A mutable token can be modified.
-         * If this key is not set on token creation, it cannot be modified.
+         * A mutable token can be modified. If this key is not set on token creation, it cannot be modified.
          *
          * @param builder A pre-populated builder
          * @return builder to continue building with
@@ -1496,8 +1522,8 @@ public record Token(
 
         /**
          * <b>(12)</b> (Optional) The fee schedule key of this token. This key should be set, in order to make any
-         * changes to the custom fee schedule.
-         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         * changes to the custom fee schedule. If this key is not set on token creation, it can only be set if the token
+         * has admin key set.
          *
          * @param feeScheduleKey value to set
          * @return builder to continue building with
@@ -1509,8 +1535,8 @@ public record Token(
 
         /**
          * <b>(12)</b> (Optional) The fee schedule key of this token. This key should be set, in order to make any
-         * changes to the custom fee schedule.
-         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         * changes to the custom fee schedule. If this key is not set on token creation, it can only be set if the token
+         * has admin key set.
          *
          * @param builder A pre-populated builder
          * @return builder to continue building with
@@ -1616,9 +1642,9 @@ public record Token(
 
         /**
          * <b>(19)</b> The number of seconds the network should automatically extend the token's expiration by, if the
-         * token has a valid auto-renew account, and is not deleted upon expiration.
-         * If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
-         * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
+         * token has a valid auto-renew account, and is not deleted upon expiration. If this is not provided in a
+         * allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD. The default
+         * values for the minimum period and maximum period are 30 days and 90 days, respectively.
          *
          * @param autoRenewSeconds value to set
          * @return builder to continue building with
@@ -1684,7 +1710,8 @@ public record Token(
         }
 
         /**
-         * <b>(25)</b> The flag indicating if this token has accounts associated with it that are KYC granted by default.
+         * <b>(25)</b> The flag indicating if this token has accounts associated with it that are KYC granted by
+         * default.
          *
          * @param accountsKycGrantedByDefault value to set
          * @return builder to continue building with
@@ -1750,39 +1777,5 @@ public record Token(
             this.metadataKey = builder.build();
             return this;
         }
-    }
-
-    @Override
-    public String toString() {
-        return "Token{" + "tokenId="
-                + tokenId + ", name='"
-                + name + '\'' + ", symbol='"
-                + symbol + '\'' + ", decimals="
-                + decimals + ", totalSupplySupplier="
-                + (totalSupplySupplier != null ? totalSupplySupplier.get() : "null") + ", treasuryAccountIdSupplier="
-                + (treasuryAccountIdSupplier != null ? treasuryAccountIdSupplier.get() : "null") + ", adminKey="
-                + adminKey + ", kycKey="
-                + kycKey + ", freezeKey="
-                + freezeKey + ", wipeKey="
-                + wipeKey + ", supplyKey="
-                + supplyKey + ", feeScheduleKey="
-                + feeScheduleKey + ", pauseKey="
-                + pauseKey + ", lastUsedSerialNumber="
-                + lastUsedSerialNumber + ", deleted="
-                + deleted + ", tokenType="
-                + tokenType + ", supplyType="
-                + supplyType + ", autoRenewAccountIdSupplier="
-                + (autoRenewAccountIdSupplier != null ? autoRenewAccountIdSupplier.get() : "null")
-                + ", autoRenewSeconds="
-                + autoRenewSeconds + ", expirationSecond="
-                + expirationSecond + ", memo='"
-                + memo + '\'' + ", maxSupply="
-                + maxSupply + ", paused="
-                + paused + ", accountsFrozenByDefault="
-                + accountsFrozenByDefault + ", accountsKycGrantedByDefault="
-                + accountsKycGrantedByDefault + ", customFeesSupplier="
-                + (customFeesSupplier != null ? customFeesSupplier.get() : "null") + ", metadata="
-                + metadata + ", metadataKey="
-                + metadataKey + '}';
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -1,0 +1,1724 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.hapi.node.state.token;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenSupplyType;
+import com.hedera.hapi.node.base.TokenType;
+import com.hedera.hapi.node.transaction.CustomFee;
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.JsonCodec;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Representation of a Hedera Token Service token entity in the network Merkle tree.
+ * <p>
+ * As with all network entities, a token has a unique entity number, which is usually given along
+ * with the network's shard and realm in the form of a shard.realm.number id.
+ *
+ * @param tokenId <b>(1)</b> The unique entity id of this token.
+ * @param name <b>(2)</b> The human-readable name of this token. Need not be unique. Maximum length allowed is 100 bytes.
+ * @param symbol <b>(3)</b> The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is 100 bytes.
+ * @param decimals <b>(4)</b> The number of decimal places of this token. If decimals are 8 or 11, then the number of whole
+ *                 tokens can be at most a few billions or millions, respectively. For example, it could match
+ *                 Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
+ *                 It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
+ * @param totalSupplySupplier <b>(5)</b> The total supply of this token wrapped in a Supplier.
+ * @param treasuryAccountIdSupplier <b>(6)</b> The treasury account id of this token wrapped in a Supplier.
+ * @param adminKey <b>(7)</b> (Optional) The admin key of this token. If this key is set, the token is mutable.
+ *                 A mutable token can be modified.
+ *                 If this key is not set on token creation, it cannot be modified.
+ * @param kycKey <b>(8)</b> (Optional) The kyc key of this token.
+ *               If this key is not set on token creation, it can only be set if the token has admin key set.
+ * @param freezeKey <b>(9)</b> (Optional) The freeze key of this token. This key is needed for freezing the token.
+ *                  If this key is not set on token creation, it can only be set if the token has admin key set.
+ * @param wipeKey <b>(10)</b> (Optional) The wipe key of this token. This key is needed for wiping the token.
+ *                If this key is not set on token creation, it can only be set if the token has admin key set.
+ * @param supplyKey <b>(11)</b> (Optional) The supply key of this token. This key is needed for minting or burning token.
+ *                  If this key is not set on token creation, it can only be set if the token has admin key set.
+ * @param feeScheduleKey <b>(12)</b> (Optional) The fee schedule key of this token. This key should be set, in order to make any
+ *                       changes to the custom fee schedule.
+ *                       If this key is not set on token creation, it can only be set if the token has admin key set.
+ * @param pauseKey <b>(13)</b> (Optional) The pause key of this token. This key is needed for pausing the token.
+ *                 If this key is not set on token creation, it can only be set if the token has admin key set.
+ * @param lastUsedSerialNumber <b>(14)</b> The last used serial number of this token.
+ * @param deleted <b>(15)</b> The flag indicating if this token is deleted.
+ * @param tokenType <b>(16)</b> The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
+ *                  If it has been omitted during token creation, FUNGIBLE_COMMON type is used.
+ * @param supplyType <b>(17)</b> The supply type of this token.A token can have either INFINITE or FINITE supply type.
+ *                   If it has been omitted during token creation, INFINITE type is used.
+ * @param autoRenewAccountIdSupplier <b>(18)</b> The id of the account (if any) that the network will attempt to charge for the
+ *  *                           token's auto-renewal upon expiration wrapped in a Supplier.
+ * @param autoRenewSeconds <b>(19)</b> The number of seconds the network should automatically extend the token's expiration by, if the
+ *                         token has a valid auto-renew account, and is not deleted upon expiration.
+ *                         If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
+ *                         The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
+ * @param expirationSecond <b>(20)</b> The expiration time of the token, in seconds since the epoch.
+ * @param memo <b>(21)</b> An optional description of the token with UTF-8 encoding up to 100 bytes.
+ * @param maxSupply <b>(22)</b> The maximum supply of this token.
+ * @param paused <b>(23)</b> The flag indicating if this token is paused.
+ * @param accountsFrozenByDefault <b>(24)</b> The flag indicating if this token has accounts associated to it that are frozen by default.
+ * @param accountsKycGrantedByDefault <b>(25)</b> The flag indicating if this token has accounts associated with it that are KYC granted by default.
+ * @param customFeesSupplier <b>(26)</b> (Optional) The custom fees of this token wrapped in a Supplier.
+ * @param metadata <b>(27)</b> Metadata of the created token definition
+ * @param metadataKey <b>(28)</b> The key which can change the metadata of a token
+ *                    (token definition and individual NFTs).
+ */
+public record Token(
+        @jakarta.annotation.Nullable TokenID tokenId,
+        @Nonnull String name,
+        @Nonnull String symbol,
+        int decimals,
+        Supplier<Long> totalSupplySupplier,
+        @Nullable Supplier<AccountID> treasuryAccountIdSupplier,
+        @Nullable Key adminKey,
+        @Nullable Key kycKey,
+        @Nullable Key freezeKey,
+        @Nullable Key wipeKey,
+        @Nullable Key supplyKey,
+        @Nullable Key feeScheduleKey,
+        @Nullable Key pauseKey,
+        long lastUsedSerialNumber,
+        boolean deleted,
+        TokenType tokenType,
+        TokenSupplyType supplyType,
+        @Nullable Supplier<AccountID> autoRenewAccountIdSupplier,
+        long autoRenewSeconds,
+        long expirationSecond,
+        @Nonnull String memo,
+        long maxSupply,
+        boolean paused,
+        boolean accountsFrozenByDefault,
+        boolean accountsKycGrantedByDefault,
+        @Nonnull Supplier<List<CustomFee>> customFeesSupplier,
+        @Nonnull Bytes metadata,
+        @Nullable Key metadataKey) {
+    /** Protobuf codec for reading and writing in protobuf format */
+    public static final Codec<Token> PROTOBUF = new com.hedera.hapi.node.state.token.codec.TokenProtoCodec();
+    /** JSON codec for reading and writing in JSON format */
+    public static final JsonCodec<Token> JSON = new com.hedera.hapi.node.state.token.codec.TokenJsonCodec();
+
+    /** Default instance with all fields set to default values */
+    public static final Token DEFAULT = newBuilder().build();
+    /**
+     * Create a pre-populated Token.
+     *
+     * @param tokenId <b>(1)</b> The unique entity id of this token.
+     * @param name <b>(2)</b> The human-readable name of this token. Need not be unique. Maximum length allowed is 100 bytes.
+     * @param symbol <b>(3)</b> The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is 100 bytes.
+     * @param decimals <b>(4)</b> The number of decimal places of this token. If decimals are 8 or 11, then the number of whole
+     *                 tokens can be at most a few billions or millions, respectively. For example, it could match
+     *                 Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
+     *                 It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
+     * @param totalSupply<b>(5)</b> The total supply of this token wrapped in a Supplier.
+     * @param treasuryAccountId <b>(6)</b> The treasury account id of this token wrapped in a Supplier.
+     * @param adminKey <b>(7)</b> (Optional) The admin key of this token. If this key is set, the token is mutable.
+     *                 A mutable token can be modified.
+     *                 If this key is not set on token creation, it cannot be modified.
+     * @param kycKey <b>(8)</b> (Optional) The kyc key of this token.
+     *               If this key is not set on token creation, it can only be set if the token has admin key set.
+     * @param freezeKey <b>(9)</b> (Optional) The freeze key of this token. This key is needed for freezing the token.
+     *                  If this key is not set on token creation, it can only be set if the token has admin key set.
+     * @param wipeKey <b>(10)</b> (Optional) The wipe key of this token. This key is needed for wiping the token.
+     *                If this key is not set on token creation, it can only be set if the token has admin key set.
+     * @param supplyKey <b>(11)</b> (Optional) The supply key of this token. This key is needed for minting or burning token.
+     *                  If this key is not set on token creation, it can only be set if the token has admin key set.
+     * @param feeScheduleKey <b>(12)</b> (Optional) The fee schedule key of this token. This key should be set, in order to make any
+     *                       changes to the custom fee schedule.
+     *                       If this key is not set on token creation, it can only be set if the token has admin key set.
+     * @param pauseKey <b>(13)</b> (Optional) The pause key of this token. This key is needed for pausing the token.
+     *                 If this key is not set on token creation, it can only be set if the token has admin key set.
+     * @param lastUsedSerialNumber <b>(14)</b> The last used serial number of this token.
+     * @param deleted <b>(15)</b> The flag indicating if this token is deleted.
+     * @param tokenType <b>(16)</b> The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
+     *                  If it has been omitted during token creation, FUNGIBLE_COMMON type is used.
+     * @param supplyType <b>(17)</b> The supply type of this token.A token can have either INFINITE or FINITE supply type.
+     *                   If it has been omitted during token creation, INFINITE type is used.
+     * @param autoRenewAccountId <b>(18)</b> The id of the account (if any) that the network will attempt to charge for the
+     *  *                           token's auto-renewal upon expiration wrapped in a Supplier.
+     * @param autoRenewSeconds <b>(19)</b> The number of seconds the network should automatically extend the token's expiration by, if the
+     *                         token has a valid auto-renew account, and is not deleted upon expiration.
+     *                         If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
+     *                         The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
+     * @param expirationSecond <b>(20)</b> The expiration time of the token, in seconds since the epoch.
+     * @param memo <b>(21)</b> An optional description of the token with UTF-8 encoding up to 100 bytes.
+     * @param maxSupply <b>(22)</b> The maximum supply of this token.
+     * @param paused <b>(23)</b> The flag indicating if this token is paused.
+     * @param accountsFrozenByDefault <b>(24)</b> The flag indicating if this token has accounts associated to it that are frozen by default.
+     * @param accountsKycGrantedByDefault <b>(25)</b> The flag indicating if this token has accounts associated with it that are KYC granted by default.
+     * @param customFees <b>(26)</b> (Optional) The custom fees of this token wrapped in a Supplier.
+     * @param metadata <b>(27)</b> Metadata of the created token definition
+     * @param metadataKey <b>(28)</b> The key which can change the metadata of a token
+     *                    (token definition and individual NFTs).
+     */
+    public Token(
+            TokenID tokenId,
+            String name,
+            String symbol,
+            int decimals,
+            Long totalSupply,
+            AccountID treasuryAccountId,
+            Key adminKey,
+            Key kycKey,
+            Key freezeKey,
+            Key wipeKey,
+            Key supplyKey,
+            Key feeScheduleKey,
+            Key pauseKey,
+            long lastUsedSerialNumber,
+            boolean deleted,
+            TokenType tokenType,
+            TokenSupplyType supplyType,
+            AccountID autoRenewAccountId,
+            long autoRenewSeconds,
+            long expirationSecond,
+            String memo,
+            long maxSupply,
+            boolean paused,
+            boolean accountsFrozenByDefault,
+            boolean accountsKycGrantedByDefault,
+            List<CustomFee> customFees,
+            Bytes metadata,
+            Key metadataKey) {
+        this(
+                tokenId,
+                name,
+                symbol,
+                decimals,
+                () -> totalSupply,
+                () -> treasuryAccountId,
+                adminKey,
+                kycKey,
+                freezeKey,
+                wipeKey,
+                supplyKey,
+                feeScheduleKey,
+                pauseKey,
+                lastUsedSerialNumber,
+                deleted,
+                tokenType,
+                supplyType,
+                () -> autoRenewAccountId,
+                autoRenewSeconds,
+                expirationSecond,
+                memo,
+                maxSupply,
+                paused,
+                accountsFrozenByDefault,
+                accountsKycGrantedByDefault,
+                () -> customFees,
+                metadata,
+                metadataKey);
+    }
+
+    /**
+     * Return a new builder for building a model object. This is just a shortcut for <code>new Model.Builder()</code>.
+     *
+     * @return a new builder
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Override the default hashCode method for
+     * all other objects to make hashCode
+     */
+    @Override
+    public int hashCode() {
+        int result = 1;
+        if (tokenId != null && !tokenId.equals(DEFAULT.tokenId)) {
+            result = 31 * result + tokenId.hashCode();
+        }
+        if (!name.equals(DEFAULT.name)) {
+            result = 31 * result + name.hashCode();
+        }
+        if (!symbol.equals(DEFAULT.symbol)) {
+            result = 31 * result + symbol.hashCode();
+        }
+        if (decimals != DEFAULT.decimals) {
+            result = 31 * result + Integer.hashCode(decimals);
+        }
+        if (totalSupplySupplier != null
+                && DEFAULT.totalSupplySupplier != null
+                && !totalSupplySupplier.get().equals(DEFAULT.totalSupplySupplier.get())) {
+            result = 31 * result + Long.hashCode(totalSupplySupplier.get());
+        }
+        if (treasuryAccountIdSupplier != null
+                && DEFAULT.treasuryAccountIdSupplier != null
+                && !treasuryAccountIdSupplier.get().equals(DEFAULT.treasuryAccountIdSupplier.get())) {
+            result = 31 * result + treasuryAccountIdSupplier.get().hashCode();
+        }
+        if (adminKey != null && !adminKey.equals(DEFAULT.adminKey)) {
+            result = 31 * result + adminKey.hashCode();
+        }
+        if (kycKey != null && !kycKey.equals(DEFAULT.kycKey)) {
+            result = 31 * result + kycKey.hashCode();
+        }
+        if (freezeKey != null && !freezeKey.equals(DEFAULT.freezeKey)) {
+            result = 31 * result + freezeKey.hashCode();
+        }
+        if (wipeKey != null && !wipeKey.equals(DEFAULT.wipeKey)) {
+            result = 31 * result + wipeKey.hashCode();
+        }
+        if (supplyKey != null && !supplyKey.equals(DEFAULT.supplyKey)) {
+            result = 31 * result + supplyKey.hashCode();
+        }
+        if (feeScheduleKey != null && !feeScheduleKey.equals(DEFAULT.feeScheduleKey)) {
+            result = 31 * result + feeScheduleKey.hashCode();
+        }
+        if (pauseKey != null && !pauseKey.equals(DEFAULT.pauseKey)) {
+            result = 31 * result + pauseKey.hashCode();
+        }
+        if (lastUsedSerialNumber != DEFAULT.lastUsedSerialNumber) {
+            result = 31 * result + Long.hashCode(lastUsedSerialNumber);
+        }
+        if (deleted != DEFAULT.deleted) {
+            result = 31 * result + Boolean.hashCode(deleted);
+        }
+        if (tokenType != null && !tokenType.equals(DEFAULT.tokenType)) {
+            result = 31 * result + Integer.hashCode(tokenType.protoOrdinal());
+        }
+        if (supplyType != null && !supplyType.equals(DEFAULT.supplyType)) {
+            result = 31 * result + Integer.hashCode(supplyType.protoOrdinal());
+        }
+        if (autoRenewAccountIdSupplier != null
+                && DEFAULT.autoRenewAccountIdSupplier != null
+                && !autoRenewAccountIdSupplier.equals(DEFAULT.autoRenewAccountIdSupplier)) {
+            result = 31 * result + autoRenewAccountIdSupplier.get().hashCode();
+        }
+        if (autoRenewSeconds != DEFAULT.autoRenewSeconds) {
+            result = 31 * result + Long.hashCode(autoRenewSeconds);
+        }
+        if (expirationSecond != DEFAULT.expirationSecond) {
+            result = 31 * result + Long.hashCode(expirationSecond);
+        }
+        if (!memo.equals(DEFAULT.memo)) {
+            result = 31 * result + memo.hashCode();
+        }
+        if (maxSupply != DEFAULT.maxSupply) {
+            result = 31 * result + Long.hashCode(maxSupply);
+        }
+        if (paused != DEFAULT.paused) {
+            result = 31 * result + Boolean.hashCode(paused);
+        }
+        if (accountsFrozenByDefault != DEFAULT.accountsFrozenByDefault) {
+            result = 31 * result + Boolean.hashCode(accountsFrozenByDefault);
+        }
+        if (accountsKycGrantedByDefault != DEFAULT.accountsKycGrantedByDefault) {
+            result = 31 * result + Boolean.hashCode(accountsKycGrantedByDefault);
+        }
+        for (Object o : customFeesSupplier.get()) {
+            if (o != null) {
+                result = 31 * result + o.hashCode();
+            } else {
+                result = 31 * result;
+            }
+        }
+        if (!metadata.equals(DEFAULT.metadata)) {
+            result = 31 * result + metadata.hashCode();
+        }
+        if (metadataKey != null && !metadataKey.equals(DEFAULT.metadataKey)) {
+            result = 31 * result + metadataKey.hashCode();
+        }
+        long hashCode = result;
+        // Shifts: 30, 27, 16, 20, 5, 18, 10, 24, 30
+        hashCode += hashCode << 30;
+        hashCode ^= hashCode >>> 27;
+        hashCode += hashCode << 16;
+        hashCode ^= hashCode >>> 20;
+        hashCode += hashCode << 5;
+        hashCode ^= hashCode >>> 18;
+        hashCode += hashCode << 10;
+        hashCode ^= hashCode >>> 24;
+        hashCode += hashCode << 30;
+
+        return (int) hashCode;
+    }
+
+    /**
+     * Override the default equals method for
+     */
+    @Override
+    public boolean equals(Object that) {
+        if (that == null || this.getClass() != that.getClass()) {
+            return false;
+        }
+        Token thatObj = (Token) that;
+        if (tokenId == null && thatObj.tokenId != null) {
+            return false;
+        }
+        if (tokenId != null && !tokenId.equals(thatObj.tokenId)) {
+            return false;
+        }
+        if (!name.equals(thatObj.name)) {
+            return false;
+        }
+        if (!symbol.equals(thatObj.symbol)) {
+            return false;
+        }
+        if (decimals != thatObj.decimals) {
+            return false;
+        }
+        if (totalSupplySupplier == null && thatObj.totalSupplySupplier != null) {
+            return false;
+        }
+        if (totalSupplySupplier != null && thatObj.totalSupplySupplier == null) {
+            return false;
+        }
+        if (totalSupplySupplier != null && totalSupplySupplier.get().equals(thatObj.totalSupplySupplier.get())) {
+            return false;
+        }
+        if (treasuryAccountIdSupplier == null && thatObj.treasuryAccountIdSupplier != null) {
+            return false;
+        }
+        if (treasuryAccountIdSupplier != null && thatObj.treasuryAccountIdSupplier == null) {
+            return false;
+        }
+        if (treasuryAccountIdSupplier != null
+                && treasuryAccountIdSupplier.get().equals(thatObj.treasuryAccountIdSupplier.get())) {
+            return false;
+        }
+        if (adminKey == null && thatObj.adminKey != null) {
+            return false;
+        }
+        if (adminKey != null && !adminKey.equals(thatObj.adminKey)) {
+            return false;
+        }
+        if (kycKey == null && thatObj.kycKey != null) {
+            return false;
+        }
+        if (kycKey != null && !kycKey.equals(thatObj.kycKey)) {
+            return false;
+        }
+        if (freezeKey == null && thatObj.freezeKey != null) {
+            return false;
+        }
+        if (freezeKey != null && !freezeKey.equals(thatObj.freezeKey)) {
+            return false;
+        }
+        if (wipeKey == null && thatObj.wipeKey != null) {
+            return false;
+        }
+        if (wipeKey != null && !wipeKey.equals(thatObj.wipeKey)) {
+            return false;
+        }
+        if (supplyKey == null && thatObj.supplyKey != null) {
+            return false;
+        }
+        if (supplyKey != null && !supplyKey.equals(thatObj.supplyKey)) {
+            return false;
+        }
+        if (feeScheduleKey == null && thatObj.feeScheduleKey != null) {
+            return false;
+        }
+        if (feeScheduleKey != null && !feeScheduleKey.equals(thatObj.feeScheduleKey)) {
+            return false;
+        }
+        if (pauseKey == null && thatObj.pauseKey != null) {
+            return false;
+        }
+        if (pauseKey != null && !pauseKey.equals(thatObj.pauseKey)) {
+            return false;
+        }
+        if (lastUsedSerialNumber != thatObj.lastUsedSerialNumber) {
+            return false;
+        }
+        if (deleted != thatObj.deleted) {
+            return false;
+        }
+        if (tokenType == null && thatObj.tokenType != null) {
+            return false;
+        }
+        if (tokenType != null && !tokenType.equals(thatObj.tokenType)) {
+            return false;
+        }
+        if (supplyType == null && thatObj.supplyType != null) {
+            return false;
+        }
+        if (supplyType != null && !supplyType.equals(thatObj.supplyType)) {
+            return false;
+        }
+        if (autoRenewAccountIdSupplier == null && thatObj.autoRenewAccountIdSupplier != null) {
+            return false;
+        }
+        if (autoRenewAccountIdSupplier != null && thatObj.autoRenewAccountIdSupplier == null) {
+            return false;
+        }
+        if (autoRenewAccountIdSupplier != null
+                && autoRenewAccountIdSupplier.get().equals(thatObj.autoRenewAccountIdSupplier.get())) {
+            return false;
+        }
+        if (autoRenewSeconds != thatObj.autoRenewSeconds) {
+            return false;
+        }
+        if (expirationSecond != thatObj.expirationSecond) {
+            return false;
+        }
+        if (!memo.equals(thatObj.memo)) {
+            return false;
+        }
+        if (maxSupply != thatObj.maxSupply) {
+            return false;
+        }
+        if (paused != thatObj.paused) {
+            return false;
+        }
+        if (accountsFrozenByDefault != thatObj.accountsFrozenByDefault) {
+            return false;
+        }
+        if (accountsKycGrantedByDefault != thatObj.accountsKycGrantedByDefault) {
+            return false;
+        }
+
+        if (!customFeesSupplier.get().equals(thatObj.customFeesSupplier.get())) {
+            return false;
+        }
+
+        if (!metadata.equals(thatObj.metadata)) {
+            return false;
+        }
+        if (metadataKey == null && thatObj.metadataKey != null) {
+            return false;
+        }
+        return metadataKey == null || metadataKey.equals(thatObj.metadataKey);
+    }
+
+    /**
+     * Convenience method to check if the tokenId has a value
+     *
+     * @return true of the tokenId has a value
+     */
+    public boolean hasTokenId() {
+        return tokenId != null;
+    }
+
+    /**
+     * Gets the value for tokenId if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if tokenId is null
+     * @return the value for tokenId if it has a value, or else returns the default value
+     */
+    public TokenID tokenIdOrElse(@Nonnull final TokenID defaultValue) {
+        return hasTokenId() ? tokenId : defaultValue;
+    }
+
+    /**
+     * Gets the value for tokenId if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for tokenId if it has a value
+     * @throws NullPointerException if tokenId is null
+     */
+    public @Nonnull TokenID tokenIdOrThrow() {
+        return requireNonNull(tokenId, "Field tokenId is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the tokenId has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifTokenId(@Nonnull final Consumer<TokenID> ifPresent) {
+        if (hasTokenId()) {
+            ifPresent.accept(tokenId);
+        }
+    }
+
+    /**
+     * Convenience method to check if the treasuryAccountId has a value
+     *
+     * @return true of the treasuryAccountId has a value
+     */
+    public boolean hasTreasuryAccountId() {
+        return treasuryAccountIdSupplier != null && treasuryAccountIdSupplier.get() != null;
+    }
+
+    /**
+     * Gets the value for treasuryAccountId if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if treasuryAccountId is null
+     * @return the value for treasuryAccountId if it has a value, or else returns the default value
+     */
+    public AccountID treasuryAccountIdOrElse(@Nonnull final AccountID defaultValue) {
+        return hasTreasuryAccountId() ? treasuryAccountIdSupplier.get() : defaultValue;
+    }
+
+    /**
+     * Gets the value for treasuryAccountId if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for treasuryAccountId if it has a value
+     * @throws NullPointerException if treasuryAccountId is null
+     */
+    public @Nonnull AccountID treasuryAccountIdOrThrow() {
+
+        return treasuryAccountIdSupplier == null
+                ? requireNonNull(null, "Field treasuryAccountId is null")
+                : requireNonNull(treasuryAccountIdSupplier.get(), "Field treasuryAccountId is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the treasuryAccountId has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifTreasuryAccountId(@Nonnull final Consumer<AccountID> ifPresent) {
+        if (hasTreasuryAccountId()) {
+            ifPresent.accept(treasuryAccountIdSupplier.get());
+        }
+    }
+
+    /**
+     * Convenience method to check if the adminKey has a value
+     *
+     * @return true of the adminKey has a value
+     */
+    public boolean hasAdminKey() {
+        return adminKey != null;
+    }
+
+    /**
+     * Gets the value for adminKey if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if adminKey is null
+     * @return the value for adminKey if it has a value, or else returns the default value
+     */
+    public Key adminKeyOrElse(@Nonnull final Key defaultValue) {
+        return hasAdminKey() ? adminKey : defaultValue;
+    }
+
+    /**
+     * Gets the value for adminKey if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for adminKey if it has a value
+     * @throws NullPointerException if adminKey is null
+     */
+    public @Nonnull Key adminKeyOrThrow() {
+        return requireNonNull(adminKey, "Field adminKey is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the adminKey has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifAdminKey(@Nonnull final Consumer<Key> ifPresent) {
+        if (hasAdminKey()) {
+            ifPresent.accept(adminKey);
+        }
+    }
+
+    /**
+     * Convenience method to check if the kycKey has a value
+     *
+     * @return true of the kycKey has a value
+     */
+    public boolean hasKycKey() {
+        return kycKey != null;
+    }
+
+    /**
+     * Gets the value for kycKey if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if kycKey is null
+     * @return the value for kycKey if it has a value, or else returns the default value
+     */
+    public Key kycKeyOrElse(@Nonnull final Key defaultValue) {
+        return hasKycKey() ? kycKey : defaultValue;
+    }
+
+    /**
+     * Gets the value for kycKey if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for kycKey if it has a value
+     * @throws NullPointerException if kycKey is null
+     */
+    public @Nonnull Key kycKeyOrThrow() {
+        return requireNonNull(kycKey, "Field kycKey is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the kycKey has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifKycKey(@Nonnull final Consumer<Key> ifPresent) {
+        if (hasKycKey()) {
+            ifPresent.accept(kycKey);
+        }
+    }
+
+    /**
+     * Convenience method to check if the freezeKey has a value
+     *
+     * @return true of the freezeKey has a value
+     */
+    public boolean hasFreezeKey() {
+        return freezeKey != null;
+    }
+
+    /**
+     * Gets the value for freezeKey if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if freezeKey is null
+     * @return the value for freezeKey if it has a value, or else returns the default value
+     */
+    public Key freezeKeyOrElse(@Nonnull final Key defaultValue) {
+        return hasFreezeKey() ? freezeKey : defaultValue;
+    }
+
+    /**
+     * Gets the value for freezeKey if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for freezeKey if it has a value
+     * @throws NullPointerException if freezeKey is null
+     */
+    public @Nonnull Key freezeKeyOrThrow() {
+        return requireNonNull(freezeKey, "Field freezeKey is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the freezeKey has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifFreezeKey(@Nonnull final Consumer<Key> ifPresent) {
+        if (hasFreezeKey()) {
+            ifPresent.accept(freezeKey);
+        }
+    }
+
+    /**
+     * Convenience method to check if the wipeKey has a value
+     *
+     * @return true of the wipeKey has a value
+     */
+    public boolean hasWipeKey() {
+        return wipeKey != null;
+    }
+
+    /**
+     * Gets the value for wipeKey if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if wipeKey is null
+     * @return the value for wipeKey if it has a value, or else returns the default value
+     */
+    public Key wipeKeyOrElse(@Nonnull final Key defaultValue) {
+        return hasWipeKey() ? wipeKey : defaultValue;
+    }
+
+    /**
+     * Gets the value for wipeKey if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for wipeKey if it has a value
+     * @throws NullPointerException if wipeKey is null
+     */
+    public @Nonnull Key wipeKeyOrThrow() {
+        return requireNonNull(wipeKey, "Field wipeKey is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the wipeKey has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifWipeKey(@Nonnull final Consumer<Key> ifPresent) {
+        if (hasWipeKey()) {
+            ifPresent.accept(wipeKey);
+        }
+    }
+
+    /**
+     * Convenience method to check if the supplyKey has a value
+     *
+     * @return true of the supplyKey has a value
+     */
+    public boolean hasSupplyKey() {
+        return supplyKey != null;
+    }
+
+    /**
+     * Gets the value for supplyKey if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if supplyKey is null
+     * @return the value for supplyKey if it has a value, or else returns the default value
+     */
+    public Key supplyKeyOrElse(@Nonnull final Key defaultValue) {
+        return hasSupplyKey() ? supplyKey : defaultValue;
+    }
+
+    /**
+     * Gets the value for supplyKey if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for supplyKey if it has a value
+     * @throws NullPointerException if supplyKey is null
+     */
+    public @Nonnull Key supplyKeyOrThrow() {
+        return requireNonNull(supplyKey, "Field supplyKey is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the supplyKey has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifSupplyKey(@Nonnull final Consumer<Key> ifPresent) {
+        if (hasSupplyKey()) {
+            ifPresent.accept(supplyKey);
+        }
+    }
+
+    /**
+     * Convenience method to check if the feeScheduleKey has a value
+     *
+     * @return true of the feeScheduleKey has a value
+     */
+    public boolean hasFeeScheduleKey() {
+        return feeScheduleKey != null;
+    }
+
+    /**
+     * Gets the value for feeScheduleKey if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if feeScheduleKey is null
+     * @return the value for feeScheduleKey if it has a value, or else returns the default value
+     */
+    public Key feeScheduleKeyOrElse(@Nonnull final Key defaultValue) {
+        return hasFeeScheduleKey() ? feeScheduleKey : defaultValue;
+    }
+
+    /**
+     * Gets the value for feeScheduleKey if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for feeScheduleKey if it has a value
+     * @throws NullPointerException if feeScheduleKey is null
+     */
+    public @Nonnull Key feeScheduleKeyOrThrow() {
+        return requireNonNull(feeScheduleKey, "Field feeScheduleKey is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the feeScheduleKey has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifFeeScheduleKey(@Nonnull final Consumer<Key> ifPresent) {
+        if (hasFeeScheduleKey()) {
+            ifPresent.accept(feeScheduleKey);
+        }
+    }
+
+    /**
+     * Convenience method to check if the pauseKey has a value
+     *
+     * @return true of the pauseKey has a value
+     */
+    public boolean hasPauseKey() {
+        return pauseKey != null;
+    }
+
+    /**
+     * Gets the value for pauseKey if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if pauseKey is null
+     * @return the value for pauseKey if it has a value, or else returns the default value
+     */
+    public Key pauseKeyOrElse(@Nonnull final Key defaultValue) {
+        return hasPauseKey() ? pauseKey : defaultValue;
+    }
+
+    /**
+     * Gets the value for pauseKey if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for pauseKey if it has a value
+     * @throws NullPointerException if pauseKey is null
+     */
+    public @Nonnull Key pauseKeyOrThrow() {
+        return requireNonNull(pauseKey, "Field pauseKey is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the pauseKey has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifPauseKey(@Nonnull final Consumer<Key> ifPresent) {
+        if (hasPauseKey()) {
+            ifPresent.accept(pauseKey);
+        }
+    }
+
+    /**
+     * Convenience method to check if the autoRenewAccountId has a value
+     *
+     * @return true of the autoRenewAccountId has a value
+     */
+    public boolean hasAutoRenewAccountId() {
+        return autoRenewAccountIdSupplier != null && autoRenewAccountIdSupplier.get() != null;
+    }
+
+    /**
+     * Gets the value for autoRenewAccountId if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if autoRenewAccountId is null
+     * @return the value for autoRenewAccountId if it has a value, or else returns the default value
+     */
+    public AccountID autoRenewAccountIdOrElse(@Nonnull final AccountID defaultValue) {
+        return hasAutoRenewAccountId() ? autoRenewAccountIdSupplier.get() : defaultValue;
+    }
+
+    /**
+     * Gets the value for autoRenewAccountId if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for autoRenewAccountId if it has a value
+     * @throws NullPointerException if autoRenewAccountId is null
+     */
+    public @Nonnull AccountID autoRenewAccountIdOrThrow() {
+        return autoRenewAccountIdSupplier == null
+                ? requireNonNull(null, "Field autoRenewAccountId is null")
+                : requireNonNull(autoRenewAccountIdSupplier.get(), "Field autoRenewAccountId is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the autoRenewAccountId has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifAutoRenewAccountId(@Nonnull final Consumer<AccountID> ifPresent) {
+        if (hasAutoRenewAccountId()) {
+            ifPresent.accept(autoRenewAccountIdSupplier.get());
+        }
+    }
+
+    /**
+     * Convenience method to check if the metadataKey has a value
+     *
+     * @return true of the metadataKey has a value
+     */
+    public boolean hasMetadataKey() {
+        return metadataKey != null;
+    }
+
+    /**
+     * Gets the value for metadataKey if it has a value, or else returns the default
+     * value for the type.
+     *
+     * @param defaultValue the default value to return if metadataKey is null
+     * @return the value for metadataKey if it has a value, or else returns the default value
+     */
+    public Key metadataKeyOrElse(@Nonnull final Key defaultValue) {
+        return hasMetadataKey() ? metadataKey : defaultValue;
+    }
+
+    /**
+     * Gets the value for metadataKey if it has a value, or else throws an NPE.
+     * value for the type.
+     *
+     * @return the value for metadataKey if it has a value
+     * @throws NullPointerException if metadataKey is null
+     */
+    public @Nonnull Key metadataKeyOrThrow() {
+        return requireNonNull(metadataKey, "Field metadataKey is null");
+    }
+
+    /**
+     * Executes the supplied {@link Consumer} if, and only if, the metadataKey has a value
+     *
+     * @param ifPresent the {@link Consumer} to execute
+     */
+    public void ifMetadataKey(@Nonnull final Consumer<Key> ifPresent) {
+        if (hasMetadataKey()) {
+            ifPresent.accept(metadataKey);
+        }
+    }
+
+    /**
+     * Return a builder for building a copy of this model object. It will be pre-populated with all the data from this
+     * model object.
+     *
+     * @return a pre-populated builder
+     */
+    public Builder copyBuilder() {
+        return new Builder(
+                tokenId,
+                name,
+                symbol,
+                decimals,
+                totalSupplySupplier,
+                treasuryAccountIdSupplier,
+                adminKey,
+                kycKey,
+                freezeKey,
+                wipeKey,
+                supplyKey,
+                feeScheduleKey,
+                pauseKey,
+                lastUsedSerialNumber,
+                deleted,
+                tokenType,
+                supplyType,
+                autoRenewAccountIdSupplier,
+                autoRenewSeconds,
+                expirationSecond,
+                memo,
+                maxSupply,
+                paused,
+                accountsFrozenByDefault,
+                accountsKycGrantedByDefault,
+                customFeesSupplier,
+                metadata,
+                metadataKey);
+    }
+
+    /**
+     * Builder class for easy creation, ideal for clean code where performance is not critical. In critical performance
+     * paths use the constructor directly.
+     */
+    public static final class Builder {
+        @Nullable
+        private TokenID tokenId = null;
+
+        @Nonnull
+        private String name = "";
+
+        @Nonnull
+        private String symbol = "";
+
+        private int decimals = 0;
+
+        @Nullable
+        private Supplier<Long> totalSupplySupplier = null;
+
+        @Nullable
+        private Supplier<AccountID> treasuryAccountIdSupplier = null;
+
+        @Nullable
+        private Key adminKey = null;
+
+        @Nullable
+        private Key kycKey = null;
+
+        @Nullable
+        private Key freezeKey = null;
+
+        @Nullable
+        private Key wipeKey = null;
+
+        @Nullable
+        private Key supplyKey = null;
+
+        @Nullable
+        private Key feeScheduleKey = null;
+
+        @Nullable
+        private Key pauseKey = null;
+
+        private long lastUsedSerialNumber = 0;
+        private boolean deleted = false;
+        private TokenType tokenType = TokenType.fromProtobufOrdinal(0);
+        private TokenSupplyType supplyType = TokenSupplyType.fromProtobufOrdinal(0);
+
+        @Nullable
+        private Supplier<AccountID> autoRenewAccountIdSupplier = null;
+
+        private long autoRenewSeconds = 0;
+        private long expirationSecond = 0;
+
+        @Nonnull
+        private String memo = "";
+
+        private long maxSupply = 0;
+        private boolean paused = false;
+        private boolean accountsFrozenByDefault = false;
+        private boolean accountsKycGrantedByDefault = false;
+
+        @Nullable
+        private Supplier<List<CustomFee>> customFeesSupplier = Collections::emptyList;
+
+        @Nonnull
+        private Bytes metadata = Bytes.EMPTY;
+
+        @Nullable
+        private Key metadataKey = null;
+
+        /**
+         * Create an empty builder
+         */
+        public Builder() {}
+
+        /**
+         * Create a pre-populated Builder.
+         *
+         * @param tokenId <b>(1)</b> The unique entity id of this token.
+         * @param name <b>(2)</b> The human-readable name of this token. Need not be unique. Maximum length allowed is 100 bytes.
+         * @param symbol <b>(3)</b> The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is 100 bytes.
+         * @param decimals <b>(4)</b> The number of decimal places of this token. If decimals are 8 or 11, then the number of whole
+         *                 tokens can be at most a few billions or millions, respectively. For example, it could match
+         *                 Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
+         *                 It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
+         * @param totalSupplySupplier <b>(5)</b> The total supply of this token wrapped in a Supplier.
+         * @param treasuryAccountIdSupplier <b>(6)</b> The treasury account id of this token wrapped in a Supplier.
+         * @param adminKey <b>(7)</b> (Optional) The admin key of this token. If this key is set, the token is mutable.
+         *                 A mutable token can be modified.
+         *                 If this key is not set on token creation, it cannot be modified.
+         * @param kycKey <b>(8)</b> (Optional) The kyc key of this token.
+         *               If this key is not set on token creation, it can only be set if the token has admin key set.
+         * @param freezeKey <b>(9)</b> (Optional) The freeze key of this token. This key is needed for freezing the token.
+         *                  If this key is not set on token creation, it can only be set if the token has admin key set.
+         * @param wipeKey <b>(10)</b> (Optional) The wipe key of this token. This key is needed for wiping the token.
+         *                If this key is not set on token creation, it can only be set if the token has admin key set.
+         * @param supplyKey <b>(11)</b> (Optional) The supply key of this token. This key is needed for minting or burning token.
+         *                  If this key is not set on token creation, it can only be set if the token has admin key set.
+         * @param feeScheduleKey <b>(12)</b> (Optional) The fee schedule key of this token. This key should be set, in order to make any
+         *                       changes to the custom fee schedule.
+         *                       If this key is not set on token creation, it can only be set if the token has admin key set.
+         * @param pauseKey <b>(13)</b> (Optional) The pause key of this token. This key is needed for pausing the token.
+         *                 If this key is not set on token creation, it can only be set if the token has admin key set.
+         * @param lastUsedSerialNumber <b>(14)</b> The last used serial number of this token.
+         * @param deleted <b>(15)</b> The flag indicating if this token is deleted.
+         * @param tokenType <b>(16)</b> The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
+         *                  If it has been omitted during token creation, FUNGIBLE_COMMON type is used.
+         * @param supplyType <b>(17)</b> The supply type of this token.A token can have either INFINITE or FINITE supply type.
+         *                   If it has been omitted during token creation, INFINITE type is used.
+         * @param autoRenewAccountIdSupplier <b>(18)</b> The id of the account (if any) that the network will attempt to charge for the
+         *  *                           token's auto-renewal upon expiration wrapped in a Supplier.
+         * @param autoRenewSeconds <b>(19)</b> The number of seconds the network should automatically extend the token's expiration by, if the
+         *                         token has a valid auto-renew account, and is not deleted upon expiration.
+         *                         If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
+         *                         The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
+         * @param expirationSecond <b>(20)</b> The expiration time of the token, in seconds since the epoch.
+         * @param memo <b>(21)</b> An optional description of the token with UTF-8 encoding up to 100 bytes.
+         * @param maxSupply <b>(22)</b> The maximum supply of this token.
+         * @param paused <b>(23)</b> The flag indicating if this token is paused.
+         * @param accountsFrozenByDefault <b>(24)</b> The flag indicating if this token has accounts associated to it that are frozen by default.
+         * @param accountsKycGrantedByDefault <b>(25)</b> The flag indicating if this token has accounts associated with it that are KYC granted by default.
+         * @param customFeesSupplier <b>(26)</b> (Optional) The custom fees of this token wrapped in a Supplier.
+         * @param metadata <b>(27)</b> Metadata of the created token definition
+         * @param metadataKey <b>(28)</b> The key which can change the metadata of a token
+         *                    (token definition and individual NFTs).
+         */
+        public Builder(
+                TokenID tokenId,
+                String name,
+                String symbol,
+                int decimals,
+                Supplier<Long> totalSupplySupplier,
+                Supplier<AccountID> treasuryAccountIdSupplier,
+                Key adminKey,
+                Key kycKey,
+                Key freezeKey,
+                Key wipeKey,
+                Key supplyKey,
+                Key feeScheduleKey,
+                Key pauseKey,
+                long lastUsedSerialNumber,
+                boolean deleted,
+                TokenType tokenType,
+                TokenSupplyType supplyType,
+                Supplier<AccountID> autoRenewAccountIdSupplier,
+                long autoRenewSeconds,
+                long expirationSecond,
+                String memo,
+                long maxSupply,
+                boolean paused,
+                boolean accountsFrozenByDefault,
+                boolean accountsKycGrantedByDefault,
+                Supplier<List<CustomFee>> customFeesSupplier,
+                Bytes metadata,
+                Key metadataKey) {
+            this.tokenId = tokenId;
+            this.name = name != null ? name : "";
+            this.symbol = symbol != null ? symbol : "";
+            this.decimals = decimals;
+            this.totalSupplySupplier = totalSupplySupplier;
+            this.treasuryAccountIdSupplier = treasuryAccountIdSupplier;
+            this.adminKey = adminKey;
+            this.kycKey = kycKey;
+            this.freezeKey = freezeKey;
+            this.wipeKey = wipeKey;
+            this.supplyKey = supplyKey;
+            this.feeScheduleKey = feeScheduleKey;
+            this.pauseKey = pauseKey;
+            this.lastUsedSerialNumber = lastUsedSerialNumber;
+            this.deleted = deleted;
+            this.tokenType = tokenType;
+            this.supplyType = supplyType;
+            this.autoRenewAccountIdSupplier = autoRenewAccountIdSupplier;
+            this.autoRenewSeconds = autoRenewSeconds;
+            this.expirationSecond = expirationSecond;
+            this.memo = memo != null ? memo : "";
+            this.maxSupply = maxSupply;
+            this.paused = paused;
+            this.accountsFrozenByDefault = accountsFrozenByDefault;
+            this.accountsKycGrantedByDefault = accountsKycGrantedByDefault;
+            this.customFeesSupplier = customFeesSupplier;
+            this.metadata = metadata != null ? metadata : Bytes.EMPTY;
+            this.metadataKey = metadataKey;
+        }
+
+        /**
+         * Build a new model record with data set on builder
+         *
+         * @return new model record with data set
+         */
+        public Token build() {
+            return new Token(
+                    tokenId,
+                    name,
+                    symbol,
+                    decimals,
+                    totalSupplySupplier,
+                    treasuryAccountIdSupplier,
+                    adminKey,
+                    kycKey,
+                    freezeKey,
+                    wipeKey,
+                    supplyKey,
+                    feeScheduleKey,
+                    pauseKey,
+                    lastUsedSerialNumber,
+                    deleted,
+                    tokenType,
+                    supplyType,
+                    autoRenewAccountIdSupplier,
+                    autoRenewSeconds,
+                    expirationSecond,
+                    memo,
+                    maxSupply,
+                    paused,
+                    accountsFrozenByDefault,
+                    accountsKycGrantedByDefault,
+                    customFeesSupplier,
+                    metadata,
+                    metadataKey);
+        }
+
+        /**
+         * <b>(1)</b> The unique entity id of this token.
+         *
+         * @param tokenId value to set
+         * @return builder to continue building with
+         */
+        public Builder tokenId(@Nullable TokenID tokenId) {
+            this.tokenId = tokenId;
+            return this;
+        }
+
+        /**
+         * <b>(1)</b> The unique entity id of this token.
+         *
+         * @param builder A pre-populated builder
+         * @return builder to continue building with
+         */
+        public Builder tokenId(TokenID.Builder builder) {
+            this.tokenId = builder.build();
+            return this;
+        }
+
+        /**
+         * <b>(2)</b> The human-readable name of this token. Need not be unique. Maximum length allowed is 100 bytes.
+         *
+         * @param name value to set
+         * @return builder to continue building with
+         */
+        public Builder name(@Nonnull String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * <b>(3)</b> The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is 100 bytes.
+         *
+         * @param symbol value to set
+         * @return builder to continue building with
+         */
+        public Builder symbol(@Nonnull String symbol) {
+            this.symbol = symbol;
+            return this;
+        }
+
+        /**
+         * <b>(4)</b> The number of decimal places of this token. If decimals are 8 or 11, then the number of whole
+         * tokens can be at most a few billions or millions, respectively. For example, it could match
+         * Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
+         * It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
+         *
+         * @param decimals value to set
+         * @return builder to continue building with
+         */
+        public Builder decimals(int decimals) {
+            this.decimals = decimals;
+            return this;
+        }
+
+        /**
+         * <b>(5)</b> The total supply of this token.
+         *
+         * @param totalSupply value to set
+         * @return builder to continue building with
+         */
+        public Builder totalSupply(Long totalSupply) {
+            this.totalSupplySupplier = () -> totalSupply;
+            return this;
+        }
+
+        /**
+         * <b>(5)</b> The total supply of this token.
+         *
+         * @param totalSupplySupplier value to set
+         * @return builder to continue building with
+         */
+        public Builder totalSupply(Supplier<Long> totalSupplySupplier) {
+            this.totalSupplySupplier = totalSupplySupplier;
+            return this;
+        }
+
+        /**
+         * <b>(6)</b> The treasury account id of this token. This account receives the initial supply of
+         * tokens as well as the tokens from the Token Mint operation once executed. The balance
+         * of the treasury account is decreased when the Token Burn operation is executed.
+         *
+         * @param treasuryAccountId value to set
+         * @return builder to continue building with
+         */
+        public Builder treasuryAccountId(@Nullable AccountID treasuryAccountId) {
+            this.treasuryAccountIdSupplier = () -> treasuryAccountId;
+            return this;
+        }
+
+        /**
+         * <b>(6)</b> The treasury account id of this token. This account receives the initial supply of
+         * tokens as well as the tokens from the Token Mint operation once executed. The balance
+         * of the treasury account is decreased when the Token Burn operation is executed.
+         *
+         * @param treasuryAccountIdSupplier value to set
+         * @return builder to continue building with
+         */
+        public Builder treasuryAccountId(@Nullable Supplier<AccountID> treasuryAccountIdSupplier) {
+            this.treasuryAccountIdSupplier = treasuryAccountIdSupplier;
+            return this;
+        }
+
+        /**
+         * <b>(7)</b> (Optional) The admin key of this token. If this key is set, the token is mutable.
+         * A mutable token can be modified.
+         * If this key is not set on token creation, it cannot be modified.
+         *
+         * @param adminKey value to set
+         * @return builder to continue building with
+         */
+        public Builder adminKey(@Nullable Key adminKey) {
+            this.adminKey = adminKey;
+            return this;
+        }
+
+        /**
+         * <b>(7)</b> (Optional) The admin key of this token. If this key is set, the token is mutable.
+         * A mutable token can be modified.
+         * If this key is not set on token creation, it cannot be modified.
+         *
+         * @param builder A pre-populated builder
+         * @return builder to continue building with
+         */
+        public Builder adminKey(Key.Builder builder) {
+            this.adminKey = builder.build();
+            return this;
+        }
+
+        /**
+         * <b>(8)</b> (Optional) The kyc key of this token.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param kycKey value to set
+         * @return builder to continue building with
+         */
+        public Builder kycKey(@Nullable Key kycKey) {
+            this.kycKey = kycKey;
+            return this;
+        }
+
+        /**
+         * <b>(8)</b> (Optional) The kyc key of this token.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param builder A pre-populated builder
+         * @return builder to continue building with
+         */
+        public Builder kycKey(Key.Builder builder) {
+            this.kycKey = builder.build();
+            return this;
+        }
+
+        /**
+         * <b>(9)</b> (Optional) The freeze key of this token. This key is needed for freezing the token.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param freezeKey value to set
+         * @return builder to continue building with
+         */
+        public Builder freezeKey(@Nullable Key freezeKey) {
+            this.freezeKey = freezeKey;
+            return this;
+        }
+
+        /**
+         * <b>(9)</b> (Optional) The freeze key of this token. This key is needed for freezing the token.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param builder A pre-populated builder
+         * @return builder to continue building with
+         */
+        public Builder freezeKey(Key.Builder builder) {
+            this.freezeKey = builder.build();
+            return this;
+        }
+
+        /**
+         * <b>(10)</b> (Optional) The wipe key of this token. This key is needed for wiping the token.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param wipeKey value to set
+         * @return builder to continue building with
+         */
+        public Builder wipeKey(@Nullable Key wipeKey) {
+            this.wipeKey = wipeKey;
+            return this;
+        }
+
+        /**
+         * <b>(10)</b> (Optional) The wipe key of this token. This key is needed for wiping the token.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param builder A pre-populated builder
+         * @return builder to continue building with
+         */
+        public Builder wipeKey(Key.Builder builder) {
+            this.wipeKey = builder.build();
+            return this;
+        }
+
+        /**
+         * <b>(11)</b> (Optional) The supply key of this token. This key is needed for minting or burning token.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param supplyKey value to set
+         * @return builder to continue building with
+         */
+        public Builder supplyKey(@Nullable Key supplyKey) {
+            this.supplyKey = supplyKey;
+            return this;
+        }
+
+        /**
+         * <b>(11)</b> (Optional) The supply key of this token. This key is needed for minting or burning token.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param builder A pre-populated builder
+         * @return builder to continue building with
+         */
+        public Builder supplyKey(Key.Builder builder) {
+            this.supplyKey = builder.build();
+            return this;
+        }
+
+        /**
+         * <b>(12)</b> (Optional) The fee schedule key of this token. This key should be set, in order to make any
+         * changes to the custom fee schedule.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param feeScheduleKey value to set
+         * @return builder to continue building with
+         */
+        public Builder feeScheduleKey(@Nullable Key feeScheduleKey) {
+            this.feeScheduleKey = feeScheduleKey;
+            return this;
+        }
+
+        /**
+         * <b>(12)</b> (Optional) The fee schedule key of this token. This key should be set, in order to make any
+         * changes to the custom fee schedule.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param builder A pre-populated builder
+         * @return builder to continue building with
+         */
+        public Builder feeScheduleKey(Key.Builder builder) {
+            this.feeScheduleKey = builder.build();
+            return this;
+        }
+
+        /**
+         * <b>(13)</b> (Optional) The pause key of this token. This key is needed for pausing the token.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param pauseKey value to set
+         * @return builder to continue building with
+         */
+        public Builder pauseKey(@Nullable Key pauseKey) {
+            this.pauseKey = pauseKey;
+            return this;
+        }
+
+        /**
+         * <b>(13)</b> (Optional) The pause key of this token. This key is needed for pausing the token.
+         * If this key is not set on token creation, it can only be set if the token has admin key set.
+         *
+         * @param builder A pre-populated builder
+         * @return builder to continue building with
+         */
+        public Builder pauseKey(Key.Builder builder) {
+            this.pauseKey = builder.build();
+            return this;
+        }
+
+        /**
+         * <b>(14)</b> The last used serial number of this token.
+         *
+         * @param lastUsedSerialNumber value to set
+         * @return builder to continue building with
+         */
+        public Builder lastUsedSerialNumber(long lastUsedSerialNumber) {
+            this.lastUsedSerialNumber = lastUsedSerialNumber;
+            return this;
+        }
+
+        /**
+         * <b>(14)</b> The flag indicating if this token is deleted.
+         *
+         * @param deleted value to set
+         * @return builder to continue building with
+         */
+        public Builder deleted(boolean deleted) {
+            this.deleted = deleted;
+            return this;
+        }
+
+        /**
+         * <b>(15)</b> The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
+         * If it has been omitted during token creation, FUNGIBLE_COMMON type is used.
+         *
+         * @param tokenType value to set
+         * @return builder to continue building with
+         */
+        public Builder tokenType(TokenType tokenType) {
+            this.tokenType = tokenType;
+            return this;
+        }
+
+        /**
+         * <b>(16)</b> The supply type of this token.A token can have either INFINITE or FINITE supply type.
+         * If it has been omitted during token creation, INFINITE type is used.
+         *
+         * @param supplyType value to set
+         * @return builder to continue building with
+         */
+        public Builder supplyType(TokenSupplyType supplyType) {
+            this.supplyType = supplyType;
+            return this;
+        }
+
+        /**
+         * <b>(17)</b> The id of the account (if any) that the network will attempt to charge for the
+         * token's auto-renewal upon expiration.
+         *
+         * @param autoRenewAccountId value to set
+         * @return builder to continue building with
+         */
+        public Builder autoRenewAccountId(@Nullable AccountID autoRenewAccountId) {
+            this.autoRenewAccountIdSupplier = () -> autoRenewAccountId;
+            return this;
+        }
+
+        /**
+         * <b>(17)</b> The id of the account (if any) that the network will attempt to charge for the
+         * token's auto-renewal upon expiration.
+         *
+         * @param autoRenewAccountIdSupplier value to set
+         * @return builder to continue building with
+         */
+        public Builder autoRenewAccountId(@Nullable Supplier<AccountID> autoRenewAccountIdSupplier) {
+            this.autoRenewAccountIdSupplier = autoRenewAccountIdSupplier;
+            return this;
+        }
+
+        /**
+         * <b>(18)</b> The number of seconds the network should automatically extend the token's expiration by, if the
+         * token has a valid auto-renew account, and is not deleted upon expiration.
+         * If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
+         * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
+         *
+         * @param autoRenewSeconds value to set
+         * @return builder to continue building with
+         */
+        public Builder autoRenewSeconds(long autoRenewSeconds) {
+            this.autoRenewSeconds = autoRenewSeconds;
+            return this;
+        }
+
+        /**
+         * <b>(19)</b> The expiration time of the token, in seconds since the epoch.
+         *
+         * @param expirationSecond value to set
+         * @return builder to continue building with
+         */
+        public Builder expirationSecond(long expirationSecond) {
+            this.expirationSecond = expirationSecond;
+            return this;
+        }
+
+        /**
+         * <b>(20)</b> An optional description of the token with UTF-8 encoding up to 100 bytes.
+         *
+         * @param memo value to set
+         * @return builder to continue building with
+         */
+        public Builder memo(@Nonnull String memo) {
+            this.memo = memo;
+            return this;
+        }
+
+        /**
+         * <b>(21)</b> The maximum supply of this token.
+         *
+         * @param maxSupply value to set
+         * @return builder to continue building with
+         */
+        public Builder maxSupply(long maxSupply) {
+            this.maxSupply = maxSupply;
+            return this;
+        }
+
+        /**
+         * <b>(22)</b> The flag indicating if this token is paused.
+         *
+         * @param paused value to set
+         * @return builder to continue building with
+         */
+        public Builder paused(boolean paused) {
+            this.paused = paused;
+            return this;
+        }
+
+        /**
+         * <b>(23)</b> The flag indicating if this token has accounts associated to it that are frozen by default.
+         *
+         * @param accountsFrozenByDefault value to set
+         * @return builder to continue building with
+         */
+        public Builder accountsFrozenByDefault(boolean accountsFrozenByDefault) {
+            this.accountsFrozenByDefault = accountsFrozenByDefault;
+            return this;
+        }
+
+        /**
+         * <b>(24)</b> The flag indicating if this token has accounts associated with it that are KYC granted by default.
+         *
+         * @param accountsKycGrantedByDefault value to set
+         * @return builder to continue building with
+         */
+        public Builder accountsKycGrantedByDefault(boolean accountsKycGrantedByDefault) {
+            this.accountsKycGrantedByDefault = accountsKycGrantedByDefault;
+            return this;
+        }
+
+        /**
+         * <b>(25)</b> (Optional) The custom fees of this token.
+         *
+         * @param customFees value to set
+         * @return builder to continue building with
+         */
+        public Builder customFees(@Nonnull List<CustomFee> customFees) {
+            this.customFeesSupplier = () -> customFees;
+            return this;
+        }
+
+        /**
+         * <b>(26)</b> (Optional) The custom fees of this token.
+         *
+         * @param customFeesSupplier value to set
+         * @return builder to continue building with
+         */
+        public Builder customFees(@Nonnull Supplier<List<CustomFee>> customFeesSupplier) {
+            this.customFeesSupplier = customFeesSupplier;
+            return this;
+        }
+
+        /**
+         * <b>(27)</b> Metadata of the created token definition
+         *
+         * @param metadata value to set
+         * @return builder to continue building with
+         */
+        public Builder metadata(@Nonnull Bytes metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        /**
+         * <b>(28)</b> The key which can change the metadata of a token
+         * (token definition and individual NFTs).
+         *
+         * @param metadataKey value to set
+         * @return builder to continue building with
+         */
+        public Builder metadataKey(@Nullable Key metadataKey) {
+            this.metadataKey = metadataKey;
+            return this;
+        }
+
+        /**
+         * <b>(28)</b> The key which can change the metadata of a token
+         * (token definition and individual NFTs).
+         *
+         * @param builder A pre-populated builder
+         * @return builder to continue building with
+         */
+        public Builder metadataKey(Key.Builder builder) {
+            this.metadataKey = builder.build();
+            return this;
+        }
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/hapi/node/state/token/Token.java
@@ -260,6 +260,7 @@ public record Token(
             result = 31 * result + Long.hashCode(totalSupplySupplier.get());
         }
         if (treasuryAccountIdSupplier != null
+                && treasuryAccountIdSupplier.get() != null
                 && DEFAULT.treasuryAccountIdSupplier != null
                 && !treasuryAccountIdSupplier.get().equals(DEFAULT.treasuryAccountIdSupplier.get())) {
             result = 31 * result + treasuryAccountIdSupplier.get().hashCode();
@@ -298,6 +299,7 @@ public record Token(
             result = 31 * result + Integer.hashCode(supplyType.protoOrdinal());
         }
         if (autoRenewAccountIdSupplier != null
+                && autoRenewAccountIdSupplier.get() != null
                 && DEFAULT.autoRenewAccountIdSupplier != null
                 && !autoRenewAccountIdSupplier.equals(DEFAULT.autoRenewAccountIdSupplier)) {
             result = 31 * result + autoRenewAccountIdSupplier.get().hashCode();
@@ -396,9 +398,18 @@ public record Token(
         if (treasuryAccountIdSupplier != null && thatObj.treasuryAccountIdSupplier == null) {
             return false;
         }
-        if (treasuryAccountIdSupplier != null
-                && !treasuryAccountIdSupplier.get().equals(thatObj.treasuryAccountIdSupplier.get())) {
-            return false;
+        if (treasuryAccountIdSupplier != null) {
+            AccountID thisAccountId = treasuryAccountIdSupplier.get();
+            AccountID thatAccountId = thatObj.treasuryAccountIdSupplier.get();
+
+            // If both retrieved account IDs are null, continue without returning true
+            if (thisAccountId == null && thatAccountId == null) {
+                // Both are null, but we don't return true yet; we continue checking
+            } else if (thisAccountId == null || thatAccountId == null) {
+                return false; // One is null, and the other is not
+            } else if (!thisAccountId.equals(thatAccountId)) {
+                return false; // They are not equal
+            }
         }
         if (adminKey == null && thatObj.adminKey != null) {
             return false;
@@ -466,9 +477,18 @@ public record Token(
         if (autoRenewAccountIdSupplier != null && thatObj.autoRenewAccountIdSupplier == null) {
             return false;
         }
-        if (autoRenewAccountIdSupplier != null
-                && !autoRenewAccountIdSupplier.get().equals(thatObj.autoRenewAccountIdSupplier.get())) {
-            return false;
+        if (autoRenewAccountIdSupplier != null) {
+            AccountID thisAccountId = autoRenewAccountIdSupplier.get();
+            AccountID thatAccountId = thatObj.autoRenewAccountIdSupplier.get();
+
+            // If both retrieved account IDs are null, continue without returning true
+            if (thisAccountId == null && thatAccountId == null) {
+                // Both are null, but we don't return true yet; we continue checking
+            } else if (thisAccountId == null || thatAccountId == null) {
+                return false; // One is null, and the other is not
+            } else if (!thisAccountId.equals(thatAccountId)) {
+                return false; // They are not equal
+            }
         }
         if (autoRenewSeconds != thatObj.autoRenewSeconds) {
             return false;
@@ -1310,7 +1330,7 @@ public record Token(
          * @param totalSupply value to set
          * @return builder to continue building with
          */
-        public Builder totalSupply(Long totalSupply) {
+        public Builder totalSupply(long totalSupply) {
             this.totalSupplySupplier = () -> totalSupply;
             return this;
         }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
@@ -16,7 +16,6 @@
 
 package com.hedera.mirror.web3.state;
 
-import static com.hedera.services.utils.EntityIdUtils.toAccountId;
 import static com.hedera.services.utils.EntityIdUtils.toEntityId;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -36,28 +35,17 @@ public class CommonEntityAccessor {
 
     public @Nonnull Optional<Entity> get(@Nonnull AccountID accountID, final Optional<Long> timestamp) {
         if (accountID.hasAccountNum()) {
-            return getEntityByMirrorAddressAndTimestamp(toEntityId(accountID), timestamp);
+            return get(toEntityId(accountID), timestamp);
         } else {
             return getEntityByEvmAddressAndTimestamp(accountID.alias().toByteArray(), timestamp);
         }
     }
 
     public @Nonnull Optional<Entity> get(@Nonnull TokenID tokenID, final Optional<Long> timestamp) {
-        return getEntityByMirrorAddressAndTimestamp(toEntityId(tokenID), timestamp);
+        return get(toEntityId(tokenID), timestamp);
     }
 
-    public AccountID getAccountWithCanonicalAddress(EntityId entityId, final Optional<Long> timestamp) {
-        final var entity = timestamp
-                .map(t -> entityRepository
-                        .findActiveByIdAndTimestamp(entityId.getId(), t)
-                        .orElse(null))
-                .orElseGet(() -> entityRepository
-                        .findByIdAndDeletedIsFalse(entityId.getId())
-                        .orElse(null));
-        return toAccountId(entity);
-    }
-
-    private Optional<Entity> getEntityByMirrorAddressAndTimestamp(EntityId entityId, final Optional<Long> timestamp) {
+    public @Nonnull Optional<Entity> get(@Nonnull EntityId entityId, final Optional<Long> timestamp) {
         return timestamp
                 .map(t -> entityRepository.findActiveByIdAndTimestamp(entityId.getId(), t))
                 .orElseGet(() -> entityRepository.findByIdAndDeletedIsFalse(entityId.getId()));

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
@@ -43,8 +43,7 @@ public class CommonEntityAccessor {
     }
 
     public @Nonnull Optional<Entity> get(@Nonnull TokenID tokenID, final Optional<Long> timestamp) {
-        return getEntityByMirrorAddressAndTimestamp(
-                EntityId.of(tokenID.shardNum(), tokenID.realmNum(), tokenID.tokenNum()), timestamp);
+        return getEntityByMirrorAddressAndTimestamp(toEntityId(tokenID), timestamp);
     }
 
     public AccountID getAccountWithCanonicalAddress(EntityId entityId, final Optional<Long> timestamp) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state;
+
+import static com.hedera.mirror.web3.state.Utils.DEFAULT_AUTO_RENEW_PERIOD;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Fraction;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenSupplyType;
+import com.hedera.hapi.node.base.TokenType;
+import com.hedera.hapi.node.state.token.Token;
+import com.hedera.hapi.node.transaction.CustomFee;
+import com.hedera.hapi.node.transaction.CustomFee.FeeOneOfType;
+import com.hedera.hapi.node.transaction.FixedFee;
+import com.hedera.hapi.node.transaction.FractionalFee;
+import com.hedera.hapi.node.transaction.RoyaltyFee;
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.token.TokenPauseStatusEnum;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.repository.CustomFeeRepository;
+import com.hedera.mirror.web3.repository.EntityRepository;
+import com.hedera.mirror.web3.repository.TokenRepository;
+import com.hedera.mirror.web3.utils.Suppliers;
+import com.hedera.pbj.runtime.OneOf;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.services.utils.EntityIdUtils;
+import com.swirlds.state.spi.ReadableKVStateBase;
+import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.springframework.util.CollectionUtils;
+
+public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
+    private static final String KEY = "TOKENS";
+
+    private final CommonEntityAccessor commonEntityAccessor;
+    private final CustomFeeRepository customFeeRepository;
+    private final TokenRepository tokenRepository;
+    private final EntityRepository entityRepository;
+
+    protected TokenReadableKVState(
+            @Nonnull CommonEntityAccessor commonEntityAccessor,
+            @Nonnull CustomFeeRepository customFeeRepository,
+            @Nonnull TokenRepository tokenRepository,
+            @Nonnull EntityRepository entityRepository) {
+        super(KEY);
+        this.commonEntityAccessor = commonEntityAccessor;
+        this.customFeeRepository = customFeeRepository;
+        this.tokenRepository = tokenRepository;
+        this.entityRepository = entityRepository;
+    }
+
+    @Override
+    protected Token readFromDataSource(@Nonnull TokenID key) {
+        final var timestamp = ContractCallContext.get().getTimestamp();
+        final var entity = commonEntityAccessor.get(key, timestamp).orElse(null);
+
+        if (entity == null) {
+            return null;
+        }
+
+        final var token = timestamp
+                .flatMap(t -> tokenRepository.findByTokenIdAndTimestamp(entity.getId(), t))
+                .orElseGet(() -> tokenRepository.findById(entity.getId()).orElse(null));
+
+        if (token == null) {
+            return null;
+        }
+
+        return tokenFromEntities(entity, token, timestamp);
+    }
+
+    @Override
+    protected @Nonnull Iterator<TokenID> iterateFromDataSource() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public long size() {
+        return 0;
+    }
+
+    private Token tokenFromEntities(
+            final Entity entity,
+            final com.hedera.mirror.common.domain.token.Token token,
+            final Optional<Long> timestamp) {
+        return Token.newBuilder()
+                .tokenId(new TokenID(entity.getShard(), entity.getRealm(), entity.getNum()))
+                .name(token.getName())
+                .symbol(token.getSymbol())
+                .decimals(token.getDecimals())
+                .totalSupply(getTotalSupply(token, timestamp))
+                .treasuryAccountId(getTreasury(token.getTreasuryAccountId(), timestamp))
+                .adminKey(Utils.parseKey(entity.getKey()))
+                .kycKey(Utils.parseKey(token.getKycKey()))
+                .freezeKey(Utils.parseKey(token.getFreezeKey()))
+                .wipeKey(Utils.parseKey(token.getWipeKey()))
+                .supplyKey(Utils.parseKey(token.getSupplyKey()))
+                .feeScheduleKey(Utils.parseKey(token.getFeeScheduleKey()))
+                .pauseKey(Utils.parseKey(token.getPauseKey()))
+                .deleted(false)
+                .tokenType(TokenType.valueOf(token.getType().name()))
+                .supplyType(TokenSupplyType.valueOf(token.getSupplyType().name()))
+                .autoRenewAccountId(getAutoRenewAccount(entity.getAutoRenewAccountId(), timestamp))
+                .autoRenewSeconds(
+                        entity.getAutoRenewPeriod() != null ? entity.getAutoRenewPeriod() : DEFAULT_AUTO_RENEW_PERIOD)
+                .expirationSecond(TimeUnit.SECONDS.convert(entity.getEffectiveExpiration(), TimeUnit.NANOSECONDS))
+                .memo(entity.getMemo())
+                .maxSupply(token.getMaxSupply())
+                .paused(token.getPauseStatus().equals(TokenPauseStatusEnum.PAUSED))
+                .accountsFrozenByDefault(token.getFreezeDefault())
+                .metadata(Bytes.wrap(token.getMetadata()))
+                .metadataKey(Utils.parseKey(token.getMetadataKey()))
+                .customFees(getCustomFees(token.getTokenId(), timestamp))
+                .build();
+    }
+
+    private Supplier<Long> getTotalSupply(
+            final com.hedera.mirror.common.domain.token.Token token, final Optional<Long> timestamp) {
+        return Suppliers.memoize(() -> timestamp
+                .map(t -> getTotalSupplyHistorical(token.getTokenId(), t))
+                .or(() -> Optional.ofNullable(token.getTotalSupply()))
+                .orElse(0L));
+    }
+
+    private Long getTotalSupplyHistorical(long tokenId, long timestamp) {
+        return tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(tokenId, timestamp);
+    }
+
+    private Supplier<AccountID> getAutoRenewAccount(Long autoRenewAccountId, final Optional<Long> timestamp) {
+        if (autoRenewAccountId == null) {
+            return null;
+        }
+        return Suppliers.memoize(() -> timestamp
+                .map(t -> entityRepository.findActiveByIdAndTimestamp(autoRenewAccountId, t))
+                .orElseGet(() -> entityRepository.findByIdAndDeletedIsFalse(autoRenewAccountId))
+                .map(EntityIdUtils::toAccountId)
+                .orElse(null));
+    }
+
+    private Supplier<AccountID> getTreasury(EntityId treasuryId, final Optional<Long> timestamp) {
+        if (treasuryId == null) {
+            return null;
+        }
+        return Suppliers.memoize(() -> timestamp
+                .map(t -> entityRepository.findActiveByIdAndTimestamp(treasuryId.getId(), t))
+                .orElseGet(() -> entityRepository.findByIdAndDeletedIsFalse(treasuryId.getId()))
+                .map(EntityIdUtils::toAccountId)
+                .orElse(null));
+    }
+
+    private Supplier<List<CustomFee>> getCustomFees(Long tokenId, final Optional<Long> timestamp) {
+        final var customFees = timestamp
+                .map(t -> customFeeRepository.findByTokenIdAndTimestamp(tokenId, t))
+                .orElseGet(() -> customFeeRepository.findById(tokenId))
+                .map(customFee -> convertCustomFees(customFee, timestamp));
+
+        return Suppliers.memoize(() -> Collections.unmodifiableList(customFees.orElse(new ArrayList<>())));
+    }
+
+    private List<CustomFee> convertCustomFees(
+            final com.hedera.mirror.common.domain.token.CustomFee customFees, final Optional<Long> timestamp) {
+        var customFeesConstructed = new ArrayList<CustomFee>();
+        customFeesConstructed.addAll(mapFixedFees(customFees, timestamp));
+        customFeesConstructed.addAll(mapFractionalFees(customFees, timestamp));
+        customFeesConstructed.addAll(mapRoyaltyFees(customFees, timestamp));
+        return customFeesConstructed;
+    }
+
+    private List<CustomFee> mapFixedFees(
+            final com.hedera.mirror.common.domain.token.CustomFee customFee, final Optional<Long> timestamp) {
+        if (CollectionUtils.isEmpty(customFee.getFixedFees())) {
+            return Collections.emptyList();
+        }
+
+        var fixedFees = new ArrayList<CustomFee>();
+        customFee.getFixedFees().forEach(f -> {
+            final var collector =
+                    commonEntityAccessor.getAccountWithCanonicalAddress(f.getCollectorAccountId(), timestamp);
+            final var denominatingTokenId = f.getDenominatingTokenId();
+
+            final var fixedFee = new FixedFee(
+                    f.getAmount(),
+                    new TokenID(
+                            denominatingTokenId.getShard(),
+                            denominatingTokenId.getRealm(),
+                            denominatingTokenId.getNum()));
+
+            var constructed = new CustomFee(
+                    new OneOf<>(FeeOneOfType.FIXED_FEE, fixedFee), collector, f.isAllCollectorsAreExempt());
+            fixedFees.add(constructed);
+        });
+
+        return fixedFees;
+    }
+
+    private List<CustomFee> mapFractionalFees(
+            final com.hedera.mirror.common.domain.token.CustomFee customFee, final Optional<Long> timestamp) {
+        if (CollectionUtils.isEmpty(customFee.getFractionalFees())) {
+            return Collections.emptyList();
+        }
+
+        var fractionalFees = new ArrayList<CustomFee>();
+        customFee.getFractionalFees().forEach(f -> {
+            final var collector =
+                    commonEntityAccessor.getAccountWithCanonicalAddress(f.getCollectorAccountId(), timestamp);
+            final var fractionalFee = new FractionalFee(
+                    new Fraction(f.getNumerator(), f.getDenominator()),
+                    f.getMinimumAmount(),
+                    f.getMaximumAmount(),
+                    f.isNetOfTransfers());
+            var constructed = new CustomFee(
+                    new OneOf<>(FeeOneOfType.FRACTIONAL_FEE, fractionalFee), collector, f.isAllCollectorsAreExempt());
+            fractionalFees.add(constructed);
+        });
+
+        return fractionalFees;
+    }
+
+    private List<CustomFee> mapRoyaltyFees(
+            com.hedera.mirror.common.domain.token.CustomFee customFee, final Optional<Long> timestamp) {
+        if (CollectionUtils.isEmpty(customFee.getRoyaltyFees())) {
+            return Collections.emptyList();
+        }
+
+        var royaltyFees = new ArrayList<CustomFee>();
+        customFee.getRoyaltyFees().forEach(f -> {
+            final var collector =
+                    commonEntityAccessor.getAccountWithCanonicalAddress(f.getCollectorAccountId(), timestamp);
+            final var fallbackFee = f.getFallbackFee();
+
+            FixedFee convertedFallbackFee = null;
+            if (fallbackFee != null) {
+                final var denominatingTokenId = fallbackFee.getDenominatingTokenId();
+                convertedFallbackFee = new FixedFee(
+                        fallbackFee.getAmount(),
+                        new TokenID(
+                                denominatingTokenId.getShard(),
+                                denominatingTokenId.getRealm(),
+                                denominatingTokenId.getNum()));
+            }
+            final var royaltyFee =
+                    new RoyaltyFee(new Fraction(f.getNumerator(), f.getDenominator()), convertedFallbackFee);
+            var constructed = new CustomFee(
+                    new OneOf<>(FeeOneOfType.ROYALTY_FEE, royaltyFee), collector, f.isAllCollectorsAreExempt());
+            royaltyFees.add(constructed);
+        });
+
+        return royaltyFees;
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.web3.state;
 
 import static com.hedera.mirror.web3.state.Utils.DEFAULT_AUTO_RENEW_PERIOD;
+import static com.hedera.services.utils.EntityIdUtils.toAccountId;
 import static com.hedera.services.utils.EntityIdUtils.toTokenId;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -59,10 +60,10 @@ public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
     private final EntityRepository entityRepository;
 
     protected TokenReadableKVState(
-            @Nonnull CommonEntityAccessor commonEntityAccessor,
-            @Nonnull CustomFeeRepository customFeeRepository,
-            @Nonnull TokenRepository tokenRepository,
-            @Nonnull EntityRepository entityRepository) {
+            final CommonEntityAccessor commonEntityAccessor,
+            final CustomFeeRepository customFeeRepository,
+            final TokenRepository tokenRepository,
+            final EntityRepository entityRepository) {
         super("TOKENS");
         this.commonEntityAccessor = commonEntityAccessor;
         this.customFeeRepository = customFeeRepository;
@@ -197,8 +198,9 @@ public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
 
         var fixedFees = new ArrayList<CustomFee>();
         customFee.getFixedFees().forEach(f -> {
-            final var collector =
-                    commonEntityAccessor.getAccountWithCanonicalAddress(f.getCollectorAccountId(), timestamp);
+            final var collector = toAccountId(commonEntityAccessor
+                    .get(f.getCollectorAccountId(), timestamp)
+                    .get());
             final var denominatingTokenId = f.getDenominatingTokenId();
 
             final var fixedFee = new FixedFee(f.getAmount(), toTokenId(denominatingTokenId));
@@ -218,8 +220,9 @@ public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
 
         var fractionalFees = new ArrayList<CustomFee>();
         customFee.getFractionalFees().forEach(f -> {
-            final var collector =
-                    commonEntityAccessor.getAccountWithCanonicalAddress(f.getCollectorAccountId(), timestamp);
+            final var collector = toAccountId(commonEntityAccessor
+                    .get(f.getCollectorAccountId(), timestamp)
+                    .get());
             final var fractionalFee = new FractionalFee(
                     new Fraction(f.getNumerator(), f.getDenominator()),
                     f.getMinimumAmount(),
@@ -241,8 +244,9 @@ public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
 
         var royaltyFees = new ArrayList<CustomFee>();
         customFee.getRoyaltyFees().forEach(f -> {
-            final var collector =
-                    commonEntityAccessor.getAccountWithCanonicalAddress(f.getCollectorAccountId(), timestamp);
+            final var collector = toAccountId(commonEntityAccessor
+                    .get(f.getCollectorAccountId(), timestamp)
+                    .get());
             final var fallbackFee = f.getFallbackFee();
 
             FixedFee convertedFallbackFee = null;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
@@ -46,6 +46,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.utils.EntityIdUtils;
 import com.swirlds.state.spi.ReadableKVStateBase;
 import jakarta.annotation.Nonnull;
+import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -55,6 +56,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.springframework.util.CollectionUtils;
 
+@Named
 public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
     private final CommonEntityAccessor commonEntityAccessor;
     private final CustomFeeRepository customFeeRepository;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.web3.state;
 
 import static com.hedera.mirror.web3.state.Utils.DEFAULT_AUTO_RENEW_PERIOD;
+import static com.hedera.services.utils.EntityIdUtils.toTokenId;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Fraction;
@@ -106,33 +107,33 @@ public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
             final com.hedera.mirror.common.domain.token.Token token,
             final Optional<Long> timestamp) {
         return Token.newBuilder()
-                .tokenId(new TokenID(entity.getShard(), entity.getRealm(), entity.getNum()))
-                .name(token.getName())
-                .symbol(token.getSymbol())
-                .decimals(token.getDecimals())
-                .totalSupply(getTotalSupply(token, timestamp))
-                .treasuryAccountId(getTreasury(token.getTreasuryAccountId(), timestamp))
+                .accountsFrozenByDefault(token.getFreezeDefault())
                 .adminKey(Utils.parseKey(entity.getKey()))
-                .kycKey(Utils.parseKey(token.getKycKey()))
-                .freezeKey(Utils.parseKey(token.getFreezeKey()))
-                .wipeKey(Utils.parseKey(token.getWipeKey()))
-                .supplyKey(Utils.parseKey(token.getSupplyKey()))
-                .feeScheduleKey(Utils.parseKey(token.getFeeScheduleKey()))
-                .pauseKey(Utils.parseKey(token.getPauseKey()))
-                .deleted(false)
-                .tokenType(TokenType.valueOf(token.getType().name()))
-                .supplyType(TokenSupplyType.valueOf(token.getSupplyType().name()))
                 .autoRenewAccountId(getAutoRenewAccount(entity.getAutoRenewAccountId(), timestamp))
                 .autoRenewSeconds(
                         entity.getAutoRenewPeriod() != null ? entity.getAutoRenewPeriod() : DEFAULT_AUTO_RENEW_PERIOD)
+                .decimals(token.getDecimals())
+                .deleted(false)
                 .expirationSecond(TimeUnit.SECONDS.convert(entity.getEffectiveExpiration(), TimeUnit.NANOSECONDS))
-                .memo(entity.getMemo())
+                .feeScheduleKey(Utils.parseKey(token.getFeeScheduleKey()))
+                .freezeKey(Utils.parseKey(token.getFreezeKey()))
+                .kycKey(Utils.parseKey(token.getKycKey()))
                 .maxSupply(token.getMaxSupply())
-                .paused(token.getPauseStatus().equals(TokenPauseStatusEnum.PAUSED))
-                .accountsFrozenByDefault(token.getFreezeDefault())
+                .memo(entity.getMemo())
                 .metadata(Bytes.wrap(token.getMetadata()))
                 .metadataKey(Utils.parseKey(token.getMetadataKey()))
+                .name(token.getName())
+                .paused(token.getPauseStatus().equals(TokenPauseStatusEnum.PAUSED))
+                .supplyKey(Utils.parseKey(token.getSupplyKey()))
+                .supplyType(TokenSupplyType.valueOf(token.getSupplyType().name()))
+                .symbol(token.getSymbol())
+                .tokenId(toTokenId(entity.getId()))
+                .tokenType(TokenType.valueOf(token.getType().name()))
+                .totalSupply(getTotalSupply(token, timestamp))
+                .treasuryAccountId(getTreasury(token.getTreasuryAccountId(), timestamp))
                 .customFees(getCustomFees(token.getTokenId(), timestamp))
+                .pauseKey(Utils.parseKey(token.getPauseKey()))
+                .wipeKey(Utils.parseKey(token.getWipeKey()))
                 .build();
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
@@ -111,6 +111,7 @@ public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
                 .autoRenewAccountId(getAutoRenewAccount(entity.getAutoRenewAccountId(), timestamp))
                 .autoRenewSeconds(
                         entity.getAutoRenewPeriod() != null ? entity.getAutoRenewPeriod() : DEFAULT_AUTO_RENEW_PERIOD)
+                .customFees(getCustomFees(token.getTokenId(), timestamp))
                 .decimals(token.getDecimals())
                 .deleted(false)
                 .expirationSecond(TimeUnit.SECONDS.convert(entity.getEffectiveExpiration(), TimeUnit.NANOSECONDS))
@@ -122,6 +123,7 @@ public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
                 .metadata(Bytes.wrap(token.getMetadata()))
                 .metadataKey(Utils.parseKey(token.getMetadataKey()))
                 .name(token.getName())
+                .pauseKey(Utils.parseKey(token.getPauseKey()))
                 .paused(token.getPauseStatus().equals(TokenPauseStatusEnum.PAUSED))
                 .supplyKey(Utils.parseKey(token.getSupplyKey()))
                 .supplyType(TokenSupplyType.valueOf(token.getSupplyType().name()))
@@ -130,8 +132,6 @@ public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
                 .tokenType(TokenType.valueOf(token.getType().name()))
                 .totalSupply(getTotalSupply(token, timestamp))
                 .treasuryAccountId(getTreasury(token.getTreasuryAccountId(), timestamp))
-                .customFees(getCustomFees(token.getTokenId(), timestamp))
-                .pauseKey(Utils.parseKey(token.getPauseKey()))
                 .wipeKey(Utils.parseKey(token.getWipeKey()))
                 .build();
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
@@ -53,8 +53,6 @@ import java.util.function.Supplier;
 import org.springframework.util.CollectionUtils;
 
 public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
-    private static final String KEY = "TOKENS";
-
     private final CommonEntityAccessor commonEntityAccessor;
     private final CustomFeeRepository customFeeRepository;
     private final TokenRepository tokenRepository;
@@ -65,7 +63,7 @@ public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
             @Nonnull CustomFeeRepository customFeeRepository,
             @Nonnull TokenRepository tokenRepository,
             @Nonnull EntityRepository entityRepository) {
-        super(KEY);
+        super("TOKENS");
         this.commonEntityAccessor = commonEntityAccessor;
         this.customFeeRepository = customFeeRepository;
         this.tokenRepository = tokenRepository;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/Suppliers.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/Suppliers.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.web3.utils;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
@@ -49,5 +50,27 @@ public class Suppliers {
             value.set(newValue);
             return newValue;
         };
+    }
+
+    /**
+     * Compares two Suppliers of values for equality, handling null checks.
+     *
+     * @param <T> the type of the value
+     * @param supplier1 the first supplier to compare
+     * @param supplier2 the second supplier to compare
+     * @return true if both suppliers produce equal values, or if both are null; false otherwise
+     */
+    public static <T> boolean areSuppliersEqual(final Supplier<T> supplier1, final Supplier<T> supplier2) {
+        if (supplier1 == null && supplier2 == null) {
+            return true;
+        }
+        if (supplier1 == null || supplier2 == null) {
+            return false;
+        }
+
+        T value1 = supplier1.get();
+        T value2 = supplier2.get();
+
+        return Objects.equals(value1, value2);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -186,7 +186,7 @@ public final class EntityIdUtils {
                 .build();
     }
 
-    public static com.hedera.hapi.node.base.AccountID getAccountId(final Long shard, final Long realm, final Long num) {
+    public static com.hedera.hapi.node.base.AccountID toAccountId(final Long shard, final Long realm, final Long num) {
         return new com.hedera.hapi.node.base.AccountID(shard, realm, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, num));
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -151,6 +151,10 @@ public final class EntityIdUtils {
         return EntityId.of(accountID.shardNum(), accountID.realmNum(), accountID.accountNum());
     }
 
+    public static EntityId toEntityId(final com.hedera.hapi.node.base.TokenID tokenID) {
+        return EntityId.of(tokenID.shardNum(), tokenID.realmNum(), tokenID.tokenNum());
+    }
+
     public static com.hedera.hapi.node.base.AccountID toAccountId(final Long id) {
         final var decodedEntityId = EntityId.of(id);
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -23,8 +23,10 @@ import static java.lang.System.arraycopy;
 
 import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
+import com.hedera.hapi.node.base.AccountID.AccountOneOfType;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.pbj.runtime.OneOf;
 import com.hedera.services.store.models.Id;
 import com.hedera.services.store.models.NftId;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -182,6 +184,10 @@ public final class EntityIdUtils {
                 .realmNum(entityId.getRealm())
                 .accountNum(entityId.getNum())
                 .build();
+    }
+
+    public static com.hedera.hapi.node.base.AccountID getAccountId(final Long shard, final Long realm, final Long num) {
+        return new com.hedera.hapi.node.base.AccountID(shard, realm, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, num));
     }
 
     public static com.hedera.hapi.node.base.TokenID toTokenId(final Long entityId) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/AbstractStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/AbstractStateTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.hapi.node.state.token;
+
+import static com.hedera.pbj.runtime.ProtoTestTools.BOOLEAN_TESTS_LIST;
+import static com.hedera.pbj.runtime.ProtoTestTools.LONG_TESTS_LIST;
+
+import com.hedera.hapi.node.base.Fraction;
+import com.hedera.hapi.node.transaction.CustomFee;
+import com.hedera.hapi.node.transaction.FixedFee;
+import com.hedera.hapi.node.transaction.FractionalFee;
+import com.hedera.hapi.node.transaction.RoyaltyFee;
+import com.hedera.pbj.runtime.OneOf;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class AbstractStateTest {
+
+    public static final List<Fraction> FRACTION_ARGUMENTS = createFractionArguments();
+    public static final List<FractionalFee> FRACTIONAL_FEE_ARGUMENTS = createFractionalFeeArguments();
+    public static final List<FixedFee> FIXED_FEES_ARGUMENTS = createFixedFeeArguments();
+    public static final List<RoyaltyFee> ROYALTY_FEES_ARGUMENTS = createRoyaltyFeeArguments();
+    public static final List<CustomFee> CUSTOM_FEE_ARGUMENTS = createCustomFeeArguments();
+
+    private static List<Fraction> createFractionArguments() {
+        final var numeratorList = LONG_TESTS_LIST;
+        final var denominatorList = LONG_TESTS_LIST;
+        int maxValues = Math.max(numeratorList.size(), denominatorList.size());
+
+        return IntStream.range(0, maxValues)
+                .mapToObj(i -> new Fraction(
+                        numeratorList.get(Math.min(i, numeratorList.size() - 1)),
+                        denominatorList.get(Math.min(i, denominatorList.size() - 1))))
+                .toList();
+    }
+
+    private static List<FractionalFee> createFractionalFeeArguments() {
+        final var fractionalAmountList = FRACTION_ARGUMENTS;
+        final var minimumAmountList = LONG_TESTS_LIST;
+        final var maximumAmountList = LONG_TESTS_LIST;
+        final var netOfTransfersList = BOOLEAN_TESTS_LIST;
+        int maxValues = Math.max(
+                Math.max(fractionalAmountList.size(), minimumAmountList.size()),
+                Math.max(maximumAmountList.size(), netOfTransfersList.size()));
+
+        return IntStream.range(0, maxValues)
+                .mapToObj(i -> new FractionalFee(
+                        fractionalAmountList.get(Math.min(i, fractionalAmountList.size() - 1)),
+                        minimumAmountList.get(Math.min(i, minimumAmountList.size() - 1)),
+                        maximumAmountList.get(Math.min(i, maximumAmountList.size() - 1)),
+                        netOfTransfersList.get(Math.min(i, netOfTransfersList.size() - 1))))
+                .toList();
+    }
+
+    private static List<FixedFee> createFixedFeeArguments() {
+        final var amountList = LONG_TESTS_LIST;
+        final var denominatingTokenIdList = TokenIDTest.ARGUMENTS;
+        int maxValues = Math.max(amountList.size(), denominatingTokenIdList.size());
+
+        return IntStream.range(0, maxValues)
+                .mapToObj(i -> new FixedFee(
+                        amountList.get(Math.min(i, amountList.size() - 1)),
+                        denominatingTokenIdList.get(Math.min(i, denominatingTokenIdList.size() - 1))))
+                .toList();
+    }
+
+    private static List<RoyaltyFee> createRoyaltyFeeArguments() {
+        final var exchangeValueFractionList = FRACTION_ARGUMENTS;
+        final var fallbackFeeList = FIXED_FEES_ARGUMENTS;
+        int maxValues = Math.max(exchangeValueFractionList.size(), fallbackFeeList.size());
+
+        return IntStream.range(0, maxValues)
+                .mapToObj(i -> new RoyaltyFee(
+                        exchangeValueFractionList.get(Math.min(i, exchangeValueFractionList.size() - 1)),
+                        fallbackFeeList.get(Math.min(i, fallbackFeeList.size() - 1))))
+                .toList();
+    }
+
+    private static List<CustomFee> createCustomFeeArguments() {
+        final var feeList = Stream.of(
+                        List.of(new OneOf<>(CustomFee.FeeOneOfType.UNSET, null)),
+                        FIXED_FEES_ARGUMENTS.stream()
+                                .map(value -> new OneOf<>(CustomFee.FeeOneOfType.FIXED_FEE, value))
+                                .toList(),
+                        FRACTIONAL_FEE_ARGUMENTS.stream()
+                                .map(value -> new OneOf<>(CustomFee.FeeOneOfType.FRACTIONAL_FEE, value))
+                                .toList(),
+                        ROYALTY_FEES_ARGUMENTS.stream()
+                                .map(value -> new OneOf<>(CustomFee.FeeOneOfType.ROYALTY_FEE, value))
+                                .toList())
+                .flatMap(List::stream)
+                .toList();
+
+        final var feeCollectorAccountIdList = AccountIDTest.ARGUMENTS;
+        final var allCollectorsAreExemptList = BOOLEAN_TESTS_LIST;
+        int maxValues =
+                Math.max(Math.max(feeList.size(), feeCollectorAccountIdList.size()), allCollectorsAreExemptList.size());
+
+        return IntStream.range(0, maxValues)
+                .mapToObj(i -> new CustomFee(
+                        feeList.get(Math.min(i, feeList.size() - 1)),
+                        feeCollectorAccountIdList.get(Math.min(i, feeCollectorAccountIdList.size() - 1)),
+                        allCollectorsAreExemptList.get(Math.min(i, allCollectorsAreExemptList.size() - 1))))
+                .toList();
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -25,10 +25,18 @@ import static com.hedera.pbj.runtime.ProtoTestTools.generateListArguments;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.AccountID.AccountOneOfType;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenSupplyType;
 import com.hedera.hapi.node.base.TokenType;
+import com.hedera.pbj.runtime.OneOf;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +60,369 @@ public class TokenTest extends AbstractStateTest {
             assertNotEquals(item1HashCode, item2HashCode);
             assertNotEquals(item2HashCode, item3HashCode);
         }
+    }
+
+    @Test
+    void testEqualsWithNull() {
+        final var item1 = ARGUMENTS.get(0);
+        assertNotEquals(null, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentClass() {
+        final var item1 = ARGUMENTS.get(0);
+        assertNotEquals(item1, new Object());
+    }
+
+    @Test
+    void testEqualsWithNullTokenId() {
+        final var item1 = ARGUMENTS.get(0);
+        final var item1WithNullTokenId =
+                item1.copyBuilder().tokenId((TokenID) null).build();
+        assertNotEquals(item1, item1WithNullTokenId);
+        assertNotEquals(item1WithNullTokenId, item1);
+    }
+
+    @Test
+    void testEqualsWithNullName() {
+        final var item1 = ARGUMENTS.get(0);
+        final var item1WithNullName = item1.copyBuilder().name(null).build();
+        assertNotEquals(item1, item1WithNullName);
+        assertNotEquals(item1WithNullName, item1);
+    }
+
+    @Test
+    void testEqualsWithNullSymbol() {
+        final var item1 = ARGUMENTS.get(0);
+        final var item1WithNullSymbol = item1.copyBuilder().symbol(null).build();
+        assertNotEquals(item1, item1WithNullSymbol);
+        assertNotEquals(item1WithNullSymbol, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentDecimals() {
+        final var item1 = ARGUMENTS.get(0);
+        final var item1WithDifferentDecimals =
+                item1.copyBuilder().decimals(item1.decimals() + 1).build();
+        assertNotEquals(item1, item1WithDifferentDecimals);
+    }
+
+    @Test
+    void testEqualsWithDifferentTotalSupply() {
+        final var item1 = ARGUMENTS.get(0);
+        final var item1WithDifferentTotalSupply = item1.copyBuilder()
+                .totalSupply(item1.totalSupplySupplier().get() + 1)
+                .build();
+        assertNotEquals(item1, item1WithDifferentTotalSupply);
+    }
+
+    @Test
+    void testEqualsWithNullTotalSupply() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTotalSupply = item1.copyBuilder().totalSupply(null).build();
+
+        assertNotEquals(itemNullTotalSupply, item1);
+        assertNotEquals(item1, itemNullTotalSupply);
+    }
+
+    @Test
+    void testEqualsWithDifferentTreasuryAccountId() {
+        final var item1 = ARGUMENTS.get(0);
+        final var item1WithDifferentTreasuryAccountId = item1.copyBuilder()
+                .treasuryAccountId(new AccountID(0L, 0L, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 1L)))
+                .build();
+        assertNotEquals(item1, item1WithDifferentTreasuryAccountId);
+    }
+
+    @Test
+    void testEqualsWithNullTreasuryAccountIdSupplierValue() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTreasuryAccountIdSupplierValue =
+                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+        assertNotEquals(itemNullTreasuryAccountIdSupplierValue, item1);
+        assertNotEquals(item1, itemNullTreasuryAccountIdSupplierValue);
+    }
+
+    @Test
+    void testEqualsWithNullTreasuryAccountIdSupplier() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTreasuryAccountIdSupplier = item1.copyBuilder()
+                .treasuryAccountId((Supplier<AccountID>) null)
+                .build();
+        assertNotEquals(itemNullTreasuryAccountIdSupplier, item1);
+        assertNotEquals(item1, itemNullTreasuryAccountIdSupplier);
+    }
+
+    @Test
+    void testEqualsWithNullTreasuryAccountIdBoth() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTreasuryAccountId =
+                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+        final var itemNullTreasuryAccountId2 =
+                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+        assertEquals(itemNullTreasuryAccountId, itemNullTreasuryAccountId2);
+    }
+
+    @Test
+    void testEqualsWithNullAdminKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAdminKey = item1.copyBuilder().adminKey((Key) null).build();
+
+        assertNotEquals(itemNullAdminKey, item1);
+        assertNotEquals(item1, itemNullAdminKey);
+    }
+
+    @Test
+    void testEqualsWithNullKycKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullKycKey = item1.copyBuilder().kycKey((Key) null).build();
+
+        assertNotEquals(itemNullKycKey, item1);
+        assertNotEquals(item1, itemNullKycKey);
+    }
+
+    @Test
+    void testEqualsWithNullFreezeKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullFreezeKey = item1.copyBuilder().freezeKey((Key) null).build();
+
+        assertNotEquals(itemNullFreezeKey, item1);
+        assertNotEquals(item1, itemNullFreezeKey);
+    }
+
+    @Test
+    void testEqualsWithNullWipeKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullWipeKey = item1.copyBuilder().wipeKey((Key) null).build();
+
+        assertNotEquals(itemNullWipeKey, item1);
+        assertNotEquals(item1, itemNullWipeKey);
+    }
+
+    @Test
+    void testEqualsWithNullSupplyKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullSupplyKey = item1.copyBuilder().supplyKey((Key) null).build();
+
+        assertNotEquals(itemNullSupplyKey, item1);
+        assertNotEquals(item1, itemNullSupplyKey);
+    }
+
+    @Test
+    void testEqualsWithNullFeeScheduleKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullFeeScheduleKey =
+                item1.copyBuilder().feeScheduleKey((Key) null).build();
+
+        assertNotEquals(itemNullFeeScheduleKey, item1);
+        assertNotEquals(item1, itemNullFeeScheduleKey);
+    }
+
+    @Test
+    void testEqualsWithNullPauseKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullPauseKey = item1.copyBuilder().pauseKey((Key) null).build();
+
+        assertNotEquals(itemNullPauseKey, item1);
+        assertNotEquals(item1, itemNullPauseKey);
+    }
+
+    @Test
+    void testEqualsWithDifferentLastUsedSerialNumber() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentLastUsedSerialNumber = item1.copyBuilder()
+                .lastUsedSerialNumber(item1.lastUsedSerialNumber() + 1)
+                .build();
+
+        assertNotEquals(itemDifferentLastUsedSerialNumber, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentDeletedFlag() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentDeletedFlag =
+                item1.copyBuilder().deleted(!item1.deleted()).build();
+
+        assertNotEquals(itemDifferentDeletedFlag, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentTokenType() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentTokenType =
+                item1.copyBuilder().tokenType(TokenType.NON_FUNGIBLE_UNIQUE).build();
+
+        assertNotEquals(itemDifferentTokenType, item1);
+    }
+
+    @Test
+    void testEqualsWithNullTokenType() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTokenType = item1.copyBuilder().tokenType(null).build();
+        assertNotEquals(itemNullTokenType, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentSupplyType() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentSupplyType =
+                item1.copyBuilder().supplyType(TokenSupplyType.FINITE).build();
+
+        assertNotEquals(itemDifferentSupplyType, item1);
+    }
+
+    @Test
+    void testEqualsWithNullSupplyType() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullSupplyType = item1.copyBuilder().supplyType(null).build();
+        assertNotEquals(itemNullSupplyType, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentAutoRenewAccountId() {
+        final var item1 = ARGUMENTS.get(0);
+        final var item1WithDifferentAutoRenewAccountId = item1.copyBuilder()
+                .autoRenewAccountId(new AccountID(0L, 0L, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 1L)))
+                .build();
+        assertNotEquals(item1, item1WithDifferentAutoRenewAccountId);
+    }
+
+    @Test
+    void testEqualsWithNullAutoRenewAccountIdSupplierValue() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAutoRenewAccountId =
+                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+        assertNotEquals(itemNullAutoRenewAccountId, item1);
+        assertNotEquals(item1, itemNullAutoRenewAccountId);
+    }
+
+    @Test
+    void testEqualsWithNullAutoRenewAccountIdSupplier() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAutoRenewAccountId = item1.copyBuilder()
+                .autoRenewAccountId((Supplier<AccountID>) null)
+                .build();
+        assertNotEquals(itemNullAutoRenewAccountId, item1);
+        assertNotEquals(item1, itemNullAutoRenewAccountId);
+    }
+
+    @Test
+    void testEqualsWithNullAutoRenewAccountIdBoth() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAutoRenewAccountId =
+                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+        final var itemNullAutoRenewAccountId2 =
+                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+        assertEquals(itemNullAutoRenewAccountId, itemNullAutoRenewAccountId2);
+    }
+
+    @Test
+    void testEqualsWithDifferentAutoRenewSeconds() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentAutoRenewSeconds = item1.copyBuilder()
+                .autoRenewSeconds(item1.autoRenewSeconds() + 1)
+                .build();
+        assertNotEquals(itemDifferentAutoRenewSeconds, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentExpirationSeconds() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentExpirationSeconds = item1.copyBuilder()
+                .expirationSecond(item1.expirationSecond() + 1)
+                .build();
+        assertNotEquals(itemDifferentExpirationSeconds, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentMemo() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentMemo =
+                item1.copyBuilder().memo("1" + item1.memo()).build();
+        assertNotEquals(itemDifferentMemo, item1);
+    }
+
+    @Test
+    void testEqualsWithNullMemo() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullMemo = item1.copyBuilder().memo(null).build();
+        assertNotEquals(itemNullMemo, item1);
+        assertNotEquals(item1, itemNullMemo);
+    }
+
+    @Test
+    void testEqualsWithDifferentMaxSupply() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentMaxSupply =
+                item1.copyBuilder().maxSupply(item1.maxSupply() + 1).build();
+        assertNotEquals(itemDifferentMaxSupply, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentPausedFlag() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentPauseFlag =
+                item1.copyBuilder().paused(!item1.paused()).build();
+        assertNotEquals(itemDifferentPauseFlag, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentAccountsFrozenByDefaultFlag() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentAccountsFrozenByDefaultFlag = item1.copyBuilder()
+                .accountsFrozenByDefault(!item1.accountsFrozenByDefault())
+                .build();
+        assertNotEquals(itemDifferentAccountsFrozenByDefaultFlag, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentAccountsKycGrantedByDefaultFlag() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentAccountsKycGrantedByDefaultFlag = item1.copyBuilder()
+                .accountsKycGrantedByDefault(!item1.accountsKycGrantedByDefault())
+                .build();
+        assertNotEquals(itemDifferentAccountsKycGrantedByDefaultFlag, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentCustomFees() {
+        final var item1 = ARGUMENTS.get(1);
+        final var itemDifferentCustomFees =
+                item1.copyBuilder().customFees(Collections.EMPTY_LIST).build();
+        assertNotEquals(itemDifferentCustomFees, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentMetadata() {
+        final var item1 = ARGUMENTS.get(1);
+        final var itemDifferentMetadata =
+                item1.copyBuilder().metadata(Bytes.EMPTY).build();
+        assertNotEquals(itemDifferentMetadata, item1);
+    }
+
+    @Test
+    void testEqualsWithNullMetadata() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentMetadata = item1.copyBuilder().metadata(null).build();
+        assertNotEquals(itemDifferentMetadata, item1);
+        assertNotEquals(item1, itemDifferentMetadata);
+    }
+
+    @Test
+    void testEqualsWithDifferentMetadataKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentMetadataKey = item1.copyBuilder()
+                .metadataKey(new Key(new OneOf<>(Key.KeyOneOfType.CONTRACT_ID, 1L)))
+                .build();
+        assertNotEquals(itemDifferentMetadataKey, item1);
+    }
+
+    @Test
+    void testEqualsWithNullMetadataKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentMetadataKey = item1.copyBuilder().metadata(null).build();
+        assertNotEquals(itemDifferentMetadataKey, item1);
+        assertNotEquals(item1, itemDifferentMetadataKey);
     }
 
     /**

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -71,8 +71,7 @@ public class TokenTest extends AbstractStateTest {
         final var item1 = ARGUMENTS.get(0);
         final var item1Copy = item1.copyBuilder().build();
 
-        assertThat(item1).hasSameHashCodeAs(item1.hashCode());
-        assertThat(item1).hasSameHashCodeAs(item1Copy.hashCode());
+        assertThat(item1).hasSameHashCodeAs(item1Copy);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -36,7 +36,7 @@ public class TokenTest extends AbstractStateTest {
 
     @SuppressWarnings("EqualsWithItself")
     @Test
-    public void testTestEqualsAndHashCode() {
+    void testTestEqualsAndHashCode() {
         if (ARGUMENTS.size() >= 3) {
             final var item1 = ARGUMENTS.get(0);
             final var item2 = ARGUMENTS.get(1);

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -117,11 +117,25 @@ public class TokenTest extends AbstractStateTest {
     }
 
     @Test
+    void testEqualsWithDifferentName() {
+        final var item1 = ARGUMENTS.get(0);
+        final var item1WithNullName = item1.copyBuilder().name("different").build();
+        assertNotEquals(item1, item1WithNullName);
+    }
+
+    @Test
     void testEqualsWithNullSymbol() {
         final var item1 = ARGUMENTS.get(0);
         final var item1WithNullSymbol = item1.copyBuilder().symbol(null).build();
         assertNotEquals(item1, item1WithNullSymbol);
         assertNotEquals(item1WithNullSymbol, item1);
+    }
+
+    @Test
+    void testEqualsWithDifferentSymbol() {
+        final var item1 = ARGUMENTS.get(0);
+        final var item1WithNullName = item1.copyBuilder().symbol("different").build();
+        assertNotEquals(item1, item1WithNullName);
     }
 
     @Test
@@ -198,12 +212,32 @@ public class TokenTest extends AbstractStateTest {
     }
 
     @Test
+    void testEqualsWithDifferentAdminKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentAdminKey = item1.copyBuilder()
+                .adminKey(new Key(new OneOf<>(Key.KeyOneOfType.CONTRACT_ID, 1L)))
+                .build();
+
+        assertNotEquals(item1, itemDifferentAdminKey);
+    }
+
+    @Test
     void testEqualsWithNullKycKey() {
         final var item1 = ARGUMENTS.get(0);
         final var itemNullKycKey = item1.copyBuilder().kycKey((Key) null).build();
 
         assertNotEquals(itemNullKycKey, item1);
         assertNotEquals(item1, itemNullKycKey);
+    }
+
+    @Test
+    void testEqualsWithDifferentKycKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentKycKey = item1.copyBuilder()
+                .kycKey(new Key(new OneOf<>(Key.KeyOneOfType.CONTRACT_ID, 1L)))
+                .build();
+
+        assertNotEquals(item1, itemDifferentKycKey);
     }
 
     @Test
@@ -216,6 +250,16 @@ public class TokenTest extends AbstractStateTest {
     }
 
     @Test
+    void testEqualsWithDifferentFreezeKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentFreezeKey = item1.copyBuilder()
+                .freezeKey(new Key(new OneOf<>(Key.KeyOneOfType.CONTRACT_ID, 1L)))
+                .build();
+
+        assertNotEquals(item1, itemDifferentFreezeKey);
+    }
+
+    @Test
     void testEqualsWithNullWipeKey() {
         final var item1 = ARGUMENTS.get(0);
         final var itemNullWipeKey = item1.copyBuilder().wipeKey((Key) null).build();
@@ -225,12 +269,32 @@ public class TokenTest extends AbstractStateTest {
     }
 
     @Test
+    void testEqualsWithDifferentWipeKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentWipeKey = item1.copyBuilder()
+                .wipeKey(new Key(new OneOf<>(Key.KeyOneOfType.CONTRACT_ID, 1L)))
+                .build();
+
+        assertNotEquals(item1, itemDifferentWipeKey);
+    }
+
+    @Test
     void testEqualsWithNullSupplyKey() {
         final var item1 = ARGUMENTS.get(0);
         final var itemNullSupplyKey = item1.copyBuilder().supplyKey((Key) null).build();
 
         assertNotEquals(itemNullSupplyKey, item1);
         assertNotEquals(item1, itemNullSupplyKey);
+    }
+
+    @Test
+    void testEqualsWithDifferentSupplyKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentSupplyKey = item1.copyBuilder()
+                .supplyKey(new Key(new OneOf<>(Key.KeyOneOfType.CONTRACT_ID, 1L)))
+                .build();
+
+        assertNotEquals(item1, itemDifferentSupplyKey);
     }
 
     @Test
@@ -244,12 +308,32 @@ public class TokenTest extends AbstractStateTest {
     }
 
     @Test
+    void testEqualsWithDifferentFeeScheduleKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentFeeScheduleKey = item1.copyBuilder()
+                .feeScheduleKey(new Key(new OneOf<>(Key.KeyOneOfType.CONTRACT_ID, 1L)))
+                .build();
+
+        assertNotEquals(item1, itemDifferentFeeScheduleKey);
+    }
+
+    @Test
     void testEqualsWithNullPauseKey() {
         final var item1 = ARGUMENTS.get(0);
         final var itemNullPauseKey = item1.copyBuilder().pauseKey((Key) null).build();
 
         assertNotEquals(itemNullPauseKey, item1);
         assertNotEquals(item1, itemNullPauseKey);
+    }
+
+    @Test
+    void testEqualsWithDifferentPauseKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemDifferentPauseKey = item1.copyBuilder()
+                .pauseKey(new Key(new OneOf<>(Key.KeyOneOfType.CONTRACT_ID, 1L)))
+                .build();
+
+        assertNotEquals(item1, itemDifferentPauseKey);
     }
 
     @Test
@@ -445,7 +529,8 @@ public class TokenTest extends AbstractStateTest {
     @Test
     void testEqualsWithNullMetadataKey() {
         final var item1 = ARGUMENTS.get(0);
-        final var itemDifferentMetadataKey = item1.copyBuilder().metadata(null).build();
+        final var itemDifferentMetadataKey =
+                item1.copyBuilder().metadataKey((Key) null).build();
         assertNotEquals(itemDifferentMetadataKey, item1);
         assertNotEquals(item1, itemDifferentMetadataKey);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -923,6 +923,34 @@ public class TokenTest extends AbstractStateTest {
         assertThat(keys).isNotEmpty().hasSize(1).contains(item1.metadataKey());
     }
 
+    @Test
+    void testBuilders() {
+        Key.Builder keyBuilder = new Key.Builder();
+        Token.Builder tokenBuilder = new Token.Builder();
+        TokenID.Builder tokenIdBuilder = new TokenID.Builder();
+        Token token = tokenBuilder
+                .tokenId(tokenIdBuilder)
+                .adminKey(keyBuilder)
+                .kycKey(keyBuilder)
+                .freezeKey(keyBuilder)
+                .wipeKey(keyBuilder)
+                .supplyKey(keyBuilder)
+                .feeScheduleKey(keyBuilder)
+                .pauseKey(keyBuilder)
+                .metadataKey(keyBuilder)
+                .build();
+
+        assertThat(token.tokenId()).isNotNull();
+        assertThat(token.adminKey()).isNotNull();
+        assertThat(token.kycKey()).isNotNull();
+        assertThat(token.freezeKey()).isNotNull();
+        assertThat(token.wipeKey()).isNotNull();
+        assertThat(token.supplyKey()).isNotNull();
+        assertThat(token.feeScheduleKey()).isNotNull();
+        assertThat(token.pauseKey()).isNotNull();
+        assertThat(token.metadataKey()).isNotNull();
+    }
+
     /**
      * List of all valid arguments for testing, built as a static list, so we can reuse it.
      */

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -87,6 +87,23 @@ public class TokenTest extends AbstractStateTest {
     }
 
     @Test
+    void testEqualsWithNullSuppliers() {
+        final var item1 = ARGUMENTS.get(1);
+        final var itemNullSuppliers1 = item1.copyBuilder()
+                .totalSupply(null)
+                .treasuryAccountId((Supplier<AccountID>) null)
+                .autoRenewAccountId((Supplier<AccountID>) null)
+                .build();
+        final var itemNullSuppliers2 = item1.copyBuilder()
+                .totalSupply(null)
+                .treasuryAccountId((Supplier<AccountID>) null)
+                .autoRenewAccountId((Supplier<AccountID>) null)
+                .build();
+
+        assertEquals(itemNullSuppliers1, itemNullSuppliers2);
+    }
+
+    @Test
     void testEqualsWithNull() {
         final var item1 = ARGUMENTS.get(0);
         assertNotEquals(null, item1);

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -790,6 +790,118 @@ public class TokenTest extends AbstractStateTest {
         assertThat(keys).isNotEmpty().hasSize(1).contains(item1.pauseKey());
     }
 
+    @Test
+    void testHasAutoRenewAccountId() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAutoRenewIdSupplier = item1.copyBuilder()
+                .autoRenewAccountId((Supplier<AccountID>) null)
+                .build();
+        final var itemNullAutoRenewIdSupplierValue =
+                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+
+        assertThat(item1.hasAutoRenewAccountId()).isTrue();
+        assertThat(itemNullAutoRenewIdSupplier.hasAutoRenewAccountId()).isFalse();
+        assertThat(itemNullAutoRenewIdSupplierValue.hasAutoRenewAccountId()).isFalse();
+    }
+
+    @Test
+    void testIfAutoRenewAccountId() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAutoRenewIdSupplier = item1.copyBuilder()
+                .autoRenewAccountId((Supplier<AccountID>) null)
+                .build();
+        final var itemNullAutoRenewIdSupplierValue =
+                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+
+        List<AccountID> accountIDS = new ArrayList<>();
+        Consumer<AccountID> accountIDConsumer = accountIDS::add;
+
+        item1.ifAutoRenewAccountId(accountIDConsumer);
+        itemNullAutoRenewIdSupplier.ifAutoRenewAccountId(accountIDConsumer);
+        itemNullAutoRenewIdSupplierValue.ifAutoRenewAccountId(accountIDConsumer);
+        assertThat(accountIDS)
+                .isNotEmpty()
+                .hasSize(1)
+                .contains(item1.autoRenewAccountIdSupplier().get());
+    }
+
+    @Test
+    void testAutoRenewAccountIdOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAutoRenewIdSupplier = item1.copyBuilder()
+                .autoRenewAccountId((Supplier<AccountID>) null)
+                .build();
+        final var itemNullAutoRenewIdSupplierValue =
+                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+
+        assertThat(item1.autoRenewAccountIdOrElse(AccountID.DEFAULT))
+                .isEqualTo(item1.autoRenewAccountIdSupplier().get());
+        assertThat(itemNullAutoRenewIdSupplier.autoRenewAccountIdOrElse(AccountID.DEFAULT))
+                .isEqualTo(AccountID.DEFAULT);
+        assertThat(itemNullAutoRenewIdSupplierValue.autoRenewAccountIdOrElse(AccountID.DEFAULT))
+                .isEqualTo(AccountID.DEFAULT);
+    }
+
+    @Test
+    void testAutoRenewAccountIdOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAutoRenewIdSupplier = item1.copyBuilder()
+                .autoRenewAccountId((Supplier<AccountID>) null)
+                .build();
+        final var itemNullAutoRenewIdSupplierValue =
+                item1.copyBuilder().autoRenewAccountId((AccountID) null).build();
+
+        assertThat(item1.autoRenewAccountIdOrThrow())
+                .isEqualTo(item1.autoRenewAccountIdSupplier().get());
+        assertThatThrownBy(itemNullAutoRenewIdSupplier::autoRenewAccountIdOrThrow)
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(itemNullAutoRenewIdSupplierValue::autoRenewAccountIdOrThrow)
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testHasMetadataKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullMetadataKey =
+                item1.copyBuilder().metadataKey((Key) null).build();
+
+        assertThat(item1.hasMetadataKey()).isTrue();
+        assertThat(itemNullMetadataKey.hasMetadataKey()).isFalse();
+    }
+
+    @Test
+    void testMetadataKeyOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullMetadataKey =
+                item1.copyBuilder().metadataKey((Key) null).build();
+
+        assertThat(item1.metadataKeyOrElse(Key.DEFAULT)).isEqualTo(item1.metadataKey());
+        assertThat(itemNullMetadataKey.metadataKeyOrElse(Key.DEFAULT)).isEqualTo(Key.DEFAULT);
+    }
+
+    @Test
+    void testMetadataKeyOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullMetadataKey =
+                item1.copyBuilder().metadataKey((Key) null).build();
+
+        assertThat(item1.metadataKeyOrThrow()).isEqualTo(item1.metadataKey());
+        assertThatThrownBy(itemNullMetadataKey::metadataKeyOrThrow).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testIfMetadataKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullMetadataKey =
+                item1.copyBuilder().metadataKey((Key) null).build();
+        List<Key> keys = new ArrayList<>();
+        Consumer<Key> keyConsumer = keys::add;
+
+        item1.ifMetadataKey(keyConsumer);
+        itemNullMetadataKey.ifMetadataKey(keyConsumer);
+        assertThat(keys).isNotEmpty().hasSize(1).contains(item1.metadataKey());
+    }
+
     /**
      * List of all valid arguments for testing, built as a static list, so we can reuse it.
      */

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -22,6 +22,8 @@ import static com.hedera.pbj.runtime.ProtoTestTools.INTEGER_TESTS_LIST;
 import static com.hedera.pbj.runtime.ProtoTestTools.LONG_TESTS_LIST;
 import static com.hedera.pbj.runtime.ProtoTestTools.STRING_TESTS_LIST;
 import static com.hedera.pbj.runtime.ProtoTestTools.generateListArguments;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -33,9 +35,11 @@ import com.hedera.hapi.node.base.TokenSupplyType;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
@@ -423,6 +427,367 @@ public class TokenTest extends AbstractStateTest {
         final var itemDifferentMetadataKey = item1.copyBuilder().metadata(null).build();
         assertNotEquals(itemDifferentMetadataKey, item1);
         assertNotEquals(item1, itemDifferentMetadataKey);
+    }
+
+    @Test
+    void testHasTokenId() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTokenId = item1.copyBuilder().tokenId((TokenID) null).build();
+        assertThat(item1.hasTokenId()).isTrue();
+        assertThat(itemNullTokenId.hasTokenId()).isFalse();
+    }
+
+    @Test
+    void testTokenIdOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTokenId = item1.copyBuilder().tokenId((TokenID) null).build();
+        assertThat(item1.tokenIdOrElse(TokenID.DEFAULT)).isEqualTo(item1.tokenId());
+        assertThat(itemNullTokenId.tokenIdOrElse(TokenID.DEFAULT)).isEqualTo(TokenID.DEFAULT);
+    }
+
+    @Test
+    void testTokenIdOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTokenId = item1.copyBuilder().tokenId((TokenID) null).build();
+        assertThat(item1.tokenIdOrThrow()).isEqualTo(item1.tokenId());
+        assertThatThrownBy(itemNullTokenId::tokenIdOrThrow).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testIfTokenId() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTokenId = item1.copyBuilder().tokenId((TokenID) null).build();
+        List<TokenID> tokenIds = new ArrayList<>();
+        Consumer<TokenID> tokenIDConsumer = tokenIds::add;
+
+        item1.ifTokenId(tokenIDConsumer);
+        itemNullTokenId.ifTokenId(tokenIDConsumer);
+        assertThat(tokenIds).isNotEmpty().hasSize(1).contains(item1.tokenId());
+    }
+
+    @Test
+    void testHasTreasuryAccountId() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTreasuryIdSupplier = item1.copyBuilder()
+                .treasuryAccountId((Supplier<AccountID>) null)
+                .build();
+        final var itemNullTreasuryIdSupplierValue =
+                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+
+        assertThat(item1.hasTreasuryAccountId()).isTrue();
+        assertThat(itemNullTreasuryIdSupplier.hasTreasuryAccountId()).isFalse();
+        assertThat(itemNullTreasuryIdSupplierValue.hasTreasuryAccountId()).isFalse();
+    }
+
+    @Test
+    void testIfTreasuryAccountId() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTreasuryIdSupplier = item1.copyBuilder()
+                .treasuryAccountId((Supplier<AccountID>) null)
+                .build();
+        final var itemNullTreasuryIdSupplierValue =
+                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+
+        List<AccountID> accountIDS = new ArrayList<>();
+        Consumer<AccountID> accountIDConsumerIDConsumer = accountIDS::add;
+
+        item1.ifTreasuryAccountId(accountIDConsumerIDConsumer);
+        itemNullTreasuryIdSupplier.ifTreasuryAccountId(accountIDConsumerIDConsumer);
+        itemNullTreasuryIdSupplierValue.ifTreasuryAccountId(accountIDConsumerIDConsumer);
+        assertThat(accountIDS)
+                .isNotEmpty()
+                .hasSize(1)
+                .contains(item1.treasuryAccountIdSupplier().get());
+    }
+
+    @Test
+    void testTreasuryAccountIdOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTreasuryIdSupplier = item1.copyBuilder()
+                .treasuryAccountId((Supplier<AccountID>) null)
+                .build();
+        final var itemNullTreasuryIdSupplierValue =
+                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+
+        assertThat(item1.treasuryAccountIdOrElse(AccountID.DEFAULT))
+                .isEqualTo(item1.treasuryAccountIdSupplier().get());
+        assertThat(itemNullTreasuryIdSupplier.treasuryAccountIdOrElse(AccountID.DEFAULT))
+                .isEqualTo(AccountID.DEFAULT);
+        assertThat(itemNullTreasuryIdSupplierValue.treasuryAccountIdOrElse(AccountID.DEFAULT))
+                .isEqualTo(AccountID.DEFAULT);
+    }
+
+    @Test
+    void testTreasuryAccountIdOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullTreasuryIdSupplier = item1.copyBuilder()
+                .treasuryAccountId((Supplier<AccountID>) null)
+                .build();
+        final var itemNullTreasuryIdSupplierValue =
+                item1.copyBuilder().treasuryAccountId((AccountID) null).build();
+
+        assertThat(item1.treasuryAccountIdOrThrow())
+                .isEqualTo(item1.treasuryAccountIdSupplier().get());
+        assertThatThrownBy(itemNullTreasuryIdSupplier::treasuryAccountIdOrThrow)
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(itemNullTreasuryIdSupplierValue::treasuryAccountIdOrThrow)
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testHasAdminKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAdminKey = item1.copyBuilder().adminKey((Key) null).build();
+        assertThat(item1.hasAdminKey()).isTrue();
+        assertThat(itemNullAdminKey.hasAdminKey()).isFalse();
+    }
+
+    @Test
+    void testAdminKeyOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAdminKey = item1.copyBuilder().adminKey((Key) null).build();
+        assertThat(item1.adminKeyOrElse(Key.DEFAULT)).isEqualTo(item1.adminKey());
+        assertThat(itemNullAdminKey.adminKeyOrElse(Key.DEFAULT)).isEqualTo(Key.DEFAULT);
+    }
+
+    @Test
+    void testAdminKeyOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAdminKey = item1.copyBuilder().adminKey((Key) null).build();
+        assertThat(item1.adminKeyOrThrow()).isEqualTo(item1.adminKey());
+        assertThatThrownBy(itemNullAdminKey::adminKeyOrThrow).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testIfAdminKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullAdminKey = item1.copyBuilder().adminKey((Key) null).build();
+        List<Key> keys = new ArrayList<>();
+        Consumer<Key> keyConsumer = keys::add;
+
+        item1.ifAdminKey(keyConsumer);
+        itemNullAdminKey.ifAdminKey(keyConsumer);
+        assertThat(keys).isNotEmpty().hasSize(1).contains(item1.adminKey());
+    }
+
+    @Test
+    void testHasKycKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullKycKey = item1.copyBuilder().kycKey((Key) null).build();
+        assertThat(item1.hasKycKey()).isTrue();
+        assertThat(itemNullKycKey.hasKycKey()).isFalse();
+    }
+
+    @Test
+    void testKycKeyOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullKycKey = item1.copyBuilder().kycKey((Key) null).build();
+        assertThat(item1.kycKeyOrElse(Key.DEFAULT)).isEqualTo(item1.kycKey());
+        assertThat(itemNullKycKey.kycKeyOrElse(Key.DEFAULT)).isEqualTo(Key.DEFAULT);
+    }
+
+    @Test
+    void testKycKeyOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullKycKey = item1.copyBuilder().kycKey((Key) null).build();
+        assertThat(item1.kycKeyOrThrow()).isEqualTo(item1.kycKey());
+        assertThatThrownBy(itemNullKycKey::kycKeyOrThrow).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testIfKycKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullKycKey = item1.copyBuilder().kycKey((Key) null).build();
+        List<Key> keys = new ArrayList<>();
+        Consumer<Key> keyConsumer = keys::add;
+
+        item1.ifKycKey(keyConsumer);
+        itemNullKycKey.ifKycKey(keyConsumer);
+        assertThat(keys).isNotEmpty().hasSize(1).contains(item1.kycKey());
+    }
+
+    @Test
+    void testHasFreezeKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullFreezeKey = item1.copyBuilder().freezeKey((Key) null).build();
+        assertThat(item1.hasFreezeKey()).isTrue();
+        assertThat(itemNullFreezeKey.hasFreezeKey()).isFalse();
+    }
+
+    @Test
+    void testFreezeKeyOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullFreezeKey = item1.copyBuilder().freezeKey((Key) null).build();
+        assertThat(item1.freezeKeyOrElse(Key.DEFAULT)).isEqualTo(item1.freezeKey());
+        assertThat(itemNullFreezeKey.freezeKeyOrElse(Key.DEFAULT)).isEqualTo(Key.DEFAULT);
+    }
+
+    @Test
+    void testFreezeKeyOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullFreezeKey = item1.copyBuilder().freezeKey((Key) null).build();
+        assertThat(item1.freezeKeyOrThrow()).isEqualTo(item1.freezeKey());
+        assertThatThrownBy(itemNullFreezeKey::freezeKeyOrThrow).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testIfFreezeKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullFreezeKey = item1.copyBuilder().freezeKey((Key) null).build();
+        List<Key> keys = new ArrayList<>();
+        Consumer<Key> keyConsumer = keys::add;
+
+        item1.ifFreezeKey(keyConsumer);
+        itemNullFreezeKey.ifFreezeKey(keyConsumer);
+        assertThat(keys).isNotEmpty().hasSize(1).contains(item1.freezeKey());
+    }
+
+    @Test
+    void testHasWipeKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullWipeKey = item1.copyBuilder().wipeKey((Key) null).build();
+        assertThat(item1.hasWipeKey()).isTrue();
+        assertThat(itemNullWipeKey.hasWipeKey()).isFalse();
+    }
+
+    @Test
+    void testWipeKeyOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullWipeKey = item1.copyBuilder().wipeKey((Key) null).build();
+        assertThat(item1.wipeKeyOrElse(Key.DEFAULT)).isEqualTo(item1.wipeKey());
+        assertThat(itemNullWipeKey.wipeKeyOrElse(Key.DEFAULT)).isEqualTo(Key.DEFAULT);
+    }
+
+    @Test
+    void testWipeKeyOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullWipeKey = item1.copyBuilder().wipeKey((Key) null).build();
+        assertThat(item1.wipeKeyOrThrow()).isEqualTo(item1.wipeKey());
+        assertThatThrownBy(itemNullWipeKey::wipeKeyOrThrow).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testIfWipeKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullWipeKey = item1.copyBuilder().wipeKey((Key) null).build();
+        List<Key> keys = new ArrayList<>();
+        Consumer<Key> keyConsumer = keys::add;
+
+        item1.ifWipeKey(keyConsumer);
+        itemNullWipeKey.ifWipeKey(keyConsumer);
+        assertThat(keys).isNotEmpty().hasSize(1).contains(item1.wipeKey());
+    }
+
+    @Test
+    void testHasSupplyKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullSupplyKey = item1.copyBuilder().supplyKey((Key) null).build();
+        assertThat(item1.hasSupplyKey()).isTrue();
+        assertThat(itemNullSupplyKey.hasSupplyKey()).isFalse();
+    }
+
+    @Test
+    void testSupplyKeyOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullSupplyKey = item1.copyBuilder().supplyKey((Key) null).build();
+        assertThat(item1.supplyKeyOrElse(Key.DEFAULT)).isEqualTo(item1.supplyKey());
+        assertThat(itemNullSupplyKey.supplyKeyOrElse(Key.DEFAULT)).isEqualTo(Key.DEFAULT);
+    }
+
+    @Test
+    void testSupplyKeyOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullSupplyKey = item1.copyBuilder().supplyKey((Key) null).build();
+        assertThat(item1.supplyKeyOrThrow()).isEqualTo(item1.supplyKey());
+        assertThatThrownBy(itemNullSupplyKey::supplyKeyOrThrow).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testIfSupplyKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullSupplyKey = item1.copyBuilder().supplyKey((Key) null).build();
+        List<Key> keys = new ArrayList<>();
+        Consumer<Key> keyConsumer = keys::add;
+
+        item1.ifSupplyKey(keyConsumer);
+        itemNullSupplyKey.ifSupplyKey(keyConsumer);
+        assertThat(keys).isNotEmpty().hasSize(1).contains(item1.supplyKey());
+    }
+
+    @Test
+    void testHasFeeScheduleKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullFeeScheduleKey =
+                item1.copyBuilder().feeScheduleKey((Key) null).build();
+        assertThat(item1.hasFeeScheduleKey()).isTrue();
+        assertThat(itemNullFeeScheduleKey.hasFeeScheduleKey()).isFalse();
+    }
+
+    @Test
+    void testFeeScheduleKeyOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullFeeScheduleKey =
+                item1.copyBuilder().feeScheduleKey((Key) null).build();
+        assertThat(item1.feeScheduleKeyOrElse(Key.DEFAULT)).isEqualTo(item1.feeScheduleKey());
+        assertThat(itemNullFeeScheduleKey.feeScheduleKeyOrElse(Key.DEFAULT)).isEqualTo(Key.DEFAULT);
+    }
+
+    @Test
+    void testFeeScheduleKeyOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullFeeScheduleKey =
+                item1.copyBuilder().feeScheduleKey((Key) null).build();
+        assertThat(item1.feeScheduleKeyOrThrow()).isEqualTo(item1.feeScheduleKey());
+        assertThatThrownBy(itemNullFeeScheduleKey::feeScheduleKeyOrThrow).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testIfFeeScheduleKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullFeeScheduleKey =
+                item1.copyBuilder().feeScheduleKey((Key) null).build();
+        List<Key> keys = new ArrayList<>();
+        Consumer<Key> keyConsumer = keys::add;
+
+        item1.ifFeeScheduleKey(keyConsumer);
+        itemNullFeeScheduleKey.ifFeeScheduleKey(keyConsumer);
+        assertThat(keys).isNotEmpty().hasSize(1).contains(item1.feeScheduleKey());
+    }
+
+    @Test
+    void testHasPauseKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullPauseKey = item1.copyBuilder().pauseKey((Key) null).build();
+        assertThat(item1.hasPauseKey()).isTrue();
+        assertThat(itemNullPauseKey.hasPauseKey()).isFalse();
+    }
+
+    @Test
+    void testPauseKeyOrElse() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullPauseKey = item1.copyBuilder().pauseKey((Key) null).build();
+        assertThat(item1.pauseKeyOrElse(Key.DEFAULT)).isEqualTo(item1.pauseKey());
+        assertThat(itemNullPauseKey.pauseKeyOrElse(Key.DEFAULT)).isEqualTo(Key.DEFAULT);
+    }
+
+    @Test
+    void testPauseKeyOrThrow() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullPauseKey = item1.copyBuilder().pauseKey((Key) null).build();
+        assertThat(item1.pauseKeyOrThrow()).isEqualTo(item1.pauseKey());
+        assertThatThrownBy(itemNullPauseKey::pauseKeyOrThrow).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testIfPauseKey() {
+        final var item1 = ARGUMENTS.get(0);
+        final var itemNullPauseKey = item1.copyBuilder().pauseKey((Key) null).build();
+        List<Key> keys = new ArrayList<>();
+        Consumer<Key> keyConsumer = keys::add;
+
+        item1.ifPauseKey(keyConsumer);
+        itemNullPauseKey.ifPauseKey(keyConsumer);
+        assertThat(keys).isNotEmpty().hasSize(1).contains(item1.pauseKey());
     }
 
     /**

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -71,8 +71,8 @@ public class TokenTest extends AbstractStateTest {
         final var item1 = ARGUMENTS.get(0);
         final var item1Copy = item1.copyBuilder().build();
 
-        assertThat(item1.hashCode()).isEqualTo(item1.hashCode());
-        assertThat(item1.hashCode()).isEqualTo(item1Copy.hashCode());
+        assertThat(item1).hasSameHashCodeAs(item1.hashCode());
+        assertThat(item1).hasSameHashCodeAs(item1Copy.hashCode());
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -67,6 +67,27 @@ public class TokenTest extends AbstractStateTest {
     }
 
     @Test
+    void testHashCodeConsistency() {
+        final var item1 = ARGUMENTS.get(0);
+        final var item1Copy = item1.copyBuilder().build();
+
+        assertThat(item1.hashCode()).isEqualTo(item1.hashCode());
+        assertThat(item1.hashCode()).isEqualTo(item1Copy.hashCode());
+    }
+
+    @Test
+    void testHashCodeWithCustomSuppliers() {
+        final var item1 = ARGUMENTS.get(1);
+        final var itemCustomSuppliers = item1.copyBuilder()
+                .totalSupply(1)
+                .treasuryAccountId(() -> new AccountID(0L, 0L, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 1L)))
+                .autoRenewAccountId(() -> new AccountID(0L, 0L, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, 2L)))
+                .build();
+
+        assertThat(item1.hashCode()).isNotEqualTo(itemCustomSuppliers.hashCode());
+    }
+
+    @Test
     void testEqualsWithNull() {
         final var item1 = ARGUMENTS.get(0);
         assertNotEquals(null, item1);

--- a/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/hapi/node/state/token/TokenTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.hapi.node.state.token;
+
+import static com.hedera.pbj.runtime.ProtoTestTools.BOOLEAN_TESTS_LIST;
+import static com.hedera.pbj.runtime.ProtoTestTools.BYTES_TESTS_LIST;
+import static com.hedera.pbj.runtime.ProtoTestTools.INTEGER_TESTS_LIST;
+import static com.hedera.pbj.runtime.ProtoTestTools.LONG_TESTS_LIST;
+import static com.hedera.pbj.runtime.ProtoTestTools.STRING_TESTS_LIST;
+import static com.hedera.pbj.runtime.ProtoTestTools.generateListArguments;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.hedera.hapi.node.base.TokenSupplyType;
+import com.hedera.hapi.node.base.TokenType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+public class TokenTest extends AbstractStateTest {
+
+    @SuppressWarnings("EqualsWithItself")
+    @Test
+    public void testTestEqualsAndHashCode() {
+        if (ARGUMENTS.size() >= 3) {
+            final var item1 = ARGUMENTS.get(0);
+            final var item2 = ARGUMENTS.get(1);
+            final var item3 = ARGUMENTS.get(2);
+            assertEquals(item1, item1);
+            assertEquals(item2, item2);
+            assertEquals(item3, item3);
+            assertNotEquals(item1, item2);
+            assertNotEquals(item2, item3);
+            final var item1HashCode = item1.hashCode();
+            final var item2HashCode = item2.hashCode();
+            final var item3HashCode = item3.hashCode();
+            assertNotEquals(item1HashCode, item2HashCode);
+            assertNotEquals(item2HashCode, item3HashCode);
+        }
+    }
+
+    /**
+     * List of all valid arguments for testing, built as a static list, so we can reuse it.
+     */
+    public static final List<Token> ARGUMENTS;
+
+    static {
+        final var tokenIdList = TokenIDTest.ARGUMENTS;
+        final var nameList = STRING_TESTS_LIST;
+        final var symbolList = STRING_TESTS_LIST;
+        final var decimalsList = INTEGER_TESTS_LIST;
+        final var totalSupplyList = LONG_TESTS_LIST;
+        final var treasuryAccountIdList = AccountIDTest.ARGUMENTS;
+        final var adminKeyList = KeyTest.ARGUMENTS;
+        final var kycKeyList = KeyTest.ARGUMENTS;
+        final var freezeKeyList = KeyTest.ARGUMENTS;
+        final var wipeKeyList = KeyTest.ARGUMENTS;
+        final var supplyKeyList = KeyTest.ARGUMENTS;
+        final var feeScheduleKeyList = KeyTest.ARGUMENTS;
+        final var pauseKeyList = KeyTest.ARGUMENTS;
+        final var lastUsedSerialNumberList = LONG_TESTS_LIST;
+        final var deletedList = BOOLEAN_TESTS_LIST;
+        final var tokenTypeList = Arrays.asList(TokenType.values());
+        final var supplyTypeList = Arrays.asList(TokenSupplyType.values());
+        final var autoRenewAccountIdList = AccountIDTest.ARGUMENTS;
+        final var autoRenewSecondsList = LONG_TESTS_LIST;
+        final var expirationSecondList = LONG_TESTS_LIST;
+        final var memoList = STRING_TESTS_LIST;
+        final var maxSupplyList = LONG_TESTS_LIST;
+        final var pausedList = BOOLEAN_TESTS_LIST;
+        final var accountsFrozenByDefaultList = BOOLEAN_TESTS_LIST;
+        final var accountsKycGrantedByDefaultList = BOOLEAN_TESTS_LIST;
+        final var customFeesList = generateListArguments(CUSTOM_FEE_ARGUMENTS);
+        final var metadataList = BYTES_TESTS_LIST;
+        final var metadataKeyList = KeyTest.ARGUMENTS;
+
+        // work out the longest of all the lists of args as that is how many test cases we need
+        final int maxValues = IntStream.of(
+                        tokenIdList.size(),
+                        nameList.size(),
+                        symbolList.size(),
+                        decimalsList.size(),
+                        totalSupplyList.size(),
+                        treasuryAccountIdList.size(),
+                        adminKeyList.size(),
+                        kycKeyList.size(),
+                        freezeKeyList.size(),
+                        wipeKeyList.size(),
+                        supplyKeyList.size(),
+                        feeScheduleKeyList.size(),
+                        pauseKeyList.size(),
+                        lastUsedSerialNumberList.size(),
+                        deletedList.size(),
+                        tokenTypeList.size(),
+                        supplyTypeList.size(),
+                        autoRenewAccountIdList.size(),
+                        autoRenewSecondsList.size(),
+                        expirationSecondList.size(),
+                        memoList.size(),
+                        maxSupplyList.size(),
+                        pausedList.size(),
+                        accountsFrozenByDefaultList.size(),
+                        accountsKycGrantedByDefaultList.size(),
+                        customFeesList.size(),
+                        metadataList.size(),
+                        metadataKeyList.size())
+                .max()
+                .getAsInt();
+        // create new stream of model objects using lists above as constructor params
+        ARGUMENTS = (maxValues > 0 ? IntStream.range(0, maxValues) : IntStream.of(0))
+                .mapToObj(i -> new Token(
+                        tokenIdList.get(Math.min(i, tokenIdList.size() - 1)),
+                        nameList.get(Math.min(i, nameList.size() - 1)),
+                        symbolList.get(Math.min(i, symbolList.size() - 1)),
+                        decimalsList.get(Math.min(i, decimalsList.size() - 1)),
+                        totalSupplyList.get(Math.min(i, totalSupplyList.size() - 1)),
+                        treasuryAccountIdList.get(Math.min(i, treasuryAccountIdList.size() - 1)),
+                        adminKeyList.get(Math.min(i, adminKeyList.size() - 1)),
+                        kycKeyList.get(Math.min(i, kycKeyList.size() - 1)),
+                        freezeKeyList.get(Math.min(i, freezeKeyList.size() - 1)),
+                        wipeKeyList.get(Math.min(i, wipeKeyList.size() - 1)),
+                        supplyKeyList.get(Math.min(i, supplyKeyList.size() - 1)),
+                        feeScheduleKeyList.get(Math.min(i, feeScheduleKeyList.size() - 1)),
+                        pauseKeyList.get(Math.min(i, pauseKeyList.size() - 1)),
+                        lastUsedSerialNumberList.get(Math.min(i, lastUsedSerialNumberList.size() - 1)),
+                        deletedList.get(Math.min(i, deletedList.size() - 1)),
+                        tokenTypeList.get(Math.min(i, tokenTypeList.size() - 1)),
+                        supplyTypeList.get(Math.min(i, supplyTypeList.size() - 1)),
+                        autoRenewAccountIdList.get(Math.min(i, autoRenewAccountIdList.size() - 1)),
+                        autoRenewSecondsList.get(Math.min(i, autoRenewSecondsList.size() - 1)),
+                        expirationSecondList.get(Math.min(i, expirationSecondList.size() - 1)),
+                        memoList.get(Math.min(i, memoList.size() - 1)),
+                        maxSupplyList.get(Math.min(i, maxSupplyList.size() - 1)),
+                        pausedList.get(Math.min(i, pausedList.size() - 1)),
+                        accountsFrozenByDefaultList.get(Math.min(i, accountsFrozenByDefaultList.size() - 1)),
+                        accountsKycGrantedByDefaultList.get(Math.min(i, accountsKycGrantedByDefaultList.size() - 1)),
+                        customFeesList.get(Math.min(i, customFeesList.size() - 1)),
+                        metadataList.get(Math.min(i, metadataList.size() - 1)),
+                        metadataKeyList.get(Math.min(i, metadataKeyList.size() - 1))))
+                .toList();
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/CommonEntityAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/CommonEntityAccessorTest.java
@@ -17,7 +17,6 @@
 package com.hedera.mirror.web3.state;
 
 import static com.hedera.services.utils.EntityIdUtils.entityIdFromId;
-import static com.hedera.services.utils.EntityIdUtils.toAccountId;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -97,27 +96,6 @@ class CommonEntityAccessorTest {
 
         assertThat(commonEntityAccessor.get(tokenID, timestamp))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
-    }
-
-    @Test
-    void getAccountWithCanonicalAddress() {
-        final var entityId = EntityId.of(NUM);
-        when(mockEntity.toEntityId()).thenReturn(entityId);
-        when(entityRepository.findByIdAndDeletedIsFalse(entityId.getId())).thenReturn(Optional.of(mockEntity));
-
-        final AccountID accountId = commonEntityAccessor.getAccountWithCanonicalAddress(entityId, Optional.empty());
-        assertThat(accountId).isEqualTo(toAccountId(mockEntity));
-    }
-
-    @Test
-    void getAccountWithCanonicalAddressHistorical() {
-        final var entityId = EntityId.of(NUM);
-        when(mockEntity.toEntityId()).thenReturn(entityId);
-        when(entityRepository.findActiveByIdAndTimestamp(entityId.getId(), timestamp.get()))
-                .thenReturn(Optional.of(mockEntity));
-
-        final AccountID accountId = commonEntityAccessor.getAccountWithCanonicalAddress(entityId, timestamp);
-        assertThat(accountId).isEqualTo(toAccountId(mockEntity));
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
@@ -1,0 +1,797 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.AccountID.AccountOneOfType;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenSupplyType;
+import com.hedera.hapi.node.base.TokenType;
+import com.hedera.hapi.node.state.token.Token;
+import com.hedera.mirror.common.domain.DomainBuilder;
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
+import com.hedera.mirror.common.domain.token.CustomFee;
+import com.hedera.mirror.common.domain.token.FallbackFee;
+import com.hedera.mirror.common.domain.token.FixedFee;
+import com.hedera.mirror.common.domain.token.FractionalFee;
+import com.hedera.mirror.common.domain.token.RoyaltyFee;
+import com.hedera.mirror.common.domain.token.TokenTypeEnum;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.repository.CustomFeeRepository;
+import com.hedera.mirror.web3.repository.EntityRepository;
+import com.hedera.mirror.web3.repository.TokenRepository;
+import com.hedera.pbj.runtime.OneOf;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TokenReadableKVStateTest {
+
+    private static final TokenID TOKEN_ID =
+            TokenID.newBuilder().shardNum(0L).realmNum(0L).tokenNum(1252L).build();
+    private static final Long TOKEN_ENCODED_ID = EntityId.of(
+                    TOKEN_ID.shardNum(), TOKEN_ID.realmNum(), TOKEN_ID.tokenNum())
+            .getId();
+    private static final Optional<Long> timestamp = Optional.of(1234L);
+    private static final TokenID DENOMINATING_TOKEN_ID =
+            TokenID.newBuilder().shardNum(11L).realmNum(12L).tokenNum(13L).build();
+    private static MockedStatic<ContractCallContext> contextMockedStatic;
+    private final EntityId collectorId = EntityId.of(1L, 2L, 3L);
+    private final AccountID collectorAccountId = new AccountID(
+            collectorId.getShard(),
+            collectorId.getRealm(),
+            new OneOf<>(AccountOneOfType.ACCOUNT_NUM, collectorId.getNum()));
+    private final EntityId denominatingTokenId = EntityId.of(11L, 12L, 13L);
+    com.hedera.mirror.common.domain.token.Token databaseToken;
+    private CustomFee customFee;
+
+    @InjectMocks
+    private TokenReadableKVState tokenReadableKVState;
+
+    @Mock
+    private TokenRepository tokenRepository;
+
+    @Mock
+    private CommonEntityAccessor commonEntityAccessor;
+
+    @Mock
+    private CustomFeeRepository customFeeRepository;
+
+    @Mock
+    private EntityRepository entityRepository;
+
+    private DomainBuilder domainBuilder;
+    private Entity entity;
+
+    @Spy
+    private ContractCallContext contractCallContext;
+
+    @BeforeAll
+    static void initStaticMocks() {
+        contextMockedStatic = mockStatic(ContractCallContext.class);
+    }
+
+    @AfterAll
+    static void closeStaticMocks() {
+        contextMockedStatic.close();
+    }
+
+    @BeforeEach
+    void setup() {
+        domainBuilder = new DomainBuilder();
+        entity = domainBuilder
+                .entity()
+                .customize(e -> e.id(TOKEN_ID.tokenNum()))
+                .customize(e -> e.num(TOKEN_ID.tokenNum()))
+                .customize(e -> e.type(EntityType.TOKEN))
+                .get();
+        customFee = new CustomFee();
+
+        contextMockedStatic.when(ContractCallContext::get).thenReturn(contractCallContext);
+    }
+
+    @Test
+    void getTokenMappedValues() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        setupToken(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+
+        Token token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        assertThat(token)
+                .returns(TOKEN_ID, Token::tokenId)
+                .returns(
+                        com.hedera.hapi.node.base.TokenType.valueOf(
+                                databaseToken.getType().name()),
+                        Token::tokenType)
+                .returns(
+                        com.hedera.hapi.node.base.TokenSupplyType.valueOf(
+                                databaseToken.getSupplyType().name()),
+                        Token::supplyType)
+                .returns(databaseToken.getMaxSupply(), Token::maxSupply)
+                .returns(databaseToken.getFreezeDefault(), Token::accountsFrozenByDefault)
+                .returns(false, Token::deleted)
+                .returns(false, Token::paused)
+                .returns(
+                        TimeUnit.SECONDS.convert(entity.getEffectiveExpiration(), TimeUnit.NANOSECONDS),
+                        Token::expirationSecond)
+                .returns(entity.getMemo(), Token::memo)
+                .returns(databaseToken.getName(), Token::name)
+                .returns(databaseToken.getSymbol(), Token::symbol)
+                .returns(databaseToken.getDecimals(), Token::decimals)
+                .returns(entity.getAutoRenewPeriod(), Token::autoRenewSeconds);
+
+        assertThat(token.totalSupplySupplier().get()).isEqualTo(databaseToken.getTotalSupply());
+    }
+
+    @Test
+    void getTokenMappedValuesHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+        Token token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        assertThat(token)
+                .returns(TOKEN_ID, Token::tokenId)
+                .returns(TokenType.valueOf(databaseToken.getType().name()), Token::tokenType)
+                .returns(TokenSupplyType.valueOf(databaseToken.getSupplyType().name()), Token::supplyType)
+                .returns(databaseToken.getMaxSupply(), Token::maxSupply)
+                .returns(databaseToken.getFreezeDefault(), Token::accountsFrozenByDefault)
+                .returns(false, Token::deleted)
+                .returns(false, Token::paused)
+                .returns(
+                        TimeUnit.SECONDS.convert(entity.getEffectiveExpiration(), TimeUnit.NANOSECONDS),
+                        Token::expirationSecond)
+                .returns(entity.getMemo(), Token::memo)
+                .returns(databaseToken.getName(), Token::name)
+                .returns(databaseToken.getSymbol(), Token::symbol)
+                .returns(databaseToken.getDecimals(), Token::decimals)
+                .returns(entity.getAutoRenewPeriod(), Token::autoRenewSeconds);
+
+        assertThat(token.totalSupplySupplier().get()).isEqualTo(0L);
+    }
+
+    @Test
+    void getCustomFees() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        setupToken(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
+                .satisfies(token -> assertThat(token.customFeesSupplier().get()).isEqualTo(Collections.emptyList()));
+        verify(customFeeRepository).findById(TOKEN_ID.tokenNum());
+    }
+
+    @Test
+    void getCustomFeesHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+        when(customFeeRepository.findByTokenIdAndTimestamp(TOKEN_ENCODED_ID, timestamp.get()))
+                .thenReturn(Optional.empty());
+
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
+                .satisfies(token -> assertThat(token.customFeesSupplier().get()).isEqualTo(Collections.emptyList()));
+    }
+
+    @Test
+    void getPartialTreasuryAccount() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        setupToken(Optional.empty());
+
+        Entity treasuryEntity = mock(Entity.class);
+        EntityId treasuryEntityId = mock(EntityId.class);
+        when(treasuryEntityId.getShard()).thenReturn(11L);
+        when(treasuryEntityId.getRealm()).thenReturn(12L);
+        when(treasuryEntityId.getNum()).thenReturn(13L);
+
+        when(treasuryEntity.toEntityId()).thenReturn(treasuryEntityId);
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+        when(entityRepository.findByIdAndDeletedIsFalse(
+                        databaseToken.getTreasuryAccountId().getId()))
+                .thenReturn(Optional.of(treasuryEntity));
+
+        final var expectedTreasuryAccountId = getAccountId(11L, 12L, 13L);
+
+        Token token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+
+        assertThat(token.treasuryAccountIdSupplier().get()).isEqualTo(expectedTreasuryAccountId);
+        verify(entityRepository)
+                .findByIdAndDeletedIsFalse(databaseToken.getTreasuryAccountId().getId());
+    }
+
+    @Test
+    void getPartialTreasuryAccountHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+
+        Entity treasuryEntity = mock(Entity.class);
+        EntityId treasuryEntityId = mock(EntityId.class);
+        when(treasuryEntityId.getShard()).thenReturn(0L);
+        when(treasuryEntityId.getRealm()).thenReturn(0L);
+        when(treasuryEntityId.getNum()).thenReturn(10L);
+        when(treasuryEntity.toEntityId()).thenReturn(treasuryEntityId);
+
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+        when(entityRepository.findActiveByIdAndTimestamp(treasuryEntity.getId(), timestamp.get()))
+                .thenReturn(Optional.of(treasuryEntity));
+
+        final var expectedTreasuryAccountId = getAccountId(0L, 0L, 10L);
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
+                .satisfies(token ->
+                        assertThat(token.treasuryAccountIdSupplier().get()).isEqualTo(expectedTreasuryAccountId));
+
+        verify(entityRepository).findActiveByIdAndTimestamp(treasuryEntity.getId(), timestamp.get());
+    }
+
+    @Test
+    void getAutoRenewAccount() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        setupToken(Optional.empty());
+        databaseToken.setTreasuryAccountId(null);
+
+        Entity autorenewEntity = mock(Entity.class);
+        entity.setAutoRenewAccountId(10L);
+        EntityId autorenewEntityId = mock(EntityId.class);
+        when(autorenewEntityId.getShard()).thenReturn(0L);
+        when(autorenewEntityId.getRealm()).thenReturn(0L);
+        when(autorenewEntityId.getNum()).thenReturn(10L);
+        when(autorenewEntity.toEntityId()).thenReturn(autorenewEntityId);
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+        when(entityRepository.findByIdAndDeletedIsFalse(entity.getAutoRenewAccountId()))
+                .thenReturn(Optional.of(autorenewEntity));
+
+        verify(entityRepository, never()).findByIdAndDeletedIsFalse(anyLong());
+
+        final var autoRenewAccountId = getAccountId(0L, 0L, 10L);
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
+                .satisfies(token ->
+                        assertThat(token.autoRenewAccountIdSupplier().get()).isEqualTo(autoRenewAccountId));
+
+        verify(entityRepository).findByIdAndDeletedIsFalse(entity.getAutoRenewAccountId());
+    }
+
+    @Test
+    void getAutoRenewAccountHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+        databaseToken.setTreasuryAccountId(null);
+
+        Entity autorenewEntity = mock(Entity.class);
+        EntityId autorenewEntityId = mock(EntityId.class);
+        when(autorenewEntityId.getShard()).thenReturn(0L);
+        when(autorenewEntityId.getRealm()).thenReturn(0L);
+        when(autorenewEntityId.getNum()).thenReturn(10L);
+        when(autorenewEntity.toEntityId()).thenReturn(autorenewEntityId);
+
+        entity.setAutoRenewAccountId(10L);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+        when(entityRepository.findActiveByIdAndTimestamp(entity.getAutoRenewAccountId(), timestamp.get()))
+                .thenReturn(Optional.of(autorenewEntity));
+
+        verify(entityRepository, never()).findActiveByIdAndTimestamp(anyLong(), anyLong());
+
+        final var autoRenewAccountId = getAccountId(0L, 0L, 10L);
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
+                .satisfies(token ->
+                        assertThat(token.autoRenewAccountIdSupplier().get()).isEqualTo(autoRenewAccountId));
+
+        verify(entityRepository).findActiveByIdAndTimestamp(entity.getAutoRenewAccountId(), timestamp.get());
+    }
+
+    @Test
+    void getTotalSupplyHistoricalFungible() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+        final var treasuryId = EntityId.of(123L);
+        final var totalSupply = 10L;
+        final var historicalSupply = 9L;
+        databaseToken.setType(TokenTypeEnum.FUNGIBLE_COMMON);
+        databaseToken.setTotalSupply(totalSupply);
+        databaseToken.setTreasuryAccountId(treasuryId);
+
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+        when(tokenRepository.findFungibleTotalSupplyByTokenIdAndTimestamp(databaseToken.getTokenId(), timestamp.get()))
+                .thenReturn(historicalSupply);
+
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
+                .satisfies(
+                        token -> assertThat(token.totalSupplySupplier().get()).isEqualTo(historicalSupply));
+
+        verify(tokenRepository)
+                .findFungibleTotalSupplyByTokenIdAndTimestamp(databaseToken.getTokenId(), timestamp.get());
+    }
+
+    @Test
+    void getNullOnMissingToken() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.empty());
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID)).isNull();
+    }
+
+    @Test
+    void getNullOnMissingTokenDHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.empty());
+        assertThat(tokenReadableKVState.get(TOKEN_ID)).isNull();
+    }
+
+    @Test
+    void getTokenKeysValues() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        setupToken(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID)).satisfies(token -> assertThat(token)
+                .returns(Utils.parseKey(entity.getKey()), Token::adminKey)
+                .returns(Utils.parseKey(databaseToken.getKycKey()), Token::kycKey)
+                .returns(Utils.parseKey(databaseToken.getPauseKey()), Token::pauseKey)
+                .returns(Utils.parseKey(databaseToken.getFreezeKey()), Token::freezeKey)
+                .returns(Utils.parseKey(databaseToken.getWipeKey()), Token::wipeKey)
+                .returns(Utils.parseKey(databaseToken.getSupplyKey()), Token::supplyKey)
+                .returns(Utils.parseKey(databaseToken.getFeeScheduleKey()), Token::feeScheduleKey));
+    }
+
+    @Test
+    void getTokenKeysValuesHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID)).satisfies(token -> assertThat(token)
+                .returns(Utils.parseKey(entity.getKey()), com.hedera.hapi.node.state.token.Token::adminKey)
+                .returns(Utils.parseKey(databaseToken.getKycKey()), Token::kycKey)
+                .returns(Utils.parseKey(databaseToken.getPauseKey()), Token::pauseKey)
+                .returns(Utils.parseKey(databaseToken.getFreezeKey()), Token::freezeKey)
+                .returns(Utils.parseKey(databaseToken.getWipeKey()), Token::wipeKey)
+                .returns(Utils.parseKey(databaseToken.getSupplyKey()), Token::supplyKey)
+                .returns(Utils.parseKey(databaseToken.getFeeScheduleKey()), Token::feeScheduleKey));
+    }
+
+    @Test
+    void getTokenEmptyWhenDatabaseTokenNotFound() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+        when(tokenRepository.findById(any())).thenReturn(Optional.empty());
+
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID)).isNull();
+    }
+
+    @Test
+    void getTokenEmptyWhenDatabaseTokenNotFoundHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+        when(tokenRepository.findByTokenIdAndTimestamp(entity.getId(), timestamp.get()))
+                .thenReturn(Optional.empty());
+
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID)).isNull();
+    }
+
+    @Test
+    void keyIsNullIfNotParsable() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        setupToken(Optional.empty());
+
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+        databaseToken.setKycKey("wrOng".getBytes());
+
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
+                .satisfies(token -> assertThat(token.kycKey()).isNull());
+    }
+
+    @Test
+    void royaltyFee() {
+        setupToken(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+
+        var fallbackFeeBuilder = FallbackFee.builder().denominatingTokenId(denominatingTokenId);
+        var fallbackFee = fallbackFeeBuilder.amount(20L).build();
+
+        var royaltyFeeBuilder = RoyaltyFee.builder().collectorAccountId(collectorId);
+        var royaltyFee = royaltyFeeBuilder
+                .numerator(15L)
+                .denominator(10L)
+                .fallbackFee(fallbackFee)
+                .build();
+        var royaltyFee2 = royaltyFeeBuilder.numerator(16L).denominator(11L).build();
+        var royaltyFees = List.of(royaltyFee, royaltyFee2);
+        customFee.setRoyaltyFees(royaltyFees);
+
+        when(customFeeRepository.findById(TOKEN_ENCODED_ID)).thenReturn(Optional.of(customFee));
+        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, Optional.empty()))
+                .thenReturn(collectorAccountId);
+
+        final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        var results = token.customFeesSupplier().get();
+        var listAssert = Assertions.assertThat(results).hasSize(2);
+        for (var domainFee : royaltyFees) {
+            listAssert.anySatisfy(fee -> {
+                Assertions.assertThat(fee.fixedFee()).isNull();
+                Assertions.assertThat(fee.fractionalFee()).isNull();
+                var resultRoyaltyFee = fee.royaltyFee();
+                Assertions.assertThat(resultRoyaltyFee.exchangeValueFraction().denominator())
+                        .isEqualTo(domainFee.getDenominator());
+                Assertions.assertThat(resultRoyaltyFee.exchangeValueFraction().numerator())
+                        .isEqualTo(domainFee.getNumerator());
+                Assertions.assertThat(resultRoyaltyFee.fallbackFee().amount())
+                        .isEqualTo(domainFee.getFallbackFee().getAmount());
+                Assertions.assertThat(resultRoyaltyFee.fallbackFee().denominatingTokenId())
+                        .isEqualTo(DENOMINATING_TOKEN_ID);
+                Assertions.assertThat(fee.feeCollectorAccountId()).isEqualTo(collectorAccountId);
+            });
+        }
+    }
+
+    @Test
+    void royaltyFeeHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+
+        var fallbackFeeBuilder = FallbackFee.builder().denominatingTokenId(denominatingTokenId);
+        var fallbackFee = fallbackFeeBuilder.amount(20L).build();
+
+        var royaltyFeeBuilder = RoyaltyFee.builder().collectorAccountId(collectorId);
+        var royaltyFee = royaltyFeeBuilder
+                .numerator(15L)
+                .denominator(10L)
+                .fallbackFee(fallbackFee)
+                .build();
+        var royaltyFee2 = royaltyFeeBuilder.numerator(16L).denominator(11L).build();
+        var royaltyFees = List.of(royaltyFee, royaltyFee2);
+        customFee.setRoyaltyFees(royaltyFees);
+
+        when(customFeeRepository.findByTokenIdAndTimestamp(TOKEN_ENCODED_ID, timestamp.get()))
+                .thenReturn(Optional.of(customFee));
+        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, timestamp))
+                .thenReturn(collectorAccountId);
+
+        final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        var results = token.customFeesSupplier().get();
+        var listAssert = Assertions.assertThat(results).hasSize(2);
+        for (var domainFee : royaltyFees) {
+            listAssert.anySatisfy(fee -> {
+                Assertions.assertThat(fee.fixedFee()).isNull();
+                Assertions.assertThat(fee.fractionalFee()).isNull();
+                var resultRoyaltyFee = fee.royaltyFee();
+                Assertions.assertThat(resultRoyaltyFee.exchangeValueFraction().denominator())
+                        .isEqualTo(domainFee.getDenominator());
+                Assertions.assertThat(resultRoyaltyFee.exchangeValueFraction().numerator())
+                        .isEqualTo(domainFee.getNumerator());
+                Assertions.assertThat(resultRoyaltyFee.fallbackFee().amount())
+                        .isEqualTo(domainFee.getFallbackFee().getAmount());
+                Assertions.assertThat(resultRoyaltyFee.fallbackFee().denominatingTokenId())
+                        .isEqualTo(DENOMINATING_TOKEN_ID);
+                Assertions.assertThat(fee.feeCollectorAccountId()).isEqualTo(collectorAccountId);
+            });
+        }
+    }
+
+    @Test
+    void royaltyFeeNoFallback() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        setupToken(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+
+        var royaltyFee = RoyaltyFee.builder()
+                .numerator(15L)
+                .denominator(10L)
+                .fallbackFee(null)
+                .collectorAccountId(collectorId)
+                .build();
+        var royaltyFees = List.of(royaltyFee);
+        customFee.setRoyaltyFees(royaltyFees);
+
+        when(customFeeRepository.findById(TOKEN_ENCODED_ID)).thenReturn(Optional.of(customFee));
+        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, Optional.empty()))
+                .thenReturn(collectorAccountId);
+
+        final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        var results = token.customFeesSupplier().get();
+        var customFee = results.get(0);
+        var resultFee = customFee.royaltyFee();
+        assertEquals(
+                royaltyFee.getNumerator(), resultFee.exchangeValueFraction().numerator());
+        assertEquals(
+                royaltyFee.getDenominator(), resultFee.exchangeValueFraction().denominator());
+        assertEquals(
+                0L, resultFee.fallbackFee() != null ? resultFee.fallbackFee().amount() : 0L);
+        assertEquals(collectorAccountId, customFee.feeCollectorAccountId());
+        assertEquals(
+                TokenID.DEFAULT,
+                resultFee.fallbackFee() != null ? resultFee.fallbackFee().denominatingTokenId() : TokenID.DEFAULT);
+    }
+
+    @Test
+    void royaltyFeeNoFallbackHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+
+        var royaltyFee = RoyaltyFee.builder()
+                .numerator(15L)
+                .denominator(10L)
+                .fallbackFee(null)
+                .collectorAccountId(collectorId)
+                .build();
+        var royaltyFees = List.of(royaltyFee);
+        customFee.setRoyaltyFees(royaltyFees);
+
+        when(customFeeRepository.findByTokenIdAndTimestamp(TOKEN_ENCODED_ID, timestamp.get()))
+                .thenReturn(Optional.of(customFee));
+        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, timestamp))
+                .thenReturn(collectorAccountId);
+
+        final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        var results = token.customFeesSupplier().get();
+        var customFee = results.get(0);
+        var resultFee = customFee.royaltyFee();
+        assertEquals(
+                royaltyFee.getNumerator(), resultFee.exchangeValueFraction().numerator());
+        assertEquals(
+                royaltyFee.getDenominator(), resultFee.exchangeValueFraction().denominator());
+        assertEquals(
+                0L, resultFee.fallbackFee() != null ? resultFee.fallbackFee().amount() : 0L);
+        assertEquals(collectorAccountId, customFee.feeCollectorAccountId());
+        assertEquals(
+                TokenID.DEFAULT,
+                resultFee.fallbackFee() != null ? resultFee.fallbackFee().denominatingTokenId() : TokenID.DEFAULT);
+    }
+
+    @Test
+    void fractionFee() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        setupToken(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+
+        var fractionalFeeBuilder = FractionalFee.builder().collectorAccountId(collectorId);
+        var fractionalFee = fractionalFeeBuilder
+                .numerator(20L)
+                .denominator(2L)
+                .maximumAmount(100L)
+                .minimumAmount(5L)
+                .netOfTransfers(true)
+                .build();
+        var fractionalFee2 = fractionalFeeBuilder
+                .numerator(21L)
+                .denominator(3L)
+                .maximumAmount(101L)
+                .minimumAmount(6L)
+                .netOfTransfers(false)
+                .build();
+        var fractionalFees = List.of(fractionalFee, fractionalFee2);
+        customFee.setFractionalFees(fractionalFees);
+
+        when(customFeeRepository.findById(TOKEN_ENCODED_ID)).thenReturn(Optional.of(customFee));
+        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, Optional.empty()))
+                .thenReturn(collectorAccountId);
+
+        final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        var results = token.customFeesSupplier().get();
+        var listAssert = Assertions.assertThat(results).hasSize(2);
+        for (var domainFee : fractionalFees) {
+            listAssert.anySatisfy(fee -> {
+                Assertions.assertThat(fee.fixedFee()).isNull();
+                Assertions.assertThat(fee.royaltyFee()).isNull();
+                var resultFractionalFee = fee.fractionalFee();
+                Assertions.assertThat(resultFractionalFee.fractionalAmount().numerator())
+                        .isEqualTo(domainFee.getNumerator());
+                Assertions.assertThat(resultFractionalFee.fractionalAmount().denominator())
+                        .isEqualTo(domainFee.getDenominator());
+                Assertions.assertThat(resultFractionalFee.maximumAmount()).isEqualTo(domainFee.getMaximumAmount());
+                Assertions.assertThat(resultFractionalFee.minimumAmount()).isEqualTo(domainFee.getMinimumAmount());
+                Assertions.assertThat(resultFractionalFee.netOfTransfers()).isEqualTo(domainFee.isNetOfTransfers());
+                Assertions.assertThat(fee.feeCollectorAccountId()).isEqualTo(collectorAccountId);
+            });
+        }
+    }
+
+    @Test
+    void fractionFeeHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+
+        var fractionalFeeBuilder = FractionalFee.builder().collectorAccountId(collectorId);
+        var fractionalFee = fractionalFeeBuilder
+                .numerator(20L)
+                .denominator(2L)
+                .maximumAmount(100L)
+                .minimumAmount(5L)
+                .netOfTransfers(true)
+                .build();
+        var fractionalFee2 = fractionalFeeBuilder
+                .numerator(21L)
+                .denominator(3L)
+                .maximumAmount(101L)
+                .minimumAmount(6L)
+                .netOfTransfers(false)
+                .build();
+        var fractionalFees = List.of(fractionalFee, fractionalFee2);
+        customFee.setFractionalFees(fractionalFees);
+
+        when(customFeeRepository.findByTokenIdAndTimestamp(TOKEN_ENCODED_ID, timestamp.get()))
+                .thenReturn(Optional.of(customFee));
+        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, timestamp))
+                .thenReturn(collectorAccountId);
+
+        final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        var results = token.customFeesSupplier().get();
+        var listAssert = Assertions.assertThat(results).hasSize(2);
+        for (var domainFee : fractionalFees) {
+            listAssert.anySatisfy(fee -> {
+                Assertions.assertThat(fee.fixedFee()).isNull();
+                Assertions.assertThat(fee.royaltyFee()).isNull();
+                var resultFractionalFee = fee.fractionalFee();
+                Assertions.assertThat(resultFractionalFee.fractionalAmount().numerator())
+                        .isEqualTo(domainFee.getNumerator());
+                Assertions.assertThat(resultFractionalFee.fractionalAmount().denominator())
+                        .isEqualTo(domainFee.getDenominator());
+                Assertions.assertThat(resultFractionalFee.maximumAmount()).isEqualTo(domainFee.getMaximumAmount());
+                Assertions.assertThat(resultFractionalFee.minimumAmount()).isEqualTo(domainFee.getMinimumAmount());
+                Assertions.assertThat(resultFractionalFee.netOfTransfers()).isEqualTo(domainFee.isNetOfTransfers());
+                Assertions.assertThat(fee.feeCollectorAccountId()).isEqualTo(collectorAccountId);
+            });
+        }
+    }
+
+    @Test
+    void fixedFee() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        setupToken(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+
+        var fixedFeeBuilder =
+                FixedFee.builder().collectorAccountId(collectorId).denominatingTokenId(denominatingTokenId);
+        var fixedFee = fixedFeeBuilder.amount(20L).build();
+        var fixedFee2 = fixedFeeBuilder.amount(21L).build();
+        var fixedFees = List.of(fixedFee, fixedFee2);
+        customFee.setFixedFees(fixedFees);
+
+        when(customFeeRepository.findById(TOKEN_ENCODED_ID)).thenReturn(Optional.of(customFee));
+        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, Optional.empty()))
+                .thenReturn(collectorAccountId);
+
+        final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        var results = token.customFeesSupplier().get();
+        var listAssert = Assertions.assertThat(results).hasSize(2);
+        for (var domainFee : fixedFees) {
+            listAssert.anySatisfy(fee -> {
+                Assertions.assertThat(fee.fractionalFee()).isNull();
+                Assertions.assertThat(fee.royaltyFee()).isNull();
+                var resultFixedFee = fee.fixedFee();
+                Assertions.assertThat(resultFixedFee.amount()).isEqualTo(domainFee.getAmount());
+                Assertions.assertThat(resultFixedFee.denominatingTokenId()).isEqualTo(DENOMINATING_TOKEN_ID);
+                Assertions.assertThat(resultFixedFee.hasDenominatingTokenId()).isTrue();
+                Assertions.assertThat(fee.feeCollectorAccountId()).isEqualTo(collectorAccountId);
+            });
+        }
+    }
+
+    @Test
+    void fixedFeeHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+
+        var fixedFeeBuilder =
+                FixedFee.builder().collectorAccountId(collectorId).denominatingTokenId(denominatingTokenId);
+        var fixedFee = fixedFeeBuilder.amount(20L).build();
+        var fixedFee2 = fixedFeeBuilder.amount(21L).build();
+        var fixedFees = List.of(fixedFee, fixedFee2);
+        customFee.setFixedFees(fixedFees);
+
+        when(customFeeRepository.findByTokenIdAndTimestamp(TOKEN_ENCODED_ID, timestamp.get()))
+                .thenReturn(Optional.of(customFee));
+        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, timestamp))
+                .thenReturn(collectorAccountId);
+
+        final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        var results = token.customFeesSupplier().get();
+        var listAssert = Assertions.assertThat(results).hasSize(2);
+        for (var domainFee : fixedFees) {
+            listAssert.anySatisfy(fee -> {
+                Assertions.assertThat(fee.fractionalFee()).isNull();
+                Assertions.assertThat(fee.royaltyFee()).isNull();
+                var resultFixedFee = fee.fixedFee();
+                Assertions.assertThat(resultFixedFee.amount()).isEqualTo(domainFee.getAmount());
+                Assertions.assertThat(resultFixedFee.denominatingTokenId()).isEqualTo(DENOMINATING_TOKEN_ID);
+                Assertions.assertThat(resultFixedFee.hasDenominatingTokenId()).isTrue();
+                Assertions.assertThat(fee.feeCollectorAccountId()).isEqualTo(collectorAccountId);
+            });
+        }
+    }
+
+    @Test
+    void mapOnlyFeesWithCollectorAccountId() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        setupToken(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID, Optional.empty())).thenReturn(Optional.ofNullable(entity));
+
+        final var noCollectorCustomFee = new CustomFee();
+        when(customFeeRepository.findById(TOKEN_ENCODED_ID)).thenReturn(Optional.of(noCollectorCustomFee));
+
+        final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        var results = token.customFeesSupplier().get();
+        Assertions.assertThat(results).isEmpty();
+    }
+
+    @Test
+    void mapOnlyFeesWithCollectorAccountIdHistorical() {
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        setupToken(timestamp);
+        when(commonEntityAccessor.get(TOKEN_ID, timestamp)).thenReturn(Optional.ofNullable(entity));
+
+        final var noCollectorCustomFee = new CustomFee();
+        when(customFeeRepository.findByTokenIdAndTimestamp(TOKEN_ENCODED_ID, timestamp.get()))
+                .thenReturn(Optional.of(noCollectorCustomFee));
+
+        final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
+        var results = token.customFeesSupplier().get();
+        Assertions.assertThat(results).isEmpty();
+    }
+
+    @Test
+    void sizeIsAlwaysEmpty() {
+        assertThat(tokenReadableKVState.size()).isZero();
+    }
+
+    @Test
+    void iterateReturnsEmptyIterator() {
+        assertThat(tokenReadableKVState.iterateFromDataSource()).isEqualTo(Collections.emptyIterator());
+    }
+
+    private void setupToken(Optional<Long> timestamp) {
+        databaseToken =
+                domainBuilder.token().customize(t -> t.tokenId(entity.getId())).get();
+        final var treasuryId = mock(EntityId.class);
+        databaseToken.setTreasuryAccountId(treasuryId);
+        if (timestamp.isPresent()) {
+            when(tokenRepository.findByTokenIdAndTimestamp(entity.getId(), timestamp.get()))
+                    .thenReturn(Optional.ofNullable(databaseToken));
+        } else {
+            when(tokenRepository.findById(any())).thenReturn(Optional.ofNullable(databaseToken));
+        }
+    }
+
+    private AccountID getAccountId(final Long shard, final Long realm, final Long num) {
+        return new AccountID(shard, realm, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, num));
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
@@ -102,6 +102,7 @@ class TokenReadableKVStateTest {
 
     private DomainBuilder domainBuilder;
     private Entity entity;
+    private Entity collector;
 
     @Spy
     private ContractCallContext contractCallContext;
@@ -121,9 +122,23 @@ class TokenReadableKVStateTest {
         domainBuilder = new DomainBuilder();
         entity = domainBuilder
                 .entity()
-                .customize(e -> e.id(TOKEN_ID.tokenNum()))
-                .customize(e -> e.num(TOKEN_ID.tokenNum()))
-                .customize(e -> e.type(EntityType.TOKEN))
+                .customize(e -> {
+                    e.id(TOKEN_ID.tokenNum());
+                    e.num(TOKEN_ID.tokenNum());
+                    e.type(EntityType.TOKEN);
+                })
+                .get();
+        collector = domainBuilder
+                .entity()
+                .customize(e -> {
+                    e.id(collectorId.getId());
+                    e.shard(collectorId.getShard());
+                    e.realm(collectorId.getRealm());
+                    e.num(collectorId.getNum());
+                    e.type(EntityType.ACCOUNT);
+                    e.evmAddress(null);
+                    e.alias(null);
+                })
                 .get();
         customFee = new CustomFee();
 
@@ -436,8 +451,7 @@ class TokenReadableKVStateTest {
         customFee.setRoyaltyFees(royaltyFees);
 
         when(customFeeRepository.findById(TOKEN_ENCODED_ID)).thenReturn(Optional.of(customFee));
-        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, Optional.empty()))
-                .thenReturn(collectorAccountId);
+        when(commonEntityAccessor.get(collectorId, Optional.empty())).thenReturn(Optional.of(collector));
 
         final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
         var results = token.customFeesSupplier().get();
@@ -481,8 +495,7 @@ class TokenReadableKVStateTest {
 
         when(customFeeRepository.findByTokenIdAndTimestamp(TOKEN_ENCODED_ID, timestamp.get()))
                 .thenReturn(Optional.of(customFee));
-        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, timestamp))
-                .thenReturn(collectorAccountId);
+        when(commonEntityAccessor.get(collectorId, timestamp)).thenReturn(Optional.of(collector));
 
         final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
         var results = token.customFeesSupplier().get();
@@ -521,8 +534,7 @@ class TokenReadableKVStateTest {
         customFee.setRoyaltyFees(royaltyFees);
 
         when(customFeeRepository.findById(TOKEN_ENCODED_ID)).thenReturn(Optional.of(customFee));
-        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, Optional.empty()))
-                .thenReturn(collectorAccountId);
+        when(commonEntityAccessor.get(collectorId, Optional.empty())).thenReturn(Optional.of(collector));
 
         final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
         var results = token.customFeesSupplier().get();
@@ -557,8 +569,7 @@ class TokenReadableKVStateTest {
 
         when(customFeeRepository.findByTokenIdAndTimestamp(TOKEN_ENCODED_ID, timestamp.get()))
                 .thenReturn(Optional.of(customFee));
-        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, timestamp))
-                .thenReturn(collectorAccountId);
+        when(commonEntityAccessor.get(collectorId, timestamp)).thenReturn(Optional.of(collector));
 
         final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
         var results = token.customFeesSupplier().get();
@@ -601,8 +612,7 @@ class TokenReadableKVStateTest {
         customFee.setFractionalFees(fractionalFees);
 
         when(customFeeRepository.findById(TOKEN_ENCODED_ID)).thenReturn(Optional.of(customFee));
-        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, Optional.empty()))
-                .thenReturn(collectorAccountId);
+        when(commonEntityAccessor.get(collectorId, Optional.empty())).thenReturn(Optional.of(collector));
 
         final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
         var results = token.customFeesSupplier().get();
@@ -650,8 +660,7 @@ class TokenReadableKVStateTest {
 
         when(customFeeRepository.findByTokenIdAndTimestamp(TOKEN_ENCODED_ID, timestamp.get()))
                 .thenReturn(Optional.of(customFee));
-        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, timestamp))
-                .thenReturn(collectorAccountId);
+        when(commonEntityAccessor.get(collectorId, timestamp)).thenReturn(Optional.of(collector));
 
         final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
         var results = token.customFeesSupplier().get();
@@ -687,8 +696,7 @@ class TokenReadableKVStateTest {
         customFee.setFixedFees(fixedFees);
 
         when(customFeeRepository.findById(TOKEN_ENCODED_ID)).thenReturn(Optional.of(customFee));
-        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, Optional.empty()))
-                .thenReturn(collectorAccountId);
+        when(commonEntityAccessor.get(collectorId, Optional.empty())).thenReturn(Optional.of(collector));
 
         final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
         var results = token.customFeesSupplier().get();
@@ -721,8 +729,7 @@ class TokenReadableKVStateTest {
 
         when(customFeeRepository.findByTokenIdAndTimestamp(TOKEN_ENCODED_ID, timestamp.get()))
                 .thenReturn(Optional.of(customFee));
-        when(commonEntityAccessor.getAccountWithCanonicalAddress(collectorId, timestamp))
-                .thenReturn(collectorAccountId);
+        when(commonEntityAccessor.get(collectorId, timestamp)).thenReturn(Optional.of(collector));
 
         final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
         var results = token.customFeesSupplier().get();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.web3.state;
 
+import static com.hedera.services.utils.EntityIdUtils.getAccountId;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -789,9 +790,5 @@ class TokenReadableKVStateTest {
         } else {
             when(tokenRepository.findById(any())).thenReturn(Optional.ofNullable(databaseToken));
         }
-    }
-
-    private AccountID getAccountId(final Long shard, final Long realm, final Long num) {
-        return new AccountID(shard, realm, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, num));
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
@@ -16,7 +16,7 @@
 
 package com.hedera.mirror.web3.state;
 
-import static com.hedera.services.utils.EntityIdUtils.getAccountId;
+import static com.hedera.services.utils.EntityIdUtils.toAccountId;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -229,7 +229,7 @@ class TokenReadableKVStateTest {
                         databaseToken.getTreasuryAccountId().getId()))
                 .thenReturn(Optional.of(treasuryEntity));
 
-        final var expectedTreasuryAccountId = getAccountId(11L, 12L, 13L);
+        final var expectedTreasuryAccountId = toAccountId(11L, 12L, 13L);
 
         Token token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
 
@@ -254,7 +254,7 @@ class TokenReadableKVStateTest {
         when(entityRepository.findActiveByIdAndTimestamp(treasuryEntity.getId(), timestamp.get()))
                 .thenReturn(Optional.of(treasuryEntity));
 
-        final var expectedTreasuryAccountId = getAccountId(0L, 0L, 10L);
+        final var expectedTreasuryAccountId = toAccountId(0L, 0L, 10L);
         assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
                 .satisfies(token ->
                         assertThat(token.treasuryAccountIdSupplier().get()).isEqualTo(expectedTreasuryAccountId));
@@ -281,7 +281,7 @@ class TokenReadableKVStateTest {
 
         verify(entityRepository, never()).findByIdAndDeletedIsFalse(anyLong());
 
-        final var autoRenewAccountId = getAccountId(0L, 0L, 10L);
+        final var autoRenewAccountId = toAccountId(0L, 0L, 10L);
         assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
                 .satisfies(token ->
                         assertThat(token.autoRenewAccountIdSupplier().get()).isEqualTo(autoRenewAccountId));
@@ -309,7 +309,7 @@ class TokenReadableKVStateTest {
 
         verify(entityRepository, never()).findActiveByIdAndTimestamp(anyLong(), anyLong());
 
-        final var autoRenewAccountId = getAccountId(0L, 0L, 10L);
+        final var autoRenewAccountId = toAccountId(0L, 0L, 10L);
         assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID))
                 .satisfies(token ->
                         assertThat(token.autoRenewAccountIdSupplier().get()).isEqualTo(autoRenewAccountId));

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
@@ -185,7 +185,7 @@ class TokenReadableKVStateTest {
                 .returns(databaseToken.getDecimals(), Token::decimals)
                 .returns(entity.getAutoRenewPeriod(), Token::autoRenewSeconds);
 
-        assertThat(token.totalSupplySupplier().get()).isEqualTo(0L);
+        assertThat(token.totalSupplySupplier().get()).isZero();
     }
 
     @Test
@@ -525,15 +525,15 @@ class TokenReadableKVStateTest {
 
         final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
         var results = token.customFeesSupplier().get();
-        var customFee = results.get(0);
-        var resultFee = customFee.royaltyFee();
+        var fee = results.get(0);
+        var resultFee = fee.royaltyFee();
         assertEquals(
                 royaltyFee.getNumerator(), resultFee.exchangeValueFraction().numerator());
         assertEquals(
                 royaltyFee.getDenominator(), resultFee.exchangeValueFraction().denominator());
         assertEquals(
                 0L, resultFee.fallbackFee() != null ? resultFee.fallbackFee().amount() : 0L);
-        assertEquals(collectorAccountId, customFee.feeCollectorAccountId());
+        assertEquals(collectorAccountId, fee.feeCollectorAccountId());
         assertEquals(
                 TokenID.DEFAULT,
                 resultFee.fallbackFee() != null ? resultFee.fallbackFee().denominatingTokenId() : TokenID.DEFAULT);
@@ -561,15 +561,15 @@ class TokenReadableKVStateTest {
 
         final var token = tokenReadableKVState.readFromDataSource(TOKEN_ID);
         var results = token.customFeesSupplier().get();
-        var customFee = results.get(0);
-        var resultFee = customFee.royaltyFee();
+        var fee = results.get(0);
+        var resultFee = fee.royaltyFee();
         assertEquals(
                 royaltyFee.getNumerator(), resultFee.exchangeValueFraction().numerator());
         assertEquals(
                 royaltyFee.getDenominator(), resultFee.exchangeValueFraction().denominator());
         assertEquals(
                 0L, resultFee.fallbackFee() != null ? resultFee.fallbackFee().amount() : 0L);
-        assertEquals(collectorAccountId, customFee.feeCollectorAccountId());
+        assertEquals(collectorAccountId, fee.feeCollectorAccountId());
         assertEquals(
                 TokenID.DEFAULT,
                 resultFee.fallbackFee() != null ? resultFee.fallbackFee().denominatingTokenId() : TokenID.DEFAULT);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
@@ -31,9 +31,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
+import com.hedera.hapi.node.base.AccountID.AccountOneOfType;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.store.models.Id;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -304,6 +306,19 @@ class EntityIdUtilsTest {
                 .alias(Bytes.wrap(entity.getAlias()))
                 .build();
         assertEquals(expectedAccountId, EntityIdUtils.toAccountId(entity));
+    }
+
+    @Test
+    void toAccountIdWithShardRealmAndNum() {
+        final long shard = 0L;
+        final long realm = 0L;
+        final long num = 10L;
+
+        final var accountId = EntityIdUtils.toAccountId(shard, realm, num);
+        final var expectedAccountId =
+                new com.hedera.hapi.node.base.AccountID(shard, realm, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, num));
+
+        assertEquals(expectedAccountId, accountId);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

Adding `TokenReadableKVState` for returning fungible token models into PBJ types, reading from DB.

Added `TokenReadableKVStateTest` which test method in `TokenReadableKVState`

Copied `Token` model from services.
(We need this copy since for some fields we change with Suppliers and we need to modify the hashcode and equals in the copied classes to handle the new supplier changes)

Added `TokenTest` which adds test for all of the Token model methods.

Added couple of utility methods in `CommonEntityAccessor` and `EntityIdUtils`.

Added a new parent class `AbstractStateTest` which has a full token setup logic that is copied from services 






**Related issue(s)**:

Fixes #9252

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
