### PR TITLE
Implement `AliasesReadableKVState `

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -98,6 +98,7 @@ public class EvmConfiguration {
     public static final String CACHE_NAME = "default";
     public static final String CACHE_NAME_CONTRACT = "contract";
     public static final String CACHE_NAME_EVM_ADDRESS = "evmAddress";
+    public static final String CACHE_NAME_ALIAS = "alias";
     public static final String CACHE_NAME_EXCHANGE_RATE = "exchangeRate";
     public static final String CACHE_NAME_FEE_SCHEDULE = "feeSchedule";
     public static final String CACHE_NAME_NFT = "nft";

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -145,7 +145,7 @@ public class EvmConfiguration {
     @Bean(CACHE_MANAGER_ENTITY)
     CacheManager cacheManagerEntity() {
         final CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
-        caffeineCacheManager.setCacheNames(Set.of(CACHE_NAME, CACHE_NAME_EVM_ADDRESS));
+        caffeineCacheManager.setCacheNames(Set.of(CACHE_NAME, CACHE_NAME_EVM_ADDRESS, CACHE_NAME_ALIAS));
         caffeineCacheManager.setCacheSpecification(cacheProperties.getEntity());
         return caffeineCacheManager;
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/EntityRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/EntityRepository.java
@@ -44,7 +44,15 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
             cacheManager = CACHE_MANAGER_ENTITY,
             key = "T(java.util.Arrays).hashCode(#alias)",
             unless = "#result == null")
-    Optional<Entity> findByAliasAndDeletedIsFalse(byte[] alias);
+    @Query(
+            value =
+                    """
+            select *
+            from entity
+            where (evm_address = ?1 or alias = ?1) and deleted is not true
+            """,
+            nativeQuery = true)
+    Optional<Entity> findByEvmAddressOrAlias(byte[] alias);
 
     /**
      * Retrieves the most recent state of an entity by its evm address up to a given block timestamp.
@@ -99,7 +107,7 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
             with entity_cte as (
                 select id
                 from entity
-                where alias = ?1 and created_timestamp <= ?2
+                where (evm_address = ?1 or alias = ?1) and created_timestamp <= ?2
                 order by created_timestamp desc
                 limit 1
             )
@@ -122,7 +130,7 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
             limit 1
             """,
             nativeQuery = true)
-    Optional<Entity> findActiveByAliasAndTimestamp(byte[] alias, long blockTimestamp);
+    Optional<Entity> findActiveByEvmAddressOrAliasAndTimestamp(byte[] alias, long blockTimestamp);
 
     /**
      * Retrieves the most recent state of an entity by its ID up to a given block timestamp.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/EntityRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/EntityRepository.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.web3.repository;
 
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_ENTITY;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_ALIAS;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_EVM_ADDRESS;
 
 import com.hedera.mirror.common.domain.entity.Entity;
@@ -39,7 +40,7 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
     Optional<Entity> findByEvmAddressAndDeletedIsFalse(byte[] alias);
 
     @Cacheable(
-            cacheNames = CACHE_NAME_EVM_ADDRESS,
+            cacheNames = CACHE_NAME_ALIAS,
             cacheManager = CACHE_MANAGER_ENTITY,
             key = "T(java.util.Arrays).hashCode(#alias)",
             unless = "#result == null")

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/EntityRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/EntityRepository.java
@@ -38,6 +38,13 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
             unless = "#result == null")
     Optional<Entity> findByEvmAddressAndDeletedIsFalse(byte[] alias);
 
+    @Cacheable(
+            cacheNames = CACHE_NAME_EVM_ADDRESS,
+            cacheManager = CACHE_MANAGER_ENTITY,
+            key = "T(java.util.Arrays).hashCode(#alias)",
+            unless = "#result == null")
+    Optional<Entity> findByAliasAndDeletedIsFalse(byte[] alias);
+
     /**
      * Retrieves the most recent state of an entity by its evm address up to a given block timestamp.
      *
@@ -76,6 +83,45 @@ public interface EntityRepository extends CrudRepository<Entity, Long> {
             """,
             nativeQuery = true)
     Optional<Entity> findActiveByEvmAddressAndTimestamp(byte[] evmAddress, long blockTimestamp);
+
+    /**
+     * Retrieves the most recent state of an entity by its alias up to a given block timestamp.
+     *
+     * @param alias           the alias of the entity to be retrieved.
+     * @param blockTimestamp  the block timestamp used to filter the results.
+     * @return an Optional containing the entity's state at the specified timestamp.
+     *         If there is no record found for the given criteria, an empty Optional is returned.
+     */
+    @Query(
+            value =
+                    """
+            with entity_cte as (
+                select id
+                from entity
+                where alias = ?1 and created_timestamp <= ?2
+                order by created_timestamp desc
+                limit 1
+            )
+            (
+                select *
+                from entity e
+                where e.deleted is not true
+                and e.id = (select id from entity_cte)
+            )
+            union all
+            (
+                select *
+                from entity_history eh
+                where lower(eh.timestamp_range) <= ?2
+                and eh.id = (select id from entity_cte)
+                order by lower(eh.timestamp_range) desc
+                limit 1
+            )
+            order by timestamp_range desc
+            limit 1
+            """,
+            nativeQuery = true)
+    Optional<Entity> findActiveByAliasAndTimestamp(byte[] alias, long blockTimestamp);
 
     /**
      * Retrieves the most recent state of an entity by its ID up to a given block timestamp.

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.state.spi.ReadableKVStateBase;
+import jakarta.validation.constraints.NotNull;
+import java.util.Collections;
+import java.util.Iterator;
+
+public class AliasesReadableKVState extends ReadableKVStateBase<ProtoBytes, AccountID> {
+
+    private static final String KEY = "ALIASES";
+
+    private final CommonEntityAccessor commonEntityAccessor;
+
+    protected AliasesReadableKVState(final CommonEntityAccessor commonEntityAccessor) {
+        super(KEY);
+        this.commonEntityAccessor = commonEntityAccessor;
+    }
+
+    @Override
+    protected AccountID readFromDataSource(@NotNull ProtoBytes evmAddress) {
+        final var timestamp = ContractCallContext.get().getTimestamp();
+        final var entity = commonEntityAccessor.getEntityByEvmAddressAndTimestamp(
+                evmAddress.value().toByteArray(), timestamp);
+        return entity.map(value -> AccountID.newBuilder()
+                        .shardNum(value.getShard())
+                        .realmNum(value.getRealm())
+                        .alias(Bytes.wrap(value.getAlias()))
+                        .build())
+                .orElse(null);
+    }
+
+    @NotNull
+    @Override
+    protected Iterator<ProtoBytes> iterateFromDataSource() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public long size() {
+        return 0;
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
@@ -16,6 +16,8 @@
 
 package com.hedera.mirror.web3.state;
 
+import static com.hedera.services.utils.EntityIdUtils.toAccountId;
+
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.mirror.web3.common.ContractCallContext;
@@ -39,11 +41,7 @@ public class AliasesReadableKVState extends ReadableKVStateBase<ProtoBytes, Acco
     protected AccountID readFromDataSource(@Nonnull ProtoBytes alias) {
         final var timestamp = ContractCallContext.get().getTimestamp();
         final var entity = commonEntityAccessor.get(alias.value(), timestamp);
-        return entity.map(e -> AccountID.newBuilder()
-                        .shardNum(e.getShard())
-                        .realmNum(e.getRealm())
-                        .accountNum(e.getNum())
-                        .build())
+        return entity.map(e -> toAccountId(e.getShard(), e.getRealm(), e.getNum()))
                 .orElse(null);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
@@ -19,7 +19,6 @@ package com.hedera.mirror.web3.state;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.mirror.web3.common.ContractCallContext;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.spi.ReadableKVStateBase;
 import jakarta.annotation.Nonnull;
 import java.util.Collections;
@@ -42,7 +41,7 @@ public class AliasesReadableKVState extends ReadableKVStateBase<ProtoBytes, Acco
         return entity.map(e -> AccountID.newBuilder()
                         .shardNum(e.getShard())
                         .realmNum(e.getRealm())
-                        .alias(e.getEvmAddress() != null ? Bytes.wrap(e.getEvmAddress()) : alias.value())
+                        .accountNum(e.getNum())
                         .build())
                 .orElse(null);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
@@ -21,9 +21,11 @@ import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.swirlds.state.spi.ReadableKVStateBase;
 import jakarta.annotation.Nonnull;
+import jakarta.inject.Named;
 import java.util.Collections;
 import java.util.Iterator;
 
+@Named
 public class AliasesReadableKVState extends ReadableKVStateBase<ProtoBytes, AccountID> {
 
     private final CommonEntityAccessor commonEntityAccessor;
@@ -36,8 +38,7 @@ public class AliasesReadableKVState extends ReadableKVStateBase<ProtoBytes, Acco
     @Override
     protected AccountID readFromDataSource(@Nonnull ProtoBytes alias) {
         final var timestamp = ContractCallContext.get().getTimestamp();
-        final var entity = commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                alias.value().toByteArray(), timestamp);
+        final var entity = commonEntityAccessor.get(alias.value(), timestamp);
         return entity.map(e -> AccountID.newBuilder()
                         .shardNum(e.getShard())
                         .realmNum(e.getRealm())

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
@@ -21,7 +21,7 @@ import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.spi.ReadableKVStateBase;
-import jakarta.validation.constraints.NotNull;
+import jakarta.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Iterator;
 
@@ -35,7 +35,7 @@ public class AliasesReadableKVState extends ReadableKVStateBase<ProtoBytes, Acco
     }
 
     @Override
-    protected AccountID readFromDataSource(@NotNull ProtoBytes alias) {
+    protected AccountID readFromDataSource(@Nonnull ProtoBytes alias) {
         final var timestamp = ContractCallContext.get().getTimestamp();
         final var entity =
                 commonEntityAccessor.getEntityByAliasAndTimestamp(alias.value().toByteArray(), timestamp);
@@ -47,7 +47,7 @@ public class AliasesReadableKVState extends ReadableKVStateBase<ProtoBytes, Acco
                 .orElse(null);
     }
 
-    @NotNull
+    @Nonnull
     @Override
     protected Iterator<ProtoBytes> iterateFromDataSource() {
         return Collections.emptyIterator();

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
@@ -37,8 +37,8 @@ public class AliasesReadableKVState extends ReadableKVStateBase<ProtoBytes, Acco
     @Override
     protected AccountID readFromDataSource(@Nonnull ProtoBytes alias) {
         final var timestamp = ContractCallContext.get().getTimestamp();
-        final var entity =
-                commonEntityAccessor.getEntityByAliasAndTimestamp(alias.value().toByteArray(), timestamp);
+        final var entity = commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
+                alias.value().toByteArray(), timestamp);
         return entity.map(e -> AccountID.newBuilder()
                         .shardNum(e.getShard())
                         .realmNum(e.getRealm())

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
@@ -27,20 +27,18 @@ import java.util.Iterator;
 
 public class AliasesReadableKVState extends ReadableKVStateBase<ProtoBytes, AccountID> {
 
-    private static final String KEY = "ALIASES";
-
     private final CommonEntityAccessor commonEntityAccessor;
 
     protected AliasesReadableKVState(final CommonEntityAccessor commonEntityAccessor) {
-        super(KEY);
+        super("ALIASES");
         this.commonEntityAccessor = commonEntityAccessor;
     }
 
     @Override
-    protected AccountID readFromDataSource(@NotNull ProtoBytes evmAddress) {
+    protected AccountID readFromDataSource(@NotNull ProtoBytes alias) {
         final var timestamp = ContractCallContext.get().getTimestamp();
-        final var entity = commonEntityAccessor.getEntityByEvmAddressAndTimestamp(
-                evmAddress.value().toByteArray(), timestamp);
+        final var entity =
+                commonEntityAccessor.getEntityByAliasAndTimestamp(alias.value().toByteArray(), timestamp);
         return entity.map(value -> AccountID.newBuilder()
                         .shardNum(value.getShard())
                         .realmNum(value.getRealm())

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AliasesReadableKVState.java
@@ -39,10 +39,10 @@ public class AliasesReadableKVState extends ReadableKVStateBase<ProtoBytes, Acco
         final var timestamp = ContractCallContext.get().getTimestamp();
         final var entity =
                 commonEntityAccessor.getEntityByAliasAndTimestamp(alias.value().toByteArray(), timestamp);
-        return entity.map(value -> AccountID.newBuilder()
-                        .shardNum(value.getShard())
-                        .realmNum(value.getRealm())
-                        .alias(Bytes.wrap(value.getAlias()))
+        return entity.map(e -> AccountID.newBuilder()
+                        .shardNum(e.getShard())
+                        .realmNum(e.getRealm())
+                        .alias(e.getEvmAddress() != null ? Bytes.wrap(e.getEvmAddress()) : alias.value())
                         .build())
                 .orElse(null);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
@@ -46,7 +46,7 @@ public class CommonEntityAccessor {
                 .orElseGet(() -> entityRepository.findByIdAndDeletedIsFalse(entityId.getId()));
     }
 
-    private Optional<Entity> getEntityByEvmAddressAndTimestamp(byte[] addressBytes, final Optional<Long> timestamp) {
+    public Optional<Entity> getEntityByEvmAddressAndTimestamp(byte[] addressBytes, final Optional<Long> timestamp) {
         return timestamp
                 .map(t -> entityRepository.findActiveByEvmAddressAndTimestamp(addressBytes, t))
                 .orElseGet(() -> entityRepository.findByEvmAddressAndDeletedIsFalse(addressBytes));

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
@@ -46,9 +46,15 @@ public class CommonEntityAccessor {
                 .orElseGet(() -> entityRepository.findByIdAndDeletedIsFalse(entityId.getId()));
     }
 
-    public Optional<Entity> getEntityByEvmAddressAndTimestamp(byte[] addressBytes, final Optional<Long> timestamp) {
+    private Optional<Entity> getEntityByEvmAddressAndTimestamp(byte[] addressBytes, final Optional<Long> timestamp) {
         return timestamp
                 .map(t -> entityRepository.findActiveByEvmAddressAndTimestamp(addressBytes, t))
                 .orElseGet(() -> entityRepository.findByEvmAddressAndDeletedIsFalse(addressBytes));
+    }
+
+    public Optional<Entity> getEntityByAliasAndTimestamp(byte[] alias, final Optional<Long> timestamp) {
+        return timestamp
+                .map(t -> entityRepository.findActiveByAliasAndTimestamp(alias, t))
+                .orElseGet(() -> entityRepository.findByAliasAndDeletedIsFalse(alias));
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
@@ -52,9 +52,9 @@ public class CommonEntityAccessor {
                 .orElseGet(() -> entityRepository.findByEvmAddressAndDeletedIsFalse(addressBytes));
     }
 
-    public Optional<Entity> getEntityByAliasAndTimestamp(byte[] alias, final Optional<Long> timestamp) {
+    public Optional<Entity> getEntityByEvmAddressOrAliasAndTimestamp(byte[] alias, final Optional<Long> timestamp) {
         return timestamp
-                .map(t -> entityRepository.findActiveByAliasAndTimestamp(alias, t))
-                .orElseGet(() -> entityRepository.findByAliasAndDeletedIsFalse(alias));
+                .map(t -> entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(alias, t))
+                .orElseGet(() -> entityRepository.findByEvmAddressOrAlias(alias));
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/CommonEntityAccessor.java
@@ -36,7 +36,7 @@ public class CommonEntityAccessor {
         if (accountID.hasAccountNum()) {
             return getEntityByMirrorAddressAndTimestamp(toEntityId(accountID), timestamp);
         } else {
-            return getEntityByEvmAddressAndTimestamp(accountID.alias().toByteArray(), timestamp);
+            return getEntityByEvmAddressOrAliasAndTimestamp(accountID.alias().toByteArray(), timestamp);
         }
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -161,6 +161,12 @@ public final class EntityIdUtils {
         return toAccountId(decodedEntityId);
     }
 
+    public static com.hedera.hapi.node.base.AccountID toAccountId(final long shard, final long realm, final long num) {
+        final var decodedEntityId = EntityId.of(shard, realm, num);
+
+        return toAccountId(decodedEntityId);
+    }
+
     public static com.hedera.hapi.node.base.AccountID toAccountId(final Entity entity) {
         if (entity == null) {
             return com.hedera.hapi.node.base.AccountID.DEFAULT;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/EntityRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/EntityRepositoryTest.java
@@ -257,101 +257,222 @@ class EntityRepositoryTest extends Web3IntegrationTest {
     }
 
     @Test
-    void findByAliasAndDeletedIsFalseSuccess() {
+    void findByEvmAddressOrAliasSuccessWithAlias() {
         final var alias = domainBuilder.key();
-        domainBuilder.entity().customize(e -> e.alias(alias)).persist();
-        assertThat(entityRepository.findByAliasAndDeletedIsFalse(alias)).isNotEmpty();
+        final var entity = domainBuilder.entity().customize(e -> e.alias(alias)).persist();
+        assertThat(entityRepository.findByEvmAddressOrAlias(alias)).get().isEqualTo(entity);
     }
 
     @Test
-    void findByAliasAndDeletedIsFalseReturnsEmptyWhenDeletedIsTrue() {
+    void findByEvmAddressOrAliasSuccessWithEvmAddress() {
+        final var evmAddress = domainBuilder.evmAddress();
+        final var entity =
+                domainBuilder.entity().customize(e -> e.evmAddress(evmAddress)).persist();
+        assertThat(entityRepository.findByEvmAddressOrAlias(evmAddress)).get().isEqualTo(entity);
+    }
+
+    @Test
+    void findByEvmAddressOrAliasReturnsEmptyWhenDeletedIsTrueWithAlias() {
         final var alias = domainBuilder.key();
         domainBuilder.entity().customize(e -> e.alias(alias).deleted(true)).persist();
-        assertThat(entityRepository.findByAliasAndDeletedIsFalse(alias)).isEmpty();
+        assertThat(entityRepository.findByEvmAddressOrAlias(alias)).isEmpty();
     }
 
     @Test
-    void findByAliasAndTimestampRangeLessThanBlockTimestampAndDeletedIsFalseCall() {
-        Entity entity = domainBuilder.entity().persist();
+    void findByEvmAddressOrAliasReturnsEmptyWhenDeletedIsTrueWithEvmAddress() {
+        final var evmAddress = domainBuilder.evmAddress();
+        domainBuilder
+                .entity()
+                .customize(e -> e.evmAddress(evmAddress).deleted(true))
+                .persist();
+        assertThat(entityRepository.findByEvmAddressOrAlias(evmAddress)).isEmpty();
+    }
 
-        assertThat(entityRepository.findActiveByAliasAndTimestamp(entity.getAlias(), entity.getTimestampLower() + 1))
+    @Test
+    void findByEvmAddressOrAliasAndTimestampRangeLessThanBlockTimestampAndDeletedIsFalseCallWithAlias() {
+        final var entity = domainBuilder.entity().persist();
+
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getAlias(), entity.getTimestampLower() + 1))
                 .get()
                 .isEqualTo(entity);
     }
 
     @Test
-    void findByAliasAndTimestampRangeEqualToBlockTimestampAndDeletedIsFalseCall() {
-        Entity entity = domainBuilder.entity().persist();
+    void findByEvmAddressOrAliasAndTimestampRangeLessThanBlockTimestampAndDeletedIsFalseCallWithEvmAddress() {
+        final var entity = domainBuilder.entity().persist();
 
-        assertThat(entityRepository.findActiveByAliasAndTimestamp(entity.getAlias(), entity.getTimestampLower()))
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getEvmAddress(), entity.getTimestampLower() + 1))
                 .get()
                 .isEqualTo(entity);
     }
 
     @Test
-    void findByAliasAndTimestampRangeGreaterThanBlockTimestampAndDeletedIsFalseCall() {
-        Entity entity = domainBuilder.entity().persist();
+    void findByEvmAddressOrAliasAndTimestampRangeEqualToBlockTimestampAndDeletedIsFalseCallWithAlias() {
+        final var entity = domainBuilder.entity().persist();
 
-        assertThat(entityRepository.findActiveByAliasAndTimestamp(entity.getAlias(), entity.getTimestampLower() - 1))
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getAlias(), entity.getTimestampLower()))
+                .get()
+                .isEqualTo(entity);
+    }
+
+    @Test
+    void findByEvmAddressOrAliasAndTimestampRangeEqualToBlockTimestampAndDeletedIsFalseCallWithEvmAddress() {
+        final var entity = domainBuilder.entity().persist();
+
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getEvmAddress(), entity.getTimestampLower()))
+                .get()
+                .isEqualTo(entity);
+    }
+
+    @Test
+    void findByEvmAddressOrAliasAndTimestampRangeGreaterThanBlockTimestampAndDeletedIsFalseCallWithAlias() {
+        final var entity = domainBuilder.entity().persist();
+
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getAlias(), entity.getTimestampLower() - 1))
                 .isEmpty();
     }
 
     @Test
-    void findByAliasAndTimestampRangeLessThanBlockTimestampAndDeletedTrueCall() {
-        Entity entity = domainBuilder.entity().customize(e -> e.deleted(true)).persist();
+    void findByEvmAddressOrAliasAndTimestampRangeGreaterThanBlockTimestampAndDeletedIsFalseCallWithEvmAddress() {
+        final var entity = domainBuilder.entity().persist();
 
-        assertThat(entityRepository.findActiveByAliasAndTimestamp(entity.getAlias(), entity.getTimestampLower() + 1))
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getEvmAddress(), entity.getTimestampLower() - 1))
                 .isEmpty();
     }
 
     @Test
-    void findHistoricalEntityByAliasAndTimestampRangeAndDeletedTrueCall() {
-        EntityHistory entityHistory =
+    void findByEvmAddressOrAliasAndTimestampRangeLessThanBlockTimestampAndDeletedTrueCallWithAlias() {
+        final var entity =
+                domainBuilder.entity().customize(e -> e.deleted(true)).persist();
+
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getAlias(), entity.getTimestampLower() + 1))
+                .isEmpty();
+    }
+
+    @Test
+    void findByEvmAddressOrAliasAndTimestampRangeLessThanBlockTimestampAndDeletedTrueCallWithEvmAddress() {
+        final var entity =
+                domainBuilder.entity().customize(e -> e.deleted(true)).persist();
+
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getEvmAddress(), entity.getTimestampLower() + 1))
+                .isEmpty();
+    }
+
+    @Test
+    void findHistoricalEntityByEvmAddressOrAliasAndTimestampRangeAndDeletedTrueCallWithAlias() {
+        final var entityHistory =
                 domainBuilder.entityHistory().customize(e -> e.deleted(true)).persist();
 
-        assertThat(entityRepository.findActiveByAliasAndTimestamp(
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
                         entityHistory.getAlias(), entityHistory.getTimestampLower() - 1))
                 .isEmpty();
     }
 
     @Test
-    void findHistoricalEntityByAliasAndTimestampRangeGreaterThanBlockTimestampAndDeletedIsFalse() {
-        EntityHistory entityHistory = domainBuilder.entityHistory().persist();
-        Entity entity = domainBuilder
+    void findHistoricalEntityByEvmAddressOrAliasAndTimestampRangeAndDeletedTrueCallWithEvmAddress() {
+        final var entityHistory =
+                domainBuilder.entityHistory().customize(e -> e.deleted(true)).persist();
+
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entityHistory.getEvmAddress(), entityHistory.getTimestampLower() - 1))
+                .isEmpty();
+    }
+
+    @Test
+    void findHistoricalEntityByEvmAddressOrAliasAndTimestampRangeGreaterThanBlockTimestampAndDeletedIsFalseWithAlias() {
+        final var entityHistory = domainBuilder.entityHistory().persist();
+        final var entity = domainBuilder
                 .entity()
                 .customize(e -> e.id(entityHistory.getId()))
                 .persist();
 
-        assertThat(entityRepository.findActiveByAliasAndTimestamp(
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
                         entity.getAlias(), entityHistory.getTimestampLower() - 1))
                 .isEmpty();
     }
 
     @Test
-    void findEntityByAliasAndTimestampRangeEqualToBlockTimestampAndDeletedIsFalse() {
-        EntityHistory entityHistory = domainBuilder.entityHistory().persist();
-
-        // Both entity and entity history will be queried in union but entity record is the latest valid
-        Entity entity = domainBuilder
+    void
+            findHistoricalEntityByEvmAddressOrAliasAndTimestampRangeGreaterThanBlockTimestampAndDeletedIsFalseWithEvmAddress() {
+        final var entityHistory = domainBuilder.entityHistory().persist();
+        final var entity = domainBuilder
                 .entity()
                 .customize(e -> e.id(entityHistory.getId()))
                 .persist();
 
-        assertThat(entityRepository.findActiveByAliasAndTimestamp(entity.getAlias(), entity.getTimestampLower()))
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getEvmAddress(), entityHistory.getTimestampLower() - 1))
+                .isEmpty();
+    }
+
+    @Test
+    void findEntityByEvmAddressOrAliasAndTimestampRangeEqualToBlockTimestampAndDeletedIsFalseWithAlias() {
+        final var entityHistory = domainBuilder.entityHistory().persist();
+
+        // Both entity and entity history will be queried in union but entity record is the latest valid
+        final var entity = domainBuilder
+                .entity()
+                .customize(e -> e.id(entityHistory.getId()))
+                .persist();
+
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getAlias(), entity.getTimestampLower()))
                 .get()
                 .isEqualTo(entity);
     }
 
     @Test
-    void findHistoricalEntityByAliasAndTimestampRangeEqualToBlockTimestampAndDeletedIsFalse() {
-        Entity entity = domainBuilder.entity().persist();
+    void findEntityByEvmAddressOrAliasAndTimestampRangeEqualToBlockTimestampAndDeletedIsFalseWithEvmAddress() {
+        final var entityHistory = domainBuilder.entityHistory().persist();
+
+        // Both entity and entity history will be queried in union but entity record is the latest valid
+        final var entity = domainBuilder
+                .entity()
+                .customize(e -> e.id(entityHistory.getId()))
+                .persist();
+
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getEvmAddress(), entity.getTimestampLower()))
+                .get()
+                .isEqualTo(entity);
+    }
+
+    @Test
+    void findHistoricalEntityByEvmAddressOrAliasAndTimestampRangeEqualToBlockTimestampAndDeletedIsFalseWithAlias() {
+        final var entity = domainBuilder.entity().persist();
         // Both entity and entity history will be queried in union but entity history record is the latest valid
-        EntityHistory entityHistory = domainBuilder
+        final var entityHistory = domainBuilder
                 .entityHistory()
                 .customize(e -> e.id(entity.getId()))
                 .persist();
 
-        assertThat(entityRepository.findActiveByAliasAndTimestamp(entity.getAlias(), entityHistory.getTimestampLower()))
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getAlias(), entityHistory.getTimestampLower()))
+                .get()
+                .usingRecursiveComparison()
+                .isEqualTo(entityHistory);
+    }
+
+    @Test
+    void
+            findHistoricalEntityByEvmAddressOrAliasAndTimestampRangeEqualToBlockTimestampAndDeletedIsFalseWithEvmAddress() {
+        final var entity = domainBuilder.entity().persist();
+        // Both entity and entity history will be queried in union but entity history record is the latest valid
+        final var entityHistory = domainBuilder
+                .entityHistory()
+                .customize(e -> e.id(entity.getId()))
+                .persist();
+
+        assertThat(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        entity.getEvmAddress(), entityHistory.getTimestampLower()))
                 .get()
                 .usingRecursiveComparison()
                 .isEqualTo(entityHistory);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
@@ -42,7 +42,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class AliasesReadableKVStateTest {
+class AliasesReadableKVStateTest {
 
     @InjectMocks
     private AliasesReadableKVState aliasesReadableKVState;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
@@ -28,6 +28,7 @@ import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -117,5 +118,15 @@ public class AliasesReadableKVStateTest {
                 .thenReturn(Optional.empty());
         assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isNull());
+    }
+
+    @Test
+    void getExpectedSize() {
+        assertThat(aliasesReadableKVState.size()).isZero();
+    }
+
+    @Test
+    void iterateFromDataSourceReturnsEmptyIterator() {
+        assertThat(aliasesReadableKVState.iterateFromDataSource()).isEqualTo(Collections.emptyIterator());
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.AccountID.AccountOneOfType;
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
+import com.hedera.mirror.common.domain.entity.Entity;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.pbj.runtime.OneOf;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AliasesReadableKVStateTest {
+
+    @InjectMocks
+    private AliasesReadableKVState aliasesReadableKVState;
+
+    @Spy
+    private ContractCallContext contractCallContext;
+
+    private static MockedStatic<ContractCallContext> contextMockedStatic;
+
+    @Mock
+    private CommonEntityAccessor commonEntityAccessor;
+
+    private static final ProtoBytes EVM_ADDRESS_BYTES = new ProtoBytes(Bytes.wrap(new byte[] {1, 2, 3, 4}));
+    private static final Bytes ALIAS_BYTES = Bytes.wrap(new byte[] {2, 3, 4, 5});
+
+    private static final AccountID ACCOUNT_ID = new AccountID(1L, 0L, new OneOf<>(AccountOneOfType.ALIAS, ALIAS_BYTES));
+
+    private static final Entity ENTITY = Entity.builder()
+            .shard(ACCOUNT_ID.shardNum())
+            .realm(ACCOUNT_ID.realmNum())
+            .evmAddress(EVM_ADDRESS_BYTES.value().toByteArray())
+            .alias(ALIAS_BYTES.toByteArray())
+            .build();
+
+    @BeforeAll
+    static void initStaticMocks() {
+        contextMockedStatic = mockStatic(ContractCallContext.class);
+    }
+
+    @AfterAll
+    static void closeStaticMocks() {
+        contextMockedStatic.close();
+    }
+
+    @BeforeEach
+    void setup() {
+        contextMockedStatic.when(ContractCallContext::get).thenReturn(contractCallContext);
+    }
+
+    @Test
+    void accountNotFoundReturnsNull() {
+        when(commonEntityAccessor.getEntityByEvmAddressAndTimestamp(any(), any()))
+                .thenReturn(Optional.empty());
+        assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
+                .satisfies(accountID -> assertThat(accountID).isNull());
+    }
+
+    @Test
+    void whenTimestampIsNullReturnLatestAccountID() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        when(commonEntityAccessor.getEntityByEvmAddressAndTimestamp(
+                        EVM_ADDRESS_BYTES.value().toByteArray(), Optional.empty()))
+                .thenReturn(Optional.of(ENTITY));
+        assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
+                .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
+    }
+
+    @Test
+    void whenTimestampIsHistoricalReturnCorrectAccountID() {
+        final var blockTimestamp = 1234567L;
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.of(blockTimestamp));
+        when(commonEntityAccessor.getEntityByEvmAddressAndTimestamp(
+                        EVM_ADDRESS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
+                .thenReturn(Optional.of(ENTITY));
+        assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
+                .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
+    }
+
+    @Test
+    void whenTimestampIsLaterReturnNull() {
+        final var blockTimestamp = 1234567L;
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.of(blockTimestamp));
+        when(commonEntityAccessor.getEntityByEvmAddressAndTimestamp(
+                        EVM_ADDRESS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
+                .thenReturn(Optional.empty());
+        assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
+                .satisfies(accountID -> assertThat(accountID).isNull());
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
@@ -62,19 +62,20 @@ class AliasesReadableKVStateTest {
 
     private static final Entity ENTITY_WITH_ALIAS = Entity.builder()
             .shard(1L)
-            .realm(0L)
+            .realm(2L)
+            .num(3L)
             .alias(ALIAS_BYTES.value().toByteArray())
             .build();
 
     private static final Entity ENTITY_WITH_EVM_ADDRESS = Entity.builder()
             .shard(1L)
-            .realm(0L)
+            .realm(2L)
+            .num(3L)
             .alias(EVM_ADDRESS_BYTES.value().toByteArray())
             .build();
 
-    private static final AccountID ACCOUNT_ID_WITH_ALIAS = toAccountId(ENTITY_WITH_ALIAS);
-
-    private static final AccountID ACCOUNT_ID_WITH_EVM_ADDRESS = toAccountId(ENTITY_WITH_EVM_ADDRESS);
+    private static final AccountID ACCOUNT_ID =
+            toAccountId(ENTITY_WITH_ALIAS.getShard(), ENTITY_WITH_ALIAS.getRealm(), ENTITY_WITH_ALIAS.getNum());
 
     @BeforeAll
     static void initStaticMocks() {
@@ -114,7 +115,7 @@ class AliasesReadableKVStateTest {
                         ALIAS_BYTES.value().toByteArray(), Optional.empty()))
                 .thenReturn(Optional.of(ENTITY_WITH_ALIAS));
         assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
-                .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID_WITH_ALIAS));
+                .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
     }
 
     @Test
@@ -124,7 +125,7 @@ class AliasesReadableKVStateTest {
                         EVM_ADDRESS_BYTES.value().toByteArray(), Optional.empty()))
                 .thenReturn(Optional.of(ENTITY_WITH_EVM_ADDRESS));
         assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
-                .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID_WITH_EVM_ADDRESS));
+                .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
     }
 
     @Test
@@ -135,7 +136,7 @@ class AliasesReadableKVStateTest {
                         ALIAS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
                 .thenReturn(Optional.of(ENTITY_WITH_ALIAS));
         assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
-                .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID_WITH_ALIAS));
+                .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
     }
 
     @Test
@@ -146,7 +147,7 @@ class AliasesReadableKVStateTest {
                         EVM_ADDRESS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
                 .thenReturn(Optional.of(ENTITY_WITH_EVM_ADDRESS));
         assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
-                .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID_WITH_EVM_ADDRESS));
+                .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
@@ -54,16 +54,15 @@ public class AliasesReadableKVStateTest {
     @Mock
     private CommonEntityAccessor commonEntityAccessor;
 
-    private static final ProtoBytes EVM_ADDRESS_BYTES = new ProtoBytes(Bytes.wrap(new byte[] {1, 2, 3, 4}));
-    private static final Bytes ALIAS_BYTES = Bytes.wrap(new byte[] {2, 3, 4, 5});
+    private static final ProtoBytes ALIAS_BYTES = new ProtoBytes(Bytes.wrap(new byte[] {2, 3, 4, 5}));
 
-    private static final AccountID ACCOUNT_ID = new AccountID(1L, 0L, new OneOf<>(AccountOneOfType.ALIAS, ALIAS_BYTES));
+    private static final AccountID ACCOUNT_ID =
+            new AccountID(1L, 0L, new OneOf<>(AccountOneOfType.ALIAS, ALIAS_BYTES.value()));
 
     private static final Entity ENTITY = Entity.builder()
             .shard(ACCOUNT_ID.shardNum())
             .realm(ACCOUNT_ID.realmNum())
-            .evmAddress(EVM_ADDRESS_BYTES.value().toByteArray())
-            .alias(ALIAS_BYTES.toByteArray())
+            .alias(ALIAS_BYTES.value().toByteArray())
             .build();
 
     @BeforeAll
@@ -83,19 +82,18 @@ public class AliasesReadableKVStateTest {
 
     @Test
     void accountNotFoundReturnsNull() {
-        when(commonEntityAccessor.getEntityByEvmAddressAndTimestamp(any(), any()))
-                .thenReturn(Optional.empty());
-        assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
+        when(commonEntityAccessor.getEntityByAliasAndTimestamp(any(), any())).thenReturn(Optional.empty());
+        assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isNull());
     }
 
     @Test
     void whenTimestampIsNullReturnLatestAccountID() {
         when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
-        when(commonEntityAccessor.getEntityByEvmAddressAndTimestamp(
-                        EVM_ADDRESS_BYTES.value().toByteArray(), Optional.empty()))
+        when(commonEntityAccessor.getEntityByAliasAndTimestamp(
+                        ALIAS_BYTES.value().toByteArray(), Optional.empty()))
                 .thenReturn(Optional.of(ENTITY));
-        assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
+        assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
     }
 
@@ -103,10 +101,10 @@ public class AliasesReadableKVStateTest {
     void whenTimestampIsHistoricalReturnCorrectAccountID() {
         final var blockTimestamp = 1234567L;
         when(contractCallContext.getTimestamp()).thenReturn(Optional.of(blockTimestamp));
-        when(commonEntityAccessor.getEntityByEvmAddressAndTimestamp(
-                        EVM_ADDRESS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
+        when(commonEntityAccessor.getEntityByAliasAndTimestamp(
+                        ALIAS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
                 .thenReturn(Optional.of(ENTITY));
-        assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
+        assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
     }
 
@@ -114,10 +112,10 @@ public class AliasesReadableKVStateTest {
     void whenTimestampIsLaterReturnNull() {
         final var blockTimestamp = 1234567L;
         when(contractCallContext.getTimestamp()).thenReturn(Optional.of(blockTimestamp));
-        when(commonEntityAccessor.getEntityByEvmAddressAndTimestamp(
-                        EVM_ADDRESS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
+        when(commonEntityAccessor.getEntityByAliasAndTimestamp(
+                        ALIAS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
                 .thenReturn(Optional.empty());
-        assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
+        assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isNull());
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AliasesReadableKVStateTest.java
@@ -94,16 +94,14 @@ class AliasesReadableKVStateTest {
 
     @Test
     void accountNotFoundReturnsNullWithAlias() {
-        when(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(any(), any()))
-                .thenReturn(Optional.empty());
+        when(commonEntityAccessor.get(any(Bytes.class), any())).thenReturn(Optional.empty());
         assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isNull());
     }
 
     @Test
     void accountNotFoundReturnsNullWithEvmAddress() {
-        when(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(any(), any()))
-                .thenReturn(Optional.empty());
+        when(commonEntityAccessor.get(any(Bytes.class), any())).thenReturn(Optional.empty());
         assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isNull());
     }
@@ -111,8 +109,7 @@ class AliasesReadableKVStateTest {
     @Test
     void whenTimestampIsNullReturnLatestAccountIDWithAlias() {
         when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
-        when(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        ALIAS_BYTES.value().toByteArray(), Optional.empty()))
+        when(commonEntityAccessor.get(ALIAS_BYTES.value(), Optional.empty()))
                 .thenReturn(Optional.of(ENTITY_WITH_ALIAS));
         assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
@@ -121,8 +118,7 @@ class AliasesReadableKVStateTest {
     @Test
     void whenTimestampIsNullReturnLatestAccountIDWithEvmAddress() {
         when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
-        when(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        EVM_ADDRESS_BYTES.value().toByteArray(), Optional.empty()))
+        when(commonEntityAccessor.get(EVM_ADDRESS_BYTES.value(), Optional.empty()))
                 .thenReturn(Optional.of(ENTITY_WITH_EVM_ADDRESS));
         assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
@@ -132,8 +128,7 @@ class AliasesReadableKVStateTest {
     void whenTimestampIsHistoricalReturnCorrectAccountIDWithAlias() {
         final var blockTimestamp = 1234567L;
         when(contractCallContext.getTimestamp()).thenReturn(Optional.of(blockTimestamp));
-        when(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        ALIAS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
+        when(commonEntityAccessor.get(ALIAS_BYTES.value(), Optional.of(blockTimestamp)))
                 .thenReturn(Optional.of(ENTITY_WITH_ALIAS));
         assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
@@ -143,8 +138,7 @@ class AliasesReadableKVStateTest {
     void whenTimestampIsHistoricalReturnCorrectAccountIDWithEvmAddress() {
         final var blockTimestamp = 1234567L;
         when(contractCallContext.getTimestamp()).thenReturn(Optional.of(blockTimestamp));
-        when(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        EVM_ADDRESS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
+        when(commonEntityAccessor.get(EVM_ADDRESS_BYTES.value(), Optional.of(blockTimestamp)))
                 .thenReturn(Optional.of(ENTITY_WITH_EVM_ADDRESS));
         assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isEqualTo(ACCOUNT_ID));
@@ -154,8 +148,7 @@ class AliasesReadableKVStateTest {
     void whenTimestampIsLaterReturnNullWithAlias() {
         final var blockTimestamp = 1234567L;
         when(contractCallContext.getTimestamp()).thenReturn(Optional.of(blockTimestamp));
-        when(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        ALIAS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
+        when(commonEntityAccessor.get(ALIAS_BYTES.value(), Optional.of(blockTimestamp)))
                 .thenReturn(Optional.empty());
         assertThat(aliasesReadableKVState.get(ALIAS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isNull());
@@ -165,8 +158,7 @@ class AliasesReadableKVStateTest {
     void whenTimestampIsLaterReturnNullWithEvmAddress() {
         final var blockTimestamp = 1234567L;
         when(contractCallContext.getTimestamp()).thenReturn(Optional.of(blockTimestamp));
-        when(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        EVM_ADDRESS_BYTES.value().toByteArray(), Optional.of(blockTimestamp)))
+        when(commonEntityAccessor.get(EVM_ADDRESS_BYTES.value(), Optional.of(blockTimestamp)))
                 .thenReturn(Optional.empty());
         assertThat(aliasesReadableKVState.get(EVM_ADDRESS_BYTES))
                 .satisfies(accountID -> assertThat(accountID).isNull());

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/CommonEntityAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/CommonEntityAccessorTest.java
@@ -122,8 +122,7 @@ class CommonEntityAccessorTest {
                         ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray()))
                 .thenReturn(Optional.of(mockEntity));
 
-        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), Optional.empty()))
+        assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias(), Optional.empty()))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }
 
@@ -133,8 +132,7 @@ class CommonEntityAccessorTest {
                         ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), timestamp.get()))
                 .thenReturn(Optional.of(mockEntity));
 
-        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), timestamp))
+        assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias(), timestamp))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }
 
@@ -144,8 +142,7 @@ class CommonEntityAccessorTest {
                         ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray()))
                 .thenReturn(Optional.of(mockEntity));
 
-        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray(), Optional.empty()))
+        assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS_WITH_KEY.alias(), Optional.empty()))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }
 
@@ -155,8 +152,7 @@ class CommonEntityAccessorTest {
                         ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray(), timestamp.get()))
                 .thenReturn(Optional.of(mockEntity));
 
-        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray(), timestamp))
+        assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS_WITH_KEY.alias(), timestamp))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/CommonEntityAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/CommonEntityAccessorTest.java
@@ -38,10 +38,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class CommonEntityAccessorTest {
-    private static final String ALIAS_HEX = "0x67d8d32e9bf1a9968a5ff53b87d777aa8ebbee69";
-    private static final Address ALIAS_ADDRESS = Address.fromHexString(ALIAS_HEX);
-    private static final AccountID ACCOUNT_ALIAS =
-            new AccountID(0L, 1L, new OneOf<>(AccountOneOfType.ALIAS, Bytes.wrap(ALIAS_ADDRESS.toArray())));
+    private static final String EVM_ADDRESS_HEX = "0x67d8d32e9bf1a9968a5ff53b87d777aa8ebbee69";
+    private static final Address EVM_ADDRESS = Address.fromHexString(EVM_ADDRESS_HEX);
+    private static final AccountID ACCOUNT_ALIAS_WITH_EVM_ADDRESS =
+            new AccountID(0L, 1L, new OneOf<>(AccountOneOfType.ALIAS, Bytes.wrap(EVM_ADDRESS.toArray())));
+    private static final String ALIAS_HEX = "3a2102b3c641418e89452cd5202adfd4758f459acb8e364f741fd16cd2db79835d39d2";
+    private static final AccountID ACCOUNT_ALIAS_WITH_KEY =
+            new AccountID(0L, 1L, new OneOf<>(AccountOneOfType.ALIAS, Bytes.wrap(ALIAS_HEX.getBytes())));
     private static final Long NUM = 1252L;
     private static final AccountID ACCOUNT_ID = new AccountID(0L, 1L, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, NUM));
     private static final Optional<Long> timestamp = Optional.of(1234L);
@@ -76,41 +79,64 @@ class CommonEntityAccessorTest {
     @Test
     void getEntityByEvmAddress() {
         when(entityRepository.findByEvmAddressAndDeletedIsFalse(
-                        ACCOUNT_ALIAS.alias().toByteArray()))
+                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray()))
                 .thenReturn(Optional.of(mockEntity));
 
-        assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS, Optional.empty()))
+        assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS_WITH_EVM_ADDRESS, Optional.empty()))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }
 
     @Test
     void getEntityByEvmAddressHistorical() {
         when(entityRepository.findActiveByEvmAddressAndTimestamp(
-                        ACCOUNT_ALIAS.alias().toByteArray(), timestamp.get()))
+                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), timestamp.get()))
                 .thenReturn(Optional.of(mockEntity));
 
-        assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS, timestamp))
+        assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS_WITH_EVM_ADDRESS, timestamp))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }
 
     @Test
     void getEntityByAlias() {
-        when(entityRepository.findByAliasAndDeletedIsFalse(ACCOUNT_ALIAS.alias().toByteArray()))
+        when(entityRepository.findByEvmAddressOrAlias(
+                        ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray()))
                 .thenReturn(Optional.of(mockEntity));
 
-        assertThat(commonEntityAccessor.getEntityByAliasAndTimestamp(
-                        ACCOUNT_ALIAS.alias().toByteArray(), Optional.empty()))
+        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray(), Optional.empty()))
+                .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
+    }
+
+    @Test
+    void getEntityByEvmAddressAlias() {
+        when(entityRepository.findByEvmAddressOrAlias(
+                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray()))
+                .thenReturn(Optional.of(mockEntity));
+
+        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), Optional.empty()))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }
 
     @Test
     void getEntityByAliasAndTimestampHistorical() {
-        when(entityRepository.findActiveByAliasAndTimestamp(
-                        ACCOUNT_ALIAS.alias().toByteArray(), timestamp.get()))
+        when(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray(), timestamp.get()))
                 .thenReturn(Optional.of(mockEntity));
 
-        assertThat(commonEntityAccessor.getEntityByAliasAndTimestamp(
-                        ACCOUNT_ALIAS.alias().toByteArray(), timestamp))
+        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray(), timestamp))
+                .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
+    }
+
+    @Test
+    void getEntityByEvmAddressAliasAndTimestampHistorical() {
+        when(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), timestamp.get()))
+                .thenReturn(Optional.of(mockEntity));
+
+        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), timestamp))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/CommonEntityAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/CommonEntityAccessorTest.java
@@ -78,7 +78,7 @@ class CommonEntityAccessorTest {
 
     @Test
     void getEntityByEvmAddress() {
-        when(entityRepository.findByEvmAddressAndDeletedIsFalse(
+        when(entityRepository.findByEvmAddressOrAlias(
                         ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray()))
                 .thenReturn(Optional.of(mockEntity));
 
@@ -88,7 +88,7 @@ class CommonEntityAccessorTest {
 
     @Test
     void getEntityByEvmAddressHistorical() {
-        when(entityRepository.findActiveByEvmAddressAndTimestamp(
+        when(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
                         ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), timestamp.get()))
                 .thenReturn(Optional.of(mockEntity));
 
@@ -102,13 +102,22 @@ class CommonEntityAccessorTest {
                         ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray()))
                 .thenReturn(Optional.of(mockEntity));
 
-        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
-                        ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray(), Optional.empty()))
+        assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS_WITH_KEY, Optional.empty()))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }
 
     @Test
-    void getEntityByEvmAddressAlias() {
+    void getEntityByAliasHistorical() {
+        when(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray(), timestamp.get()))
+                .thenReturn(Optional.of(mockEntity));
+
+        assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS_WITH_KEY, timestamp))
+                .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
+    }
+
+    @Test
+    void getEntityByEvmAddressOrAliasAndTimestampWithEvmAddress() {
         when(entityRepository.findByEvmAddressOrAlias(
                         ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray()))
                 .thenReturn(Optional.of(mockEntity));
@@ -119,7 +128,29 @@ class CommonEntityAccessorTest {
     }
 
     @Test
-    void getEntityByAliasAndTimestampHistorical() {
+    void getEntityByEvmAddressOrAliasAndTimestampWithEvmAddressHistorical() {
+        when(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), timestamp.get()))
+                .thenReturn(Optional.of(mockEntity));
+
+        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), timestamp))
+                .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
+    }
+
+    @Test
+    void getEntityByEvmAddressOrAliasAndTimestampWithKey() {
+        when(entityRepository.findByEvmAddressOrAlias(
+                        ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray()))
+                .thenReturn(Optional.of(mockEntity));
+
+        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray(), Optional.empty()))
+                .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
+    }
+
+    @Test
+    void getEntityByEvmAddressOrAliasAndTimestampWithKeyHistorical() {
         when(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
                         ACCOUNT_ALIAS_WITH_KEY.alias().toByteArray(), timestamp.get()))
                 .thenReturn(Optional.of(mockEntity));
@@ -130,12 +161,23 @@ class CommonEntityAccessorTest {
     }
 
     @Test
-    void getEntityByEvmAddressAliasAndTimestampHistorical() {
-        when(entityRepository.findActiveByEvmAddressOrAliasAndTimestamp(
+    void getEntityByEvmAddressAndTimestamp() {
+        when(entityRepository.findByEvmAddressAndDeletedIsFalse(
+                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray()))
+                .thenReturn(Optional.of(mockEntity));
+
+        assertThat(commonEntityAccessor.getEntityByEvmAddressAndTimestamp(
+                        ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), Optional.empty()))
+                .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
+    }
+
+    @Test
+    void getEntityByEvmAddressAndTimestampHistorical() {
+        when(entityRepository.findActiveByEvmAddressAndTimestamp(
                         ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), timestamp.get()))
                 .thenReturn(Optional.of(mockEntity));
 
-        assertThat(commonEntityAccessor.getEntityByEvmAddressOrAliasAndTimestamp(
+        assertThat(commonEntityAccessor.getEntityByEvmAddressAndTimestamp(
                         ACCOUNT_ALIAS_WITH_EVM_ADDRESS.alias().toByteArray(), timestamp))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/CommonEntityAccessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/CommonEntityAccessorTest.java
@@ -74,7 +74,7 @@ class CommonEntityAccessorTest {
     }
 
     @Test
-    void getEntityByAlias() {
+    void getEntityByEvmAddress() {
         when(entityRepository.findByEvmAddressAndDeletedIsFalse(
                         ACCOUNT_ALIAS.alias().toByteArray()))
                 .thenReturn(Optional.of(mockEntity));
@@ -84,12 +84,33 @@ class CommonEntityAccessorTest {
     }
 
     @Test
-    void getEntityByAliasHistorical() {
+    void getEntityByEvmAddressHistorical() {
         when(entityRepository.findActiveByEvmAddressAndTimestamp(
                         ACCOUNT_ALIAS.alias().toByteArray(), timestamp.get()))
                 .thenReturn(Optional.of(mockEntity));
 
         assertThat(commonEntityAccessor.get(ACCOUNT_ALIAS, timestamp))
+                .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
+    }
+
+    @Test
+    void getEntityByAlias() {
+        when(entityRepository.findByAliasAndDeletedIsFalse(ACCOUNT_ALIAS.alias().toByteArray()))
+                .thenReturn(Optional.of(mockEntity));
+
+        assertThat(commonEntityAccessor.getEntityByAliasAndTimestamp(
+                        ACCOUNT_ALIAS.alias().toByteArray(), Optional.empty()))
+                .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
+    }
+
+    @Test
+    void getEntityByAliasAndTimestampHistorical() {
+        when(entityRepository.findActiveByAliasAndTimestamp(
+                        ACCOUNT_ALIAS.alias().toByteArray(), timestamp.get()))
+                .thenReturn(Optional.of(mockEntity));
+
+        assertThat(commonEntityAccessor.getEntityByAliasAndTimestamp(
+                        ACCOUNT_ALIAS.alias().toByteArray(), timestamp))
                 .hasValueSatisfying(entity -> assertThat(entity).isEqualTo(mockEntity));
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
@@ -266,6 +266,16 @@ class EntityIdUtilsTest {
     }
 
     @Test
+    void toAccountIdFromShardRealmNum() {
+        final var expectedAccountId = com.hedera.hapi.node.base.AccountID.newBuilder()
+                .shardNum(1)
+                .realmNum(2)
+                .accountNum(3)
+                .build();
+        assertEquals(expectedAccountId, EntityIdUtils.toAccountId(1, 2, 3));
+    }
+
+    @Test
     void toAccountIdFromEntityWithNoAlias() {
         final var domainBuilder = new DomainBuilder();
         final var entity = domainBuilder.entity().get();


### PR DESCRIPTION
**Description**:
As part of the implementation for the reusable services we need to implement `AliasesReadableKVState`. It reads the entity alias and converts it to `AccountID` PBJ type. In order to achieve this we need a new DB query that executes a select statement by evm address or alias.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/9256

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
