### PR TITLE
Bump express from 4.2.0 to 4.2.1

### DIFF
--- a/hedera-mirror-rest/monitoring/package-lock.json
+++ b/hedera-mirror-rest/monitoring/package-lock.json
@@ -12,7 +12,7 @@
         "abort-controller": "^3.0.0",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
-        "express": "^4.21.0",
+        "express": "^4.21.1",
         "extend": "^3.0.2",
         "extensionless": "^1.9.9",
         "lodash": "^4.17.21",
@@ -1721,9 +1721,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2046,16 +2046,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",

--- a/hedera-mirror-rest/monitoring/package.json
+++ b/hedera-mirror-rest/monitoring/package.json
@@ -19,7 +19,7 @@
     "abort-controller": "^3.0.0",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
-    "express": "^4.21.0",
+    "express": "^4.21.1",
     "extend": "^3.0.2",
     "extensionless": "^1.9.9",
     "lodash": "^4.17.21",

--- a/hedera-mirror-rest/package-lock.json
+++ b/hedera-mirror-rest/package-lock.json
@@ -50,7 +50,7 @@
         "asn1js": "^3.0.5",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
-        "express": "^4.21.0",
+        "express": "^4.21.1",
         "express-http-context": "^1.2.4",
         "express-openapi-validator": "^5.3.7",
         "extend": "^3.0.2",
@@ -5230,9 +5230,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "inBundle": true,
       "engines": {
         "node": ">= 0.6"
@@ -6496,9 +6496,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "inBundle": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -6506,7 +6506,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",

--- a/hedera-mirror-rest/package.json
+++ b/hedera-mirror-rest/package.json
@@ -26,7 +26,7 @@
     "asn1js": "^3.0.5",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
-    "express": "^4.21.0",
+    "express": "^4.21.1",
     "express-http-context": "^1.2.4",
     "express-openapi-validator": "^5.3.7",
     "extend": "^3.0.2",


### PR DESCRIPTION
**Description**:

Bump express from 4.2.0 to 4.2.1 to fix security issue in `cookie` lib

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
