### PR TITLE
Add acceptance tests for NFT  airdrop

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/MirrorNodeClient.java
@@ -41,6 +41,7 @@ import com.hedera.mirror.rest.model.NetworkStakeResponse;
 import com.hedera.mirror.rest.model.Nft;
 import com.hedera.mirror.rest.model.NftAllowancesResponse;
 import com.hedera.mirror.rest.model.NftTransactionHistory;
+import com.hedera.mirror.rest.model.Nfts;
 import com.hedera.mirror.rest.model.Schedule;
 import com.hedera.mirror.rest.model.TokenAirdropsResponse;
 import com.hedera.mirror.rest.model.TokenAllowancesResponse;
@@ -221,6 +222,11 @@ public class MirrorNodeClient {
                 accountId,
                 tokenId,
                 spenderId);
+    }
+
+    public Nfts getAccountsNftInfo(@NonNull AccountId accountId) {
+        log.debug("Retrieving account nft info for '{}' returned by Mirror Node", accountId);
+        return callRestEndpoint("/accounts/{accountId}/nfts", Nfts.class, accountId.toString());
     }
 
     public TokenAllowancesResponse getAccountTokenAllowanceBySpender(

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/client/TokenClient.java
@@ -689,7 +689,7 @@ public class TokenClient extends AbstractNetworkClient {
     }
 
     public NetworkTransactionResponse executeNftAirdrop(
-            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, int serialNumber) {
+            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, long serialNumber) {
         var transaction =
                 getNftAirdropTransaction(tokenId, sender.getAccountId(), receiver.getAccountId(), serialNumber);
         var response = executeTransactionAndRetrieveReceipt(transaction, KeyList.of(sender.getPrivateKey()), sender);
@@ -784,7 +784,7 @@ public class TokenClient extends AbstractNetworkClient {
     }
 
     private TokenAirdropTransaction getNftAirdropTransaction(
-            TokenId tokenId, AccountId sender, AccountId recipient, int serialNumber) {
+            TokenId tokenId, AccountId sender, AccountId recipient, long serialNumber) {
         var airdropTransaction = new TokenAirdropTransaction().setTransactionMemo(getMemo("Airdrop Nft"));
         var nftId = new NftId(tokenId, serialNumber);
         return airdropTransaction.addNftTransfer(nftId, sender, recipient);

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -501,6 +501,13 @@ public class TokenFeature extends AbstractFeature {
         assertThat(networkTransactionResponse.getReceipt()).isNotNull();
     }
 
+    @Then("I airdrop serial number {int} to {account}")
+    public void airdropNonFungibleToken(int serialNumber, AccountNameEnum accountName) {
+        var receiver = accountClient.getAccount(accountName);
+        var sender = accountClient.getSdkClient().getExpandedOperatorAccountId();
+        networkTransactionResponse = verify(tokenClient.executeNftAirdrop(tokenId, sender, receiver, serialNumber));
+    }
+
     @RetryAsserts
     @Then(
             "the mirror node REST API should return the transaction {account} returns serial number index {int} to {account}")
@@ -737,13 +744,13 @@ public class TokenFeature extends AbstractFeature {
     public void airdropTokens(int amount, AccountNameEnum accountName) {
         var receiver = accountClient.getAccount(accountName);
         var sender = accountClient.getSdkClient().getExpandedOperatorAccountId();
-        networkTransactionResponse = verify(tokenClient.executeFungibleTokenAirdrop(tokenId, sender, receiver.getAccountId(), amount));
+        networkTransactionResponse =
+                verify(tokenClient.executeFungibleTokenAirdrop(tokenId, sender, receiver.getAccountId(), amount));
     }
 
     @RetryAsserts
     @Then("I verify {string} airdrop of {int} tokens to {account}")
-    public void verifyFungibleTokenAirdrop(
-            String status, int amount, AccountNameEnum receiverName) {
+    public void verifyFungibleTokenAirdrop(String status, int amount, AccountNameEnum receiverName) {
         var receiver = accountClient.getAccount(receiverName);
         var sender = accountClient.getAccount(AccountNameEnum.OPERATOR);
 
@@ -755,11 +762,35 @@ public class TokenFeature extends AbstractFeature {
         }
     }
 
+    @RetryAsserts
+    @Then("I verify {string} airdrop of serial number {int} to {account}")
+    public void verifyNftTokenAirdrop(String status, int serialNumber, AccountNameEnum receiverName) {
+        var receiver = accountClient.getAccount(receiverName);
+        var sender = accountClient.getAccount(AccountNameEnum.OPERATOR);
+
+        switch (status) {
+            case "successful" -> verifySuccessfulNFTAirdrop(tokenId, sender, receiver, serialNumber);
+            case "pending" -> verifyPendingNftAirdrop(tokenId, sender, receiver, serialNumber);
+            case "cancelled" -> verifyCancelledNftAirdrop(tokenId, sender, receiver, serialNumber);
+            default -> throw new IllegalArgumentException("Invalid airdrop status");
+        }
+    }
+
     @Then("I cancel the airdrop to {account}")
     public void cancelPendingFungibleTokenAirdrop(AccountNameEnum accountName) {
         var receiver = accountClient.getAccount(accountName);
         var sender = accountClient.getSdkClient().getExpandedOperatorAccountId();
-        networkTransactionResponse = verify(tokenClient.executeCancelTokenAirdrop(sender, receiver.getAccountId(), tokenId));
+        networkTransactionResponse =
+                verify(tokenClient.executeCancelTokenAirdrop(sender, receiver.getAccountId(), tokenId));
+    }
+
+    @Then("I cancel the NFT with serial number {int} airdrop to {account}")
+    public void cancelNftPendingAirdrop(int serialNumber, AccountNameEnum accountName) {
+        var receiver = accountClient.getAccount(accountName);
+        var sender = accountClient.getSdkClient().getExpandedOperatorAccountId();
+        var nftId = new NftId(tokenId, serialNumber);
+        networkTransactionResponse =
+                verify(tokenClient.executeCancelNftAirdrop(sender, receiver.getAccountId(), nftId));
     }
 
     @Then("{account} claims the airdrop")
@@ -767,6 +798,14 @@ public class TokenFeature extends AbstractFeature {
         var receiver = accountClient.getAccount(accountName);
         var sender = accountClient.getSdkClient().getExpandedOperatorAccountId();
         networkTransactionResponse = verify(tokenClient.executeClaimTokenAirdrop(sender, receiver, tokenId));
+    }
+
+    @Then("{account} claims airdrop for NFT with serial number {int}")
+    public void claimPendingNftAirdrop(AccountNameEnum accountName, int serialNumber) {
+        var receiver = accountClient.getAccount(accountName);
+        var sender = accountClient.getSdkClient().getExpandedOperatorAccountId();
+        var nftId = new NftId(tokenId, serialNumber);
+        networkTransactionResponse = verify(tokenClient.executeClaimNftAirdrop(sender, receiver, nftId));
     }
 
     private void associateWithToken(ExpandedAccountId accountId, TokenId tokenId) {
@@ -1179,16 +1218,79 @@ public class TokenFeature extends AbstractFeature {
         assertThat(getTokenBalance(receiver.getAccountId(), tokenId)).isEqualTo(amount);
     }
 
+    private void verifySuccessfulNFTAirdrop(
+            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, int serialNumber) {
+        assertThat(getPendingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId()))
+                .isNull();
+        assertThat(getOutstandingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId()))
+                .isNull();
+        // Call the REST api to get the token relationship
+        var tokenRelationshipReceiver = mirrorClient.getTokenRelationships(receiver.getAccountId(), tokenId);
+        assertThat(tokenRelationshipReceiver.getTokens())
+                .hasSize(1)
+                .first()
+                .returns(tokenId.toString(), TokenRelationship::getTokenId);
+        var nftInfo = mirrorClient.getNftInfo(tokenId.toString(), serialNumber);
+        assertThat(nftInfo.getAccountId()).isEqualTo(receiver.toString());
+        assertThat(getNftAccountRelationship(receiver, tokenId, serialNumber)).isNotNull();
+        assertThat(getNftAccountRelationship(sender, tokenId, serialNumber)).isNull();
+    }
+
+    private void verifyPendingNftAirdrop(
+            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, int serialNumber) {
+        // Call the REST API to get the pending airdrops for the receiver
+        var pendingAirdropForToken = getPendingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId());
+        verifyTokenAirdrop(pendingAirdropForToken, sender.getAccountId(), receiver.getAccountId(), tokenId);
+        assertThat(pendingAirdropForToken.getSerialNumber()).isEqualTo(serialNumber);
+        // Call the REST API to get the outstanding airdrops for the sender
+        var outstandingAirdropForToken = getOutstandingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId());
+        verifyTokenAirdrop(outstandingAirdropForToken, sender.getAccountId(), receiver.getAccountId(), tokenId);
+        assertThat(outstandingAirdropForToken.getSerialNumber()).isEqualTo(serialNumber);
+        // Call the REST api to get the nft info
+        var nftInfo = mirrorClient.getNftInfo(tokenId.toString(), serialNumber);
+        assertThat(nftInfo.getAccountId()).isEqualTo(sender.toString());
+        assertThat(getNftAccountRelationship(sender, tokenId, serialNumber)).isNotNull();
+        // Call the REST api to get the token relationship
+        var tokenRelationshipSender = mirrorClient.getTokenRelationships(sender.getAccountId(), tokenId);
+        var tokenRelationshipReceiver = mirrorClient.getTokenRelationships(receiver.getAccountId(), tokenId);
+        assertThat(tokenRelationshipSender.getTokens())
+                .hasSize(1)
+                .first()
+                .returns(tokenId.toString(), TokenRelationship::getTokenId);
+        assertThat(tokenRelationshipReceiver.getTokens()).isEmpty();
+    }
+
+    private void verifyCancelledNftAirdrop(
+            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, int serialNumber) {
+        assertThat(getPendingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId()))
+                .isNull();
+        assertThat(getOutstandingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId()))
+                .isNull();
+        // Call the REST api to get the token relationship
+        var tokenRelationshipReceiver = mirrorClient.getTokenRelationships(receiver.getAccountId(), tokenId);
+        assertThat(tokenRelationshipReceiver.getTokens()).isEmpty();
+        var nftInfo = mirrorClient.getNftInfo(tokenId.toString(), serialNumber);
+        assertThat(nftInfo.getAccountId()).isEqualTo(sender.toString());
+        assertThat(getNftAccountRelationship(sender, tokenId, serialNumber)).isNotNull();
+        assertThat(getNftAccountRelationship(receiver, tokenId, serialNumber)).isNull();
+    }
+
+    private Nft getNftAccountRelationship(ExpandedAccountId owner, TokenId tokenId, long serialNumber) {
+        return mirrorClient.getAccountsNftInfo(owner.getAccountId()).getNfts().stream()
+                .filter(nft -> nft.getTokenId().equals(tokenId.toString())
+                        && nft.getSerialNumber().equals(serialNumber))
+                .findFirst()
+                .orElse(null);
+    }
+
     private void verifyPendingAirdrop(
             TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, long amount) {
         // Call the REST API to get the pending airdrops for the receiver
-        var pendingAirdropForToken =
-                getPendingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId());
+        var pendingAirdropForToken = getPendingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId());
         verifyTokenAirdrop(pendingAirdropForToken, sender.getAccountId(), receiver.getAccountId(), tokenId);
         assertThat(pendingAirdropForToken.getAmount()).isEqualTo(amount);
         // Call the REST API to get the outstanding airdrops for the sender
-        var outstandingAirdropForToken =
-                getOutstandingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId());
+        var outstandingAirdropForToken = getOutstandingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId());
         verifyTokenAirdrop(outstandingAirdropForToken, sender.getAccountId(), receiver.getAccountId(), tokenId);
         assertThat(outstandingAirdropForToken.getAmount()).isEqualTo(amount);
         // Call the REST api to get the token relationship

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/TokenFeature.java
@@ -501,8 +501,9 @@ public class TokenFeature extends AbstractFeature {
         assertThat(networkTransactionResponse.getReceipt()).isNotNull();
     }
 
-    @Then("I airdrop serial number {int} to {account}")
-    public void airdropNonFungibleToken(int serialNumber, AccountNameEnum accountName) {
+    @Then("I airdrop serial number index {int} to {account}")
+    public void airdropNonFungibleToken(int index, AccountNameEnum accountName) {
+        var serialNumber = tokenNftInfoMap.get(tokenId).get(index).serialNumber();
         var receiver = accountClient.getAccount(accountName);
         var sender = accountClient.getSdkClient().getExpandedOperatorAccountId();
         networkTransactionResponse = verify(tokenClient.executeNftAirdrop(tokenId, sender, receiver, serialNumber));
@@ -763,8 +764,9 @@ public class TokenFeature extends AbstractFeature {
     }
 
     @RetryAsserts
-    @Then("I verify {string} airdrop of serial number {int} to {account}")
-    public void verifyNftTokenAirdrop(String status, int serialNumber, AccountNameEnum receiverName) {
+    @Then("I verify {string} airdrop of serial number index {int} to {account}")
+    public void verifyNftTokenAirdrop(String status, int index, AccountNameEnum receiverName) {
+        var serialNumber = tokenNftInfoMap.get(tokenId).get(index).serialNumber();
         var receiver = accountClient.getAccount(receiverName);
         var sender = accountClient.getAccount(AccountNameEnum.OPERATOR);
 
@@ -784,8 +786,9 @@ public class TokenFeature extends AbstractFeature {
                 verify(tokenClient.executeCancelTokenAirdrop(sender, receiver.getAccountId(), tokenId));
     }
 
-    @Then("I cancel the NFT with serial number {int} airdrop to {account}")
-    public void cancelNftPendingAirdrop(int serialNumber, AccountNameEnum accountName) {
+    @Then("I cancel the NFT with serial number index {int} airdrop to {account}")
+    public void cancelNftPendingAirdrop(int index, AccountNameEnum accountName) {
+        var serialNumber = tokenNftInfoMap.get(tokenId).get(index).serialNumber();
         var receiver = accountClient.getAccount(accountName);
         var sender = accountClient.getSdkClient().getExpandedOperatorAccountId();
         var nftId = new NftId(tokenId, serialNumber);
@@ -800,8 +803,9 @@ public class TokenFeature extends AbstractFeature {
         networkTransactionResponse = verify(tokenClient.executeClaimTokenAirdrop(sender, receiver, tokenId));
     }
 
-    @Then("{account} claims airdrop for NFT with serial number {int}")
-    public void claimPendingNftAirdrop(AccountNameEnum accountName, int serialNumber) {
+    @Then("{account} claims airdrop for NFT with serial number index {int}")
+    public void claimPendingNftAirdrop(AccountNameEnum accountName, int index) {
+        var serialNumber = tokenNftInfoMap.get(tokenId).get(index).serialNumber();
         var receiver = accountClient.getAccount(accountName);
         var sender = accountClient.getSdkClient().getExpandedOperatorAccountId();
         var nftId = new NftId(tokenId, serialNumber);
@@ -1219,7 +1223,7 @@ public class TokenFeature extends AbstractFeature {
     }
 
     private void verifySuccessfulNFTAirdrop(
-            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, int serialNumber) {
+            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, long serialNumber) {
         assertThat(getPendingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId()))
                 .isNull();
         assertThat(getOutstandingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId()))
@@ -1237,7 +1241,7 @@ public class TokenFeature extends AbstractFeature {
     }
 
     private void verifyPendingNftAirdrop(
-            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, int serialNumber) {
+            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, long serialNumber) {
         // Call the REST API to get the pending airdrops for the receiver
         var pendingAirdropForToken = getPendingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId());
         verifyTokenAirdrop(pendingAirdropForToken, sender.getAccountId(), receiver.getAccountId(), tokenId);
@@ -1261,7 +1265,7 @@ public class TokenFeature extends AbstractFeature {
     }
 
     private void verifyCancelledNftAirdrop(
-            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, int serialNumber) {
+            TokenId tokenId, ExpandedAccountId sender, ExpandedAccountId receiver, long serialNumber) {
         assertThat(getPendingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId()))
                 .isNull();
         assertThat(getOutstandingAirdrop(tokenId, sender.getAccountId(), receiver.getAccountId()))

--- a/hedera-mirror-test/src/test/resources/features/token/token.feature
+++ b/hedera-mirror-test/src/test/resources/features/token/token.feature
@@ -89,12 +89,28 @@ Feature: HTS Base Coverage Feature
     Given I update the metadata for serial number indices 0 and 1
     Then the mirror node REST API should return the transaction for token serial number index 0 transaction flow
     And the mirror node REST API should return the transaction for token serial number index 1 transaction flow
+    Given I mint a serial number from the token
+    Then the mirror node REST API should return the transaction for token serial number index 2 transaction flow
+    Then I airdrop serial number 3 to CAROL
+    Then the mirror node REST API should return the transaction
+    And I verify "pending" airdrop of serial number 3 to CAROL
+    Then I cancel the NFT with serial number 3 airdrop to CAROL
+    Then the mirror node REST API should return the transaction
+    And I verify "cancelled" airdrop of serial number 3 to CAROL
+    Then I airdrop serial number 3 to CAROL
+    Then the mirror node REST API should return the transaction
     And I associate CAROL with token
     And the mirror node REST API should return the transaction
     Then the mirror node REST API should return the token relationship for nft
-    And I transfer serial number index 1 to CAROL
-    And CAROL rejects serial number index 1
-    Then the mirror node REST API should return the transaction CAROL returns serial number index 1 to OPERATOR
+    Then CAROL claims airdrop for NFT with serial number 3
+    Then the mirror node REST API should return the transaction
+    And I verify "successful" airdrop of serial number 3 to CAROL
+#    And I transfer serial number index 1 to CAROL
+    And CAROL rejects serial number index 2
+    Then the mirror node REST API should return the transaction CAROL returns serial number index 2 to OPERATOR
+    Then I airdrop serial number 3 to CAROL
+    Then the mirror node REST API should return the transaction
+    And I verify "successful" airdrop of serial number 3 to CAROL
     Then I wipe serial number index 0 from token for ALICE
     And the mirror node REST API should return the transaction for token serial number index 0 transaction flow
     Then I burn serial number index 1 from token

--- a/hedera-mirror-test/src/test/resources/features/token/token.feature
+++ b/hedera-mirror-test/src/test/resources/features/token/token.feature
@@ -105,7 +105,6 @@ Feature: HTS Base Coverage Feature
     Then CAROL claims airdrop for NFT with serial number 3
     Then the mirror node REST API should return the transaction
     And I verify "successful" airdrop of serial number 3 to CAROL
-#    And I transfer serial number index 1 to CAROL
     And CAROL rejects serial number index 2
     Then the mirror node REST API should return the transaction CAROL returns serial number index 2 to OPERATOR
     Then I airdrop serial number 3 to CAROL

--- a/hedera-mirror-test/src/test/resources/features/token/token.feature
+++ b/hedera-mirror-test/src/test/resources/features/token/token.feature
@@ -91,25 +91,25 @@ Feature: HTS Base Coverage Feature
     And the mirror node REST API should return the transaction for token serial number index 1 transaction flow
     Given I mint a serial number from the token
     Then the mirror node REST API should return the transaction for token serial number index 2 transaction flow
-    Then I airdrop serial number 3 to CAROL
+    Then I airdrop serial number index 2 to CAROL
     Then the mirror node REST API should return the transaction
-    And I verify "pending" airdrop of serial number 3 to CAROL
-    Then I cancel the NFT with serial number 3 airdrop to CAROL
+    And I verify "pending" airdrop of serial number index 2 to CAROL
+    Then I cancel the NFT with serial number index 2 airdrop to CAROL
     Then the mirror node REST API should return the transaction
-    And I verify "cancelled" airdrop of serial number 3 to CAROL
-    Then I airdrop serial number 3 to CAROL
+    And I verify "cancelled" airdrop of serial number index 2 to CAROL
+    Then I airdrop serial number index 2 to CAROL
     Then the mirror node REST API should return the transaction
     And I associate CAROL with token
     And the mirror node REST API should return the transaction
     Then the mirror node REST API should return the token relationship for nft
-    Then CAROL claims airdrop for NFT with serial number 3
+    Then CAROL claims airdrop for NFT with serial number index 2
     Then the mirror node REST API should return the transaction
-    And I verify "successful" airdrop of serial number 3 to CAROL
+    And I verify "successful" airdrop of serial number index 2 to CAROL
     And CAROL rejects serial number index 2
     Then the mirror node REST API should return the transaction CAROL returns serial number index 2 to OPERATOR
-    Then I airdrop serial number 3 to CAROL
+    Then I airdrop serial number index 2 to CAROL
     Then the mirror node REST API should return the transaction
-    And I verify "successful" airdrop of serial number 3 to CAROL
+    And I verify "successful" airdrop of serial number index 2 to CAROL
     Then I wipe serial number index 0 from token for ALICE
     And the mirror node REST API should return the transaction for token serial number index 0 transaction flow
     Then I burn serial number index 1 from token


### PR DESCRIPTION
**Description**:
This PR adds acceptance tests for airdrop of non fungible token
The tests include - Airdrop transaction, Claim airdrop, Cancel airdrop and validating the responses from the mirror node REST api for the pending and oustanding airdrops

**Related issue(s)**:

Fixes #9529 

**Notes for reviewer**:
This PR depends on the PR for fungbile token airdrop #9528 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
