### PR TITLE
Remove recoverable errors for inactive EVM addresses

### DIFF
--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/domain/ContractResultServiceImplTest.java
@@ -119,17 +119,17 @@ class ContractResultServiceImplTest {
                 (RecordItemBuilder builder) -> builder.contractCreate().build();
 
         return Stream.of(
-                Arguments.of(withoutDefaultContractId, null, true),
-                Arguments.of(withoutDefaultContractId, EntityId.EMPTY, true),
-                Arguments.of(withDefaultContractId, null, false),
-                Arguments.of(withDefaultContractId, EntityId.EMPTY, false),
-                Arguments.of(contractCreate, EntityId.EMPTY, false),
-                Arguments.of(contractCreate, null, false),
-                Arguments.of(contractCreate, EntityId.of(0, 0, 5), false),
-                Arguments.of(withInactiveEvmFunctionOnly, null, true),
-                Arguments.of(withInactiveEvmFunctionOnly, EntityId.EMPTY, true),
-                Arguments.of(withInactiveEvmReceipt, null, false),
-                Arguments.of(withInactiveEvmReceipt, EntityId.EMPTY, false));
+                Arguments.of(withoutDefaultContractId, null),
+                Arguments.of(withoutDefaultContractId, EntityId.EMPTY),
+                Arguments.of(withDefaultContractId, null),
+                Arguments.of(withDefaultContractId, EntityId.EMPTY),
+                Arguments.of(contractCreate, EntityId.EMPTY),
+                Arguments.of(contractCreate, null),
+                Arguments.of(contractCreate, EntityId.of(0, 0, 5)),
+                Arguments.of(withInactiveEvmFunctionOnly, null),
+                Arguments.of(withInactiveEvmFunctionOnly, EntityId.EMPTY),
+                Arguments.of(withInactiveEvmReceipt, null),
+                Arguments.of(withInactiveEvmReceipt, EntityId.EMPTY));
     }
 
     @BeforeEach
@@ -143,10 +143,7 @@ class ContractResultServiceImplTest {
     @MethodSource("provideEntities")
     @SneakyThrows
     void verifiesEntityLookup(
-            Function<RecordItemBuilder, RecordItem> recordBuilder,
-            EntityId entityId,
-            boolean recoverableError,
-            CapturedOutput capturedOutput) {
+            Function<RecordItemBuilder, RecordItem> recordBuilder, EntityId entityId, CapturedOutput capturedOutput) {
         var recordItem = recordBuilder.apply(recordItemBuilder);
         var transaction = domainBuilder
                 .transaction()
@@ -159,12 +156,7 @@ class ContractResultServiceImplTest {
 
         verify(entityListener, times(1)).onContractResult(any());
 
-        if (recoverableError) {
-            assertThat(capturedOutput.getAll()).containsIgnoringCase(RECOVERABLE_ERROR_LOG_PREFIX);
-        } else {
-            assertThat(capturedOutput.getAll()).doesNotContainIgnoringCase(RECOVERABLE_ERROR_LOG_PREFIX);
-        }
-
+        assertThat(capturedOutput.getAll()).doesNotContainIgnoringCase(RECOVERABLE_ERROR_LOG_PREFIX);
         verifyContractTransactions(recordItem, transaction, entityId);
     }
 


### PR DESCRIPTION
**Description**:

Remove recoverable errors for inactive EVM addresses since for EVM equivalency we can no longer differentiate between partial mirror nodes, inactive addresses, and some error in the proto data.

**Related issue(s)**:

Fixes #9333

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
