### PR TITLE
Migrate deprecated jest methods

### DIFF
--- a/hedera-mirror-rest/__tests__/entityId.test.js
+++ b/hedera-mirror-rest/__tests__/entityId.test.js
@@ -389,7 +389,7 @@ describe('EntityId parse from encoded entityId', () => {
       } else {
         expect(() => {
           EntityId.parse(encodedId, options);
-        }).toThrowError(InvalidArgumentError);
+        }).toThrow(InvalidArgumentError);
       }
     });
   }

--- a/hedera-mirror-rest/__tests__/middleware/responseHandler.test.js
+++ b/hedera-mirror-rest/__tests__/middleware/responseHandler.test.js
@@ -61,33 +61,33 @@ describe('Response middleware', () => {
   test('Custom headers', async () => {
     mockResponse.get.mockReturnValue('application/json; charset=utf-8');
     await responseHandler(mockRequest, mockResponse, null);
-    expect(mockResponse.send).toBeCalledWith(JSONStringify(responseData));
+    expect(mockResponse.send).toHaveBeenCalledWith(JSONStringify(responseData));
     expect(mockResponse.set).toHaveBeenNthCalledWith(1, headers.default);
-    expect(mockResponse.status).toBeCalledWith(mockResponse.locals.statusCode);
+    expect(mockResponse.status).toHaveBeenCalledWith(mockResponse.locals.statusCode);
   });
 
   test('Default headers', async () => {
     mockRequest.route.path = '/api/v1/accounts';
     mockResponse.get.mockReturnValue('application/json; charset=utf-8');
     await responseHandler(mockRequest, mockResponse, null);
-    expect(mockResponse.send).toBeCalledWith(JSONStringify(responseData));
+    expect(mockResponse.send).toHaveBeenCalledWith(JSONStringify(responseData));
     expect(mockResponse.set).toHaveBeenCalledWith({
       [cacheControl]: headers.path[mockRequest.route.path][cacheControl],
       [contentTypeHeader]: 'application/json; charset=utf-8',
     });
-    expect(mockResponse.status).toBeCalledWith(mockResponse.locals.statusCode);
+    expect(mockResponse.status).toHaveBeenCalledWith(mockResponse.locals.statusCode);
   });
 
   test('Custom Content-Type', async () => {
     mockResponse.locals[responseHeadersLabel] = {[contentTypeHeader]: 'text/plain; charset=utf-8'};
     mockResponse.locals.responseData = '123';
     await responseHandler(mockRequest, mockResponse, null);
-    expect(mockResponse.send).toBeCalledWith(mockResponse.locals.responseData);
+    expect(mockResponse.send).toHaveBeenCalledWith(mockResponse.locals.responseData);
     expect(mockResponse.set).toHaveBeenNthCalledWith(1, {
       [cacheControl]: headers.default[cacheControl],
       [contentTypeHeader]: mockResponse.locals[responseHeadersLabel][contentTypeHeader],
     });
-    expect(mockResponse.status).toBeCalledWith(mockResponse.locals.statusCode);
+    expect(mockResponse.status).toHaveBeenCalledWith(mockResponse.locals.statusCode);
   });
 
   test('should set the Link next header and confirm it exists', async () => {

--- a/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
+++ b/hedera-mirror-rest/__tests__/model/exchangeRate.test.js
@@ -40,7 +40,7 @@ describe('exchange rate proto parse', () => {
   });
 
   test('invalid contents', () => {
-    expect(() => new ExchangeRate({file_data: Buffer.from('123456', 'hex'), consensus_timestamp: 1})).toThrowError(
+    expect(() => new ExchangeRate({file_data: Buffer.from('123456', 'hex'), consensus_timestamp: 1})).toThrow(
       FileDecodeError
     );
   });

--- a/hedera-mirror-rest/__tests__/model/feeSchedule.test.js
+++ b/hedera-mirror-rest/__tests__/model/feeSchedule.test.js
@@ -52,8 +52,8 @@ describe('fee schedule proto parse', () => {
   });
 
   test('invalid contents', () => {
-    expect(() => new FeeSchedule({file_data: '123456', consensus_timestamp: 1})).toThrowError(FileDecodeError);
-    expect(() => new FeeSchedule({file_data: Buffer.from('123456', 'hex'), consensus_timestamp: 1})).toThrowError(
+    expect(() => new FeeSchedule({file_data: '123456', consensus_timestamp: 1})).toThrow(FileDecodeError);
+    expect(() => new FeeSchedule({file_data: Buffer.from('123456', 'hex'), consensus_timestamp: 1})).toThrow(
       FileDecodeError
     );
   });

--- a/hedera-mirror-rest/__tests__/model/transactionType.test.js
+++ b/hedera-mirror-rest/__tests__/model/transactionType.test.js
@@ -56,22 +56,22 @@ describe('getProtoId', () => {
   test('Throw error for invalid name', () => {
     expect(() => {
       TransactionType.getProtoId(unknownProtoId);
-    }).toThrowError(InvalidArgumentError);
+    }).toThrow(InvalidArgumentError);
   });
   test('Throw error for unknown name', () => {
     expect(() => {
       TransactionType.getProtoId('UNKNOWN');
-    }).toThrowError(InvalidArgumentError);
+    }).toThrow(InvalidArgumentError);
   });
   test('Throw error for null name', () => {
     expect(() => {
       TransactionType.getProtoId(null);
-    }).toThrowError(InvalidArgumentError);
+    }).toThrow(InvalidArgumentError);
   });
   test('Throw error for undefined name', () => {
     expect(() => {
       TransactionType.getProtoId(undefined);
-    }).toThrowError(InvalidArgumentError);
+    }).toThrow(InvalidArgumentError);
   });
 });
 

--- a/hedera-mirror-rest/__tests__/service/contractService.test.js
+++ b/hedera-mirror-rest/__tests__/service/contractService.test.js
@@ -1042,9 +1042,7 @@ describe('ContractService.getContractIdByEvmAddress tests', () => {
 
     const evmAddressFilter = {shard: 0, realm: 0, create2_evm_address: evmAddress};
     await expect(() => ContractService.getContractIdByEvmAddress(evmAddressFilter)).rejects.toThrow(
-      new NotFoundError(
-        `More than one contract with the evm address ${JSON.stringify(evmAddressFilter)} have been found.`
-      )
+      new Error(`More than one contract with the evm address ${JSON.stringify(evmAddressFilter)} have been found.`)
     );
   });
 


### PR DESCRIPTION
**Description**:

Migrate matcher methods to native matchers to prepare us for the breaking changes in Jest 30

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
