### PR TITLE
Implement `AirdropsReadableKVState`

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -109,6 +109,7 @@ public class EvmConfiguration {
     public static final String CACHE_NAME_TOKEN_ACCOUNT = "tokenAccount";
     public static final String CACHE_NAME_TOKEN_ACCOUNT_COUNT = "tokenAccountCount";
     public static final String CACHE_NAME_TOKEN_ALLOWANCE = "tokenAllowance";
+    public static final String CACHE_NAME_TOKEN_AIRDROP = "tokenAirdrop";
     public static final SemanticVersion EVM_VERSION_0_30 = new SemanticVersion(0, 30, 0, "", "");
     public static final SemanticVersion EVM_VERSION_0_34 = new SemanticVersion(0, 34, 0, "", "");
     public static final SemanticVersion EVM_VERSION_0_38 = new SemanticVersion(0, 38, 0, "", "");
@@ -159,7 +160,8 @@ public class EvmConfiguration {
                 CACHE_NAME_TOKEN,
                 CACHE_NAME_TOKEN_ACCOUNT,
                 CACHE_NAME_TOKEN_ACCOUNT_COUNT,
-                CACHE_NAME_TOKEN_ALLOWANCE));
+                CACHE_NAME_TOKEN_ALLOWANCE,
+                CACHE_NAME_TOKEN_AIRDROP));
         caffeineCacheManager.setCacheSpecification(cacheProperties.getToken());
         return caffeineCacheManager;
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAirdropRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAirdropRepository.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.repository;
+
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_MANAGER_TOKEN;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_TOKEN_AIRDROP;
+
+import com.hedera.mirror.common.domain.token.AbstractTokenAirdrop;
+import com.hedera.mirror.common.domain.token.TokenAirdrop;
+import java.util.Optional;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TokenAirdropRepository extends CrudRepository<TokenAirdrop, AbstractTokenAirdrop.Id> {
+
+    @Cacheable(cacheNames = CACHE_NAME_TOKEN_AIRDROP, cacheManager = CACHE_MANAGER_TOKEN, unless = "#result == null")
+    @Query(
+            value =
+                    """
+                    select *
+                    from token_airdrop
+                    where sender_account_id = :senderId
+                        and receiver_account_id = :receiverId
+                        and token_id = :tokenId
+                        and state = 'PENDING'
+                    """,
+            nativeQuery = true)
+    Optional<TokenAirdrop> findById(long senderId, long receiverId, long tokenId);
+
+    /**
+     * Retrieves the most recent state of a token airdrop by its ID up to a given block timestamp.
+     * The method considers both the current state of the token airdrop and its historical states
+     * and returns the one that was valid just before or equal to the provided block timestamp.
+     *
+     * @param senderId the ID of the sender account
+     * @param receiverId the ID of the receiver account
+     * @param tokenId the ID of the token
+     * @param blockTimestamp  the block timestamp used to filter the results.
+     * @return an Optional containing the token airdrop's state at the specified timestamp.
+     *         If there is no record found for the given criteria, an empty Optional is returned.
+     */
+    @Query(
+            value =
+                    """
+                    select *
+                    from (
+                            (
+                        select *
+                        from token_airdrop
+                        where sender_account_id = :senderId
+                            and receiver_account_id = :receiverId
+                            and token_id = :tokenId
+                            and state = 'PENDING'
+                            and lower(timestamp_range) <= :blockTimestamp
+                            )
+                            union all
+                            (
+                        select *
+                        from token_airdrop_history
+                        where sender_account_id = :senderId
+                            and receiver_account_id = :receiverId
+                            and token_id = :tokenId
+                            and state = 'PENDING'
+                            and lower(timestamp_range) <= :blockTimestamp
+                        order by lower(timestamp_range) desc
+                        limit 1
+                            )
+                            order by timestamp_range desc
+                            limit 1
+                    )
+                    """,
+            nativeQuery = true)
+    Optional<TokenAirdrop> findByIdAndTimestamp(long senderId, long receiverId, long tokenId, long blockTimestamp);
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAirdropRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/TokenAirdropRepository.java
@@ -37,10 +37,11 @@ public interface TokenAirdropRepository extends CrudRepository<TokenAirdrop, Abs
                     where sender_account_id = :senderId
                         and receiver_account_id = :receiverId
                         and token_id = :tokenId
+                        and serial_number = :serialNumber
                         and state = 'PENDING'
                     """,
             nativeQuery = true)
-    Optional<TokenAirdrop> findById(long senderId, long receiverId, long tokenId);
+    Optional<TokenAirdrop> findById(long senderId, long receiverId, long tokenId, long serialNumber);
 
     /**
      * Retrieves the most recent state of a token airdrop by its ID up to a given block timestamp.
@@ -65,6 +66,7 @@ public interface TokenAirdropRepository extends CrudRepository<TokenAirdrop, Abs
                         where sender_account_id = :senderId
                             and receiver_account_id = :receiverId
                             and token_id = :tokenId
+                            and serial_number = :serialNumber
                             and state = 'PENDING'
                             and lower(timestamp_range) <= :blockTimestamp
                             )
@@ -75,15 +77,17 @@ public interface TokenAirdropRepository extends CrudRepository<TokenAirdrop, Abs
                         where sender_account_id = :senderId
                             and receiver_account_id = :receiverId
                             and token_id = :tokenId
+                            and serial_number = :serialNumber
                             and state = 'PENDING'
                             and lower(timestamp_range) <= :blockTimestamp
                         order by lower(timestamp_range) desc
                         limit 1
                             )
-                            order by timestamp_range desc
-                            limit 1
+                    order by timestamp_range desc
+                    limit 1
                     )
                     """,
             nativeQuery = true)
-    Optional<TokenAirdrop> findByIdAndTimestamp(long senderId, long receiverId, long tokenId, long blockTimestamp);
+    Optional<TokenAirdrop> findByIdAndTimestamp(
+            long senderId, long receiverId, long tokenId, long serialNumber, long blockTimestamp);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AirdropsReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AirdropsReadableKVState.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state;
+
+import static com.hedera.services.utils.EntityIdUtils.toEntityId;
+
+import com.hedera.hapi.node.base.PendingAirdropId;
+import com.hedera.hapi.node.base.PendingAirdropValue;
+import com.hedera.hapi.node.state.token.AccountPendingAirdrop;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.repository.TokenAirdropRepository;
+import com.swirlds.state.spi.ReadableKVStateBase;
+import jakarta.annotation.Nonnull;
+import jakarta.inject.Named;
+import java.util.Collections;
+import java.util.Iterator;
+
+@Named
+public class AirdropsReadableKVState extends ReadableKVStateBase<PendingAirdropId, AccountPendingAirdrop> {
+
+    private final TokenAirdropRepository tokenAirdropRepository;
+
+    protected AirdropsReadableKVState(final TokenAirdropRepository tokenAirdropRepository) {
+        super("PENDING_AIRDROPS");
+        this.tokenAirdropRepository = tokenAirdropRepository;
+    }
+
+    @Override
+    protected AccountPendingAirdrop readFromDataSource(@Nonnull PendingAirdropId key) {
+        if (key.hasNonFungibleToken()) {
+            return AccountPendingAirdrop.DEFAULT;
+        }
+
+        final var senderId = toEntityId(key.senderId()).getId();
+        final var receiverId = toEntityId(key.receiverId()).getId();
+        final var tokenId = toEntityId(key.fungibleTokenType()).getId();
+        final var timestamp = ContractCallContext.get().getTimestamp();
+
+        return timestamp
+                .map(t -> tokenAirdropRepository.findByIdAndTimestamp(senderId, receiverId, tokenId, t))
+                .orElseGet(() -> tokenAirdropRepository.findById(senderId, receiverId, tokenId))
+                .map(tokenAirdrop -> mapToAccountPendingAirdrop(tokenAirdrop.getAmount()))
+                .orElse(null);
+    }
+
+    @Nonnull
+    @Override
+    protected Iterator<PendingAirdropId> iterateFromDataSource() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public long size() {
+        return 0;
+    }
+
+    private AccountPendingAirdrop mapToAccountPendingAirdrop(final long amount) {
+        return AccountPendingAirdrop.newBuilder()
+                .pendingAirdropValue(mapToPendingAirdropValue(amount))
+                .build();
+    }
+
+    private PendingAirdropValue mapToPendingAirdropValue(final long amount) {
+        return PendingAirdropValue.newBuilder().amount(amount).build();
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenAirdropRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/TokenAirdropRepositoryTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.repository;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.google.common.collect.Range;
+import com.hedera.mirror.common.domain.token.TokenAirdrop;
+import com.hedera.mirror.common.domain.token.TokenAirdropStateEnum;
+import com.hedera.mirror.common.domain.token.TokenTypeEnum;
+import com.hedera.mirror.web3.Web3IntegrationTest;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@RequiredArgsConstructor
+class TokenAirdropRepositoryTest extends Web3IntegrationTest {
+
+    private final TokenAirdropRepository tokenAirdropRepository;
+
+    @ParameterizedTest
+    @EnumSource(TokenTypeEnum.class)
+    void testFindByIdPendingSuccess(final TokenTypeEnum tokenType) {
+        final var senderId = domainBuilder.entityId().getId();
+        final var receiverId = domainBuilder.entityId().getId();
+        final var tokenId = domainBuilder.entityId().getId();
+        final var timestampRange = Range.atLeast(domainBuilder.timestamp());
+
+        long amount;
+        long serialNumber;
+        if (tokenType == TokenTypeEnum.FUNGIBLE_COMMON) {
+            amount = 1L;
+            serialNumber = 0L;
+        } else {
+            amount = 0L;
+            serialNumber = 123L;
+        }
+
+        domainBuilder
+                .tokenAirdrop(tokenType)
+                .customize(ta -> ta.senderAccountId(senderId)
+                        .receiverAccountId(receiverId)
+                        .tokenId(tokenId)
+                        .state(TokenAirdropStateEnum.PENDING)
+                        .amount(amount)
+                        .serialNumber(serialNumber)
+                        .timestampRange(timestampRange))
+                .persist();
+
+        final var expected = TokenAirdrop.builder()
+                .senderAccountId(senderId)
+                .receiverAccountId(receiverId)
+                .tokenId(tokenId)
+                .state(TokenAirdropStateEnum.PENDING)
+                .serialNumber(serialNumber)
+                .amount(amount)
+                .timestampRange(timestampRange)
+                .build();
+
+        assertThat(tokenAirdropRepository
+                        .findById(senderId, receiverId, tokenId)
+                        .get())
+                .isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            textBlock =
+                    """
+            FUNGIBLE_COMMON, CLAIMED
+            FUNGIBLE_COMMON, CANCELLED
+            NON_FUNGIBLE_UNIQUE, CLAIMED
+            NON_FUNGIBLE_UNIQUE, CANCELLED
+            """)
+    void testFindByIdClaimedOrCancelledEmpty(final TokenTypeEnum tokenType, final TokenAirdropStateEnum state) {
+        final var senderId = domainBuilder.entityId().getId();
+        final var receiverId = domainBuilder.entityId().getId();
+        final var tokenId = domainBuilder.entityId().getId();
+        final var timestampRange = Range.atLeast(domainBuilder.timestamp());
+
+        long amount;
+        long serialNumber;
+        if (tokenType == TokenTypeEnum.FUNGIBLE_COMMON) {
+            amount = 1L;
+            serialNumber = 0L;
+        } else {
+            amount = 0L;
+            serialNumber = 123L;
+        }
+
+        domainBuilder
+                .tokenAirdrop(tokenType)
+                .customize(ta -> ta.senderAccountId(senderId)
+                        .receiverAccountId(receiverId)
+                        .tokenId(tokenId)
+                        .state(state)
+                        .amount(amount)
+                        .serialNumber(serialNumber)
+                        .timestampRange(timestampRange))
+                .persist();
+
+        assertThat(tokenAirdropRepository.findById(senderId, receiverId, tokenId))
+                .isEmpty();
+    }
+
+    @ParameterizedTest
+    @EnumSource(TokenTypeEnum.class)
+    void testFindByIdPendingSuccessHistorical(final TokenTypeEnum tokenType) {
+        final var senderId = domainBuilder.entityId().getId();
+        final var receiverId = domainBuilder.entityId().getId();
+        final var tokenId = domainBuilder.entityId().getId();
+        final var timestampRange = Range.atLeast(domainBuilder.timestamp());
+
+        long amount;
+        long serialNumber;
+        if (tokenType == TokenTypeEnum.FUNGIBLE_COMMON) {
+            amount = 1L;
+            serialNumber = 0L;
+        } else {
+            amount = 0L;
+            serialNumber = 123L;
+        }
+
+        domainBuilder
+                .tokenAirdropHistory(tokenType)
+                .customize(ta -> ta.senderAccountId(senderId)
+                        .receiverAccountId(receiverId)
+                        .tokenId(tokenId)
+                        .state(TokenAirdropStateEnum.PENDING)
+                        .amount(amount)
+                        .serialNumber(serialNumber)
+                        .timestampRange(timestampRange))
+                .persist();
+
+        final var expected = TokenAirdrop.builder()
+                .senderAccountId(senderId)
+                .receiverAccountId(receiverId)
+                .tokenId(tokenId)
+                .state(TokenAirdropStateEnum.PENDING)
+                .serialNumber(serialNumber)
+                .amount(amount)
+                .timestampRange(timestampRange)
+                .build();
+
+        assertThat(tokenAirdropRepository
+                        .findByIdAndTimestamp(senderId, receiverId, tokenId, timestampRange.lowerEndpoint())
+                        .get())
+                .isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            textBlock =
+                    """
+            FUNGIBLE_COMMON, CLAIMED
+            FUNGIBLE_COMMON, CANCELLED
+            NON_FUNGIBLE_UNIQUE, CLAIMED
+            NON_FUNGIBLE_UNIQUE, CANCELLED
+            """)
+    void testFindByIdClaimedOrCancelledEmptyHistorical(
+            final TokenTypeEnum tokenType, final TokenAirdropStateEnum state) {
+        final var senderId = domainBuilder.entityId().getId();
+        final var receiverId = domainBuilder.entityId().getId();
+        final var tokenId = domainBuilder.entityId().getId();
+        final var timestampRange = Range.atLeast(domainBuilder.timestamp());
+
+        long amount;
+        long serialNumber;
+        if (tokenType == TokenTypeEnum.FUNGIBLE_COMMON) {
+            amount = 1L;
+            serialNumber = 0L;
+        } else {
+            amount = 0L;
+            serialNumber = 123L;
+        }
+
+        domainBuilder
+                .tokenAirdropHistory(tokenType)
+                .customize(ta -> ta.senderAccountId(senderId)
+                        .receiverAccountId(receiverId)
+                        .tokenId(tokenId)
+                        .state(state)
+                        .amount(amount)
+                        .serialNumber(serialNumber)
+                        .timestampRange(timestampRange))
+                .persist();
+
+        assertThat(tokenAirdropRepository.findByIdAndTimestamp(
+                        senderId, receiverId, tokenId, timestampRange.lowerEndpoint()))
+                .isEmpty();
+    }
+
+    @Test
+    void testFindByIdAndTimestampReturnsCorrectValueForTimestamp() {
+        final var senderId = domainBuilder.entityId().getId();
+        final var receiverId = domainBuilder.entityId().getId();
+        final var tokenId = domainBuilder.entityId().getId();
+        final var timestampRangeHistorical = Range.atLeast(domainBuilder.timestamp());
+        final var timestampRange = Range.atLeast(timestampRangeHistorical.lowerEndpoint() + 100L);
+        final var amount = 1L;
+
+        domainBuilder
+                .tokenAirdrop(TokenTypeEnum.FUNGIBLE_COMMON)
+                .customize(ta -> ta.senderAccountId(senderId)
+                        .receiverAccountId(receiverId)
+                        .tokenId(tokenId)
+                        .state(TokenAirdropStateEnum.CLAIMED)
+                        .amount(amount)
+                        .timestampRange(timestampRange))
+                .persist();
+
+        domainBuilder
+                .tokenAirdropHistory(TokenTypeEnum.FUNGIBLE_COMMON)
+                .customize(ta -> ta.senderAccountId(senderId)
+                        .receiverAccountId(receiverId)
+                        .tokenId(tokenId)
+                        .state(TokenAirdropStateEnum.PENDING)
+                        .amount(amount)
+                        .timestampRange(timestampRangeHistorical))
+                .persist();
+
+        final var expected = TokenAirdrop.builder()
+                .senderAccountId(senderId)
+                .receiverAccountId(receiverId)
+                .tokenId(tokenId)
+                .state(TokenAirdropStateEnum.PENDING)
+                .amount(amount)
+                .timestampRange(timestampRangeHistorical)
+                .build();
+
+        assertThat(tokenAirdropRepository
+                        .findByIdAndTimestamp(senderId, receiverId, tokenId, timestampRangeHistorical.lowerEndpoint())
+                        .get())
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void testFindByIdAndTimestampReturnsCorrectValueForTimestampTwoHistoricalEntries() {
+        final var senderId = domainBuilder.entityId().getId();
+        final var receiverId = domainBuilder.entityId().getId();
+        final var tokenId = domainBuilder.entityId().getId();
+        final var timestampRangeHistorical = Range.atLeast(domainBuilder.timestamp());
+        final var timestampRange = Range.atLeast(timestampRangeHistorical.lowerEndpoint() + 100L);
+        final var amount = 1L;
+        final var amountLatest = 2L;
+
+        domainBuilder
+                .tokenAirdropHistory(TokenTypeEnum.FUNGIBLE_COMMON)
+                .customize(ta -> ta.senderAccountId(senderId)
+                        .receiverAccountId(receiverId)
+                        .tokenId(tokenId)
+                        .state(TokenAirdropStateEnum.PENDING)
+                        .amount(amount)
+                        .timestampRange(timestampRangeHistorical))
+                .persist();
+
+        domainBuilder
+                .tokenAirdropHistory(TokenTypeEnum.FUNGIBLE_COMMON)
+                .customize(ta -> ta.senderAccountId(senderId)
+                        .receiverAccountId(receiverId)
+                        .tokenId(tokenId)
+                        .state(TokenAirdropStateEnum.PENDING)
+                        .amount(amountLatest)
+                        .timestampRange(timestampRange))
+                .persist();
+
+        final var expected = TokenAirdrop.builder()
+                .senderAccountId(senderId)
+                .receiverAccountId(receiverId)
+                .tokenId(tokenId)
+                .state(TokenAirdropStateEnum.PENDING)
+                .amount(amount)
+                .timestampRange(timestampRangeHistorical)
+                .build();
+
+        final var expectedLatest = expected.toBuilder()
+                .timestampRange(timestampRange)
+                .amount(amountLatest)
+                .build();
+
+        assertThat(tokenAirdropRepository
+                        .findByIdAndTimestamp(senderId, receiverId, tokenId, timestampRangeHistorical.lowerEndpoint())
+                        .get())
+                .isEqualTo(expected);
+        assertThat(tokenAirdropRepository
+                        .findByIdAndTimestamp(senderId, receiverId, tokenId, timestampRange.lowerEndpoint())
+                        .get())
+                .isEqualTo(expectedLatest);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AirdropsReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AirdropsReadableKVStateTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state;
+
+import static com.hedera.services.utils.EntityIdUtils.toAccountId;
+import static com.hedera.services.utils.EntityIdUtils.toEntityId;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.node.base.NftID;
+import com.hedera.hapi.node.base.PendingAirdropId;
+import com.hedera.hapi.node.base.PendingAirdropValue;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.state.token.AccountPendingAirdrop;
+import com.hedera.mirror.common.domain.DomainBuilder;
+import com.hedera.mirror.common.domain.token.TokenAirdrop;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.repository.TokenAirdropRepository;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AirdropsReadableKVStateTest {
+
+    @InjectMocks
+    private AirdropsReadableKVState airdropsReadableKVState;
+
+    @Mock
+    private TokenAirdropRepository tokenAirdropRepository;
+
+    @Spy
+    private ContractCallContext contractCallContext;
+
+    private static MockedStatic<ContractCallContext> contextMockedStatic;
+
+    private DomainBuilder domainBuilder;
+
+    private static final Optional<Long> timestamp = Optional.of(1726231985623004672L);
+
+    @BeforeAll
+    static void initStaticMocks() {
+        contextMockedStatic = mockStatic(ContractCallContext.class);
+    }
+
+    @AfterAll
+    static void closeStaticMocks() {
+        contextMockedStatic.close();
+    }
+
+    @BeforeEach
+    void setup() {
+        domainBuilder = new DomainBuilder();
+        contextMockedStatic.when(ContractCallContext::get).thenReturn(contractCallContext);
+    }
+
+    @Test
+    void sizeIsAlwaysZero() {
+        assertThat(airdropsReadableKVState.size()).isZero();
+    }
+
+    @Test
+    void iterateReturnsEmptyIterator() {
+        assertThat(airdropsReadableKVState.iterateFromDataSource()).isEqualTo(Collections.emptyIterator());
+    }
+
+    @Test
+    void nftReturnsDefault() {
+        final var senderId = toAccountId(domainBuilder.entityId());
+        final var receiverId = toAccountId(domainBuilder.entityId());
+        assertThat(airdropsReadableKVState.get(PendingAirdropId.newBuilder()
+                        .senderId(senderId)
+                        .receiverId(receiverId)
+                        .nonFungibleToken(NftID.DEFAULT)
+                        .build()))
+                .isEqualTo(AccountPendingAirdrop.DEFAULT);
+    }
+
+    @Test
+    void fungibleTokenLatestBlockHappyPath() {
+        final var senderId = toAccountId(domainBuilder.entityId());
+        final var receiverId = toAccountId(domainBuilder.entityId());
+        final var tokenId =
+                TokenID.newBuilder().shardNum(1L).realmNum(2L).tokenNum(3L).build();
+        final var tokenAirdrop = TokenAirdrop.builder().amount(3L).build();
+        final var pendingAirdropValue =
+                PendingAirdropValue.newBuilder().amount(3L).build();
+
+        when(tokenAirdropRepository.findById(
+                        toEntityId(senderId).getId(),
+                        toEntityId(receiverId).getId(),
+                        toEntityId(tokenId).getId()))
+                .thenReturn(Optional.of(tokenAirdrop));
+
+        final var expected = AccountPendingAirdrop.newBuilder()
+                .pendingAirdropValue(pendingAirdropValue)
+                .build();
+        assertThat(airdropsReadableKVState.get(PendingAirdropId.newBuilder()
+                        .senderId(senderId)
+                        .receiverId(receiverId)
+                        .fungibleTokenType(tokenId)
+                        .build()))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void fungibleTokenHistoricalBlockHappyPath() {
+        final var senderId = toAccountId(domainBuilder.entityId());
+        final var receiverId = toAccountId(domainBuilder.entityId());
+        final var tokenId =
+                TokenID.newBuilder().shardNum(1L).realmNum(2L).tokenNum(3L).build();
+        final var tokenAirdrop = TokenAirdrop.builder().amount(3L).build();
+        final var pendingAirdropValue =
+                PendingAirdropValue.newBuilder().amount(3L).build();
+
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        when(tokenAirdropRepository.findByIdAndTimestamp(
+                        toEntityId(senderId).getId(),
+                        toEntityId(receiverId).getId(),
+                        toEntityId(tokenId).getId(),
+                        timestamp.get()))
+                .thenReturn(Optional.of(tokenAirdrop));
+
+        final var expected = AccountPendingAirdrop.newBuilder()
+                .pendingAirdropValue(pendingAirdropValue)
+                .build();
+        assertThat(airdropsReadableKVState.get(PendingAirdropId.newBuilder()
+                        .senderId(senderId)
+                        .receiverId(receiverId)
+                        .fungibleTokenType(tokenId)
+                        .build()))
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void fungibleTokenAirdropNotFoundReturnsNull() {
+        final var senderId = toAccountId(domainBuilder.entityId());
+        final var receiverId = toAccountId(domainBuilder.entityId());
+        final var tokenId =
+                TokenID.newBuilder().shardNum(1L).realmNum(2L).tokenNum(3L).build();
+
+        when(tokenAirdropRepository.findById(anyLong(), anyLong(), anyLong())).thenReturn(Optional.empty());
+
+        assertThat(airdropsReadableKVState.get(PendingAirdropId.newBuilder()
+                        .senderId(senderId)
+                        .receiverId(receiverId)
+                        .fungibleTokenType(tokenId)
+                        .build()))
+                .isNull();
+    }
+
+    @Test
+    void fungibleTokenAirdropNotFoundHistoricalReturnsNull() {
+        final var senderId = toAccountId(domainBuilder.entityId());
+        final var receiverId = toAccountId(domainBuilder.entityId());
+        final var tokenId =
+                TokenID.newBuilder().shardNum(1L).realmNum(2L).tokenNum(3L).build();
+
+        when(contractCallContext.getTimestamp()).thenReturn(timestamp);
+        when(tokenAirdropRepository.findByIdAndTimestamp(anyLong(), anyLong(), anyLong(), anyLong()))
+                .thenReturn(Optional.empty());
+
+        assertThat(airdropsReadableKVState.get(PendingAirdropId.newBuilder()
+                        .senderId(senderId)
+                        .receiverId(receiverId)
+                        .fungibleTokenType(tokenId)
+                        .build()))
+                .isNull();
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AirdropsReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AirdropsReadableKVStateTest.java
@@ -46,7 +46,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class AirdropsReadableKVStateTest {
+class AirdropsReadableKVStateTest {
 
     @InjectMocks
     private AirdropsReadableKVState airdropsReadableKVState;


### PR DESCRIPTION
**Description**:
As part of the implementation for the reusable (modularized) services we need to implement `AirdropsReadableKVState`. It reads a pending airdrop id and converts it to `AccountPendingAirdrop` PBJ type.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/9257

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
