### PR TITLE
Added gas correction to failing acceptance tests

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/EstimatePrecompileFeature.java
@@ -76,6 +76,7 @@ import org.apache.tuweni.bytes.Bytes;
 @RequiredArgsConstructor
 public class EstimatePrecompileFeature extends AbstractEstimateFeature {
     private static final String HEX_DIGITS = "0123456789abcdef";
+    private final int GAS_CORRECTION = 2507;
     private static final Tuple[] EMPTY_TUPLE_ARRAY = new Tuple[] {};
 
     private static final String RANDOM_ADDRESS = to32BytesString(RandomStringUtils.random(40, HEX_DIGITS));
@@ -1453,7 +1454,10 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
         var tokenId = tokenClient.getToken(tokenName).tokenId();
         var data = encodeDataToByteArray(ERC, BALANCE_OF, asAddress(tokenId), asAddress(admin));
         var estimateGasValue = validateAndReturnGas(data, BALANCE_OF, ercTestContractSolidityAddress);
-        executeContractTransaction(deployedErcTestContract, estimateGasValue, BALANCE_OF, data);
+        // Temporary change: Adding 2507 gas correction because of #10828 from hedera-services where the gas
+        // calculations are adjusted
+        // TODO: To be reverted when reusable services are implemented in mirror node
+        executeContractTransaction(deployedErcTestContract, estimateGasValue + GAS_CORRECTION, BALANCE_OF, data);
     }
 
     @And("I update the account and token keys")
@@ -1532,8 +1536,12 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                 asAddress(fungibleKycUnfrozenTokenId),
                 asAddress(admin),
                 asAddress(receiverAccountAlias));
+        // Temporary change: Adding 2507 gas correction because of #10828 from hedera-services where the gas
+        // calculations are adjusted
+        // TODO: To be reverted when reusable services are implemented in mirror node
         var estimateGasValue = validateAndReturnGas(data, ALLOWANCE, estimatePrecompileContractSolidityAddress);
-        executeContractTransaction(deployedEstimatePrecompileContract, estimateGasValue, ALLOWANCE, data);
+        executeContractTransaction(
+                deployedEstimatePrecompileContract, estimateGasValue + GAS_CORRECTION, ALLOWANCE, data);
     }
 
     @Then("I call estimateGas with allowance function for NFT and verify the estimated gas against HAPI")
@@ -1544,8 +1552,12 @@ public class EstimatePrecompileFeature extends AbstractEstimateFeature {
                 asAddress(nonFungibleKycUnfrozenTokenId),
                 asAddress(admin),
                 asAddress(receiverAccountAlias));
+        // Temporary change: Adding 2507 gas correction because of #10828 from hedera-services where the gas
+        // calculations are adjusted
+        // TODO: To be reverted when reusable services are implemented in mirror node
         var estimateGasValue = validateAndReturnGas(data, ALLOWANCE, estimatePrecompileContractSolidityAddress);
-        executeContractTransaction(deployedEstimatePrecompileContract, estimateGasValue, ALLOWANCE, data);
+        executeContractTransaction(
+                deployedEstimatePrecompileContract, estimateGasValue + GAS_CORRECTION, ALLOWANCE, data);
     }
 
     @Then("I call estimateGas with approve function and verify the estimated gas against HAPI")

--- a/hedera-mirror-test/src/test/resources/features/contract/estimatePrecompile.feature
+++ b/hedera-mirror-test/src/test/resources/features/contract/estimatePrecompile.feature
@@ -172,8 +172,8 @@ Feature: EstimateGas Contract Base Coverage Feature
     Then I call estimateGas with pseudo random seed
     Then I call estimateGas with pseudo random number
     #### These tests below are recommended to be kept at the end as they change the state #####
-#    Then I call estimateGas with balanceOf function for "FUNGIBLE" and verify the estimated gas against HAPI
-#    Then I call estimateGas with balanceOf function for "NFT" and verify the estimated gas against HAPI
+    Then I call estimateGas with balanceOf function for "FUNGIBLE" and verify the estimated gas against HAPI
+    Then I call estimateGas with balanceOf function for "NFT" and verify the estimated gas against HAPI
     And I update the account and token keys
     Then the mirror node REST API should return status 200 for the HAPI transaction
 #    Then I call estimateGas with transferToken function and verify the estimated gas against HAPI
@@ -184,8 +184,8 @@ Feature: EstimateGas Contract Base Coverage Feature
     Then I call estimateGas with mintToken function for NFT and verify the estimated gas against HAPI
     And I approve the receiver to use the token
     Then the mirror node REST API should return status 200 for the HAPI transaction
-#    Then I call estimateGas with allowance function for fungible token and verify the estimated gas against HAPI
-#    Then I call estimateGas with allowance function for NFT and verify the estimated gas against HAPI
+    Then I call estimateGas with allowance function for fungible token and verify the estimated gas against HAPI
+    Then I call estimateGas with allowance function for NFT and verify the estimated gas against HAPI
     Then I call estimateGas with approve function and verify the estimated gas against HAPI
     Then I call estimateGas with approveNFT function and verify the estimated gas against HAPI
     Then I call estimateGas with transferFrom function with fungible and verify the estimated gas against HAPI


### PR DESCRIPTION
**Description**:
There were some failing acceptance tests for read functions because of [this](https://github.com/hashgraph/hedera-services/issues/10828) change in services, so a correction to the gas is added temporarily to the failing tests

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
This correction is temporary and will not be needed when reusable services implementation in mirror node is done

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
