### PR TITLE
Fix empty ipAddressV4 returning 127.0.0.1 in gRPC nodes API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ extra.apply {
     set("nodeJsVersion", "18.18.0")
     set("protobufVersion", "3.25.5")
     set("reactorGrpcVersion", "1.2.4")
+    set("spring-framework.version", "6.1.14") // Temporary until next Spring Boot version
     set("vertxVersion", "4.5.10")
     set("tuweniVersion", "2.3.1")
 }

--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -372,7 +372,7 @@ prometheus:
         requests:
           cpu: 250m
           memory: 1Gi
-      retentionSize: 100GiB
+      retentionSize: 84GiB  # Capacity minus 16% so KubePersistentVolumeFillingUp alert doesn't fire
       ruleSelectorNilUsesHelmValues: false
       scrapeInterval: 30s
       serviceMonitorSelectorNilUsesHelmValues: false

--- a/docs/checklist/release.md
+++ b/docs/checklist/release.md
@@ -17,23 +17,21 @@ This checklist verifies a release is rolled out successfully.
 
 ### Previewnet
 
-v1 is deployed by tag creation automation. Upon success, a PR for v2 will automatically get created.
+Deployed automatically on every tag.
 
-- [ ] Deployed v1
-- [ ] Deployed v2
+- [ ] Deployed
 
 ### Performance
 
-- [ ] Deployed v1
-- [ ] Deployed v2
+- [ ] Deployed
 - [ ] gRPC API performance tests
 - [ ] Importer performance tests
 
 ### Mainnet Staging
 
-- [ ] Deployed v1
-- [ ] Deployed v2
+- [ ] Deployed
 - [ ] REST API performance tests
+- [ ] REST Java API performance tests
 - [ ] Web3 API performance tests
 
 ## Generally Available
@@ -43,14 +41,13 @@ v1 is deployed by tag creation automation. Upon success, a PR for v2 will automa
 
 ### Previewnet
 
-v1 is deployed by tag creation automation. Upon success, a PR for v2 will automatically get created.
+Deployed automatically on every tag.
 
-- [ ] Deployed v1
-- [ ] Deployed v2
+- [ ] Deployed
 
 ### Testnet
 
-The GA tag automation deploys v1 to NA. Upon success, a PR for EU will automatically get created.
+A GA tag will trigger an automatic deployment to NA. Upon success, a PR for EU will automatically get created.
 
 - [ ] Deployed NA
 - [ ] Deployed EU


### PR DESCRIPTION
**Description**:

* Bump Spring Framework from 6.1.13 to 6.1.14 for CVEs
* Fix `KubePersistentVolumeFillingUp` alert still triggering due to always < 15% free
* Fix empty ipAddressV4 returning 127.0.0.1 in gRPC nodes API
* Update release checklist after environments converted to Citus only

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
