### PR TITLE
Track parser's recoverable errors at warning level

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/util/Utility.java
@@ -195,7 +195,7 @@ public class Utility {
     /**
      * Handle a parser recoverable error. Depending on the value of the system property
      * HEDERA_MIRROR_IMPORTER_PARSER_HALTONERROR, when false (default), the provided message and arguments are logged at
-     * ERROR level, with the message prepended with the String defined by Utility.RECOVERABLE_ERROR, identifying it as a
+     * WARN level, with the message prepended with the String defined by Utility.RECOVERABLE_ERROR, identifying it as a
      * recoverable error.
      * <p/>
      * When the system property is set to true, then ParserException is thrown, and the provided message and arguments
@@ -217,7 +217,7 @@ public class Utility {
             var formattedMessage = formattingTuple.getMessage();
             throw new ParserException(formattedMessage, throwable);
         } else {
-            log.error(RECOVERABLE_ERROR + message, args);
+            log.warn(RECOVERABLE_ERROR + message, args);
         }
     }
 


### PR DESCRIPTION
**Description**:

Track recoverable errors of the parser at warning level.

Considering that other parts of the code seem to consider this as a warning, and considering that the user has the ability to set whether to consider this type of error as a real error to worry about with the use of the `HEDERA_MIRROR_IMPORTER_PARSER_HALTONERROR` env parameter, it would be useful to set these messages to warning level so that we can exclude them from the logs, while retaining the ability to track all other parser's errors.

**Related issue(s)**:

N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
