### PR TITLE
fix: Fix contract deployment with value

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/BytecodeUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/BytecodeUtils.java
@@ -33,7 +33,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class BytecodeUtils {
 
-    public static final String SKIP_INIT_CODE_CHECK = "HEDERA_MIRROR_WEB3_EVM_SKIP_CHECKINITCODE";
+    public static final String SKIP_INIT_CODE_CHECK = "HEDERA_MIRROR_WEB3_EVM_SKIPINITCODECHECK";
     private static final String CODECOPY = "39";
     private static final String RETURN = "f3";
     private static final long MINIMUM_INIT_CODE_SIZE = 14L;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/BytecodeUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/BytecodeUtils.java
@@ -33,7 +33,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class BytecodeUtils {
 
-    public static final String SKIP_INIT_CODE_CHECK = "HEDERA_MIRROR_WEB3_EVM_CHECKINITCODE";
+    public static final String SKIP_INIT_CODE_CHECK = "HEDERA_MIRROR_WEB3_EVM_SKIP_CHECKINITCODE";
     private static final String CODECOPY = "39";
     private static final String RETURN = "f3";
     private static final long MINIMUM_INIT_CODE_SIZE = 14L;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/BytecodeUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/BytecodeUtils.java
@@ -30,7 +30,7 @@ import lombok.experimental.UtilityClass;
  * </p>
  */
 @UtilityClass
-public class RuntimeBytecodeExtractor {
+public class BytecodeUtils {
 
     private static final String CODECOPY = "39";
     private static final String RETURN = "f3";

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/BytecodeUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/BytecodeUtils.java
@@ -33,6 +33,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class BytecodeUtils {
 
+    public static final String SKIP_INIT_CODE_CHECK = "HEDERA_MIRROR_WEB3_EVM_CHECKINITCODE";
     private static final String CODECOPY = "39";
     private static final String RETURN = "f3";
     private static final long MINIMUM_INIT_CODE_SIZE = 14L;
@@ -44,19 +45,24 @@ public class BytecodeUtils {
     /**
      * Compiled regex pattern to match the init bytecode sequence. The pattern checks for a sequence of a free memory
      * pointer setup, a CODECOPY operation, and a RETURN operation, in that order. The sequence is matched
-     * case-insensitively to account for hexadecimal representations. Pattern explanation: - (?i) enables
-     * case-insensitive matching for the entire pattern. - (%s|%s) matches either FREE_MEMORY_POINTER or
-     * FREE_MEMORY_POINTER_2, which represent setup instructions for the free memory pointer, required for
-     * initialization bytecode. - .* matches any sequence of characters (including none) after the free memory pointer
-     * setup. - %s matches the CODECOPY opcode, which copies code to memory and typically follows the memory pointer
-     * setup in init bytecode. - .* matches any sequence of characters (including none) between CODECOPY and RETURN. %s
-     * matches the RETURN opcode, signaling the end of the initialization bytecode.
+     * case-insensitively to account for hexadecimal representations.
      * <p>
-     * Example pattern: (?i)(60806040|60606040).*39.*f3 This example would match any sequence where either "60806040" or
-     * "60606040" appears, followed by "39" (CODECOPY) and then "f3" (RETURN), with any characters in between.
+     * Pattern explanation: - (%s|%s) matches either FREE_MEMORY_POINTER or FREE_MEMORY_POINTER_2, which represent setup
+     * instructions for the free memory pointer, required for initialization bytecode. - [0-9a-z]+ matches one or more
+     * valid hexadecimal characters (0-9, a-f) after the free memory pointer setup. - %s matches the CODECOPY opcode,
+     * which copies code to memory and typically follows the memory pointer setup in init bytecode. - [0-9a-z]+ matches
+     * one or more valid hexadecimal characters (0-9, a-f) between CODECOPY and RETURN. - %s matches the RETURN opcode,
+     * signaling the end of the initialization bytecode.
+     *
+     * <p>
+     * Example pattern: (60806040|60606040)[0-9a-z]+39[0-9a-z]+f3 This example would match any sequence where either
+     * "60806040" or "60606040" appears, followed by "39" (CODECOPY) and then "f3" (RETURN), with valid hexadecimal
+     * characters in between.
      */
     private static final Pattern INIT_BYTECODE_PATTERN = Pattern.compile(
-            String.format("(?i)(%s|%s).*%s.*%s", FREE_MEMORY_POINTER, FREE_MEMORY_POINTER_2, CODECOPY, RETURN));
+            String.format(
+                    "(%s|%s)[0-9a-z]+%s[0-9a-z]+%s", FREE_MEMORY_POINTER, FREE_MEMORY_POINTER_2, CODECOPY, RETURN),
+            Pattern.CASE_INSENSITIVE);
 
     public static String extractRuntimeBytecode(String initBytecode) {
         // Check if the bytecode starts with "0x" and remove it if necessary
@@ -95,11 +101,19 @@ public class BytecodeUtils {
      * @param data the data string to check.
      * @return true if it is init bytecode, false otherwise.
      */
-    public static boolean isInitBytecode(String data) {
+    public static boolean isInitBytecode(final String data) {
         if (data == null || data.length() < MINIMUM_INIT_CODE_SIZE) {
             return false;
         }
 
         return INIT_BYTECODE_PATTERN.matcher(data).find();
+    }
+
+    public static boolean isValidInitBytecode(final String data) {
+        return shouldSkipBytecodeCheck() || BytecodeUtils.isInitBytecode(data);
+    }
+
+    private static boolean shouldSkipBytecodeCheck() {
+        return Boolean.parseBoolean(System.getenv(SKIP_INIT_CODE_CHECK));
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractor.java
@@ -33,6 +33,7 @@ import lombok.experimental.UtilityClass;
 public class RuntimeBytecodeExtractor {
 
     private static final String CODECOPY = "39";
+    private static final String RETURN = "f3";
     private static final String RUNTIME_CODE_PREFIX =
             "6080"; // The pattern to find the start of the runtime code in the init bytecode
 
@@ -65,5 +66,23 @@ public class RuntimeBytecodeExtractor {
 
         // Extract the runtime bytecode starting from the runtimeCodePrefixIndex
         return initBytecode.substring(runtimeCodePrefixIndex);
+    }
+
+    /**
+     * Checks if a given data string is likely init bytecode.
+     * @param data the data string to check.
+     * @return true if it is init bytecode, false otherwise.
+     */
+    public static boolean isInitBytecode(final String data) {
+        if (data == null || data.isEmpty()) {
+            return false;
+        }
+
+        // CODECOPY (0x39) and RETURN (0xf3)
+        boolean hasCodeCopy = data.contains(CODECOPY);
+        boolean hasReturn = data.contains(RETURN);
+
+        // Check if both CODECOPY and RETURN opcodes are present
+        return hasCodeCopy && hasReturn;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractor.java
@@ -55,14 +55,14 @@ public class RuntimeBytecodeExtractor {
         int codeCopyIndex = initBytecode.indexOf(CODECOPY);
 
         if (codeCopyIndex == -1) {
-            throw new RuntimeException("CODECOPY instruction (39) not found in init bytecode.");
+            throw new IllegalArgumentException("CODECOPY instruction (39) not found in init bytecode.");
         }
 
         // Find the first occurrence of "6080" after the "CODECOPY"
         int runtimeCodePrefixIndex = initBytecode.indexOf(RUNTIME_CODE_PREFIX, codeCopyIndex);
 
         if (runtimeCodePrefixIndex == -1) {
-            throw new RuntimeException("Runtime code prefix (6080) not found after CODECOPY.");
+            throw new IllegalArgumentException("Runtime code prefix (6080) not found after CODECOPY.");
         }
 
         // Extract the runtime bytecode starting from the runtimeCodePrefixIndex

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractor.java
@@ -24,9 +24,9 @@ import lombok.experimental.UtilityClass;
 /**
  * A utility class for extracting runtime bytecode from init bytecode of a smart contract.
  * <p>
- * Smart contracts have init bytecode (constructor bytecode) and runtime bytecode (the code
- * executed when the contract is called). This class helps in extracting the runtime bytecode from the
- * given init bytecode by searching for specific patterns.
+ * Smart contracts have init bytecode (constructor bytecode) and runtime bytecode (the code executed when the contract
+ * is called). This class helps in extracting the runtime bytecode from the given init bytecode by searching for
+ * specific patterns.
  * </p>
  */
 @UtilityClass
@@ -34,6 +34,7 @@ public class RuntimeBytecodeExtractor {
 
     private static final String CODECOPY = "39";
     private static final String RETURN = "f3";
+    private static final long MINIMUM_INIT_CODE_SIZE = 14L;
     private static final String RUNTIME_CODE_PREFIX =
             "6080"; // The pattern to find the start of the runtime code in the init bytecode
 
@@ -70,6 +71,7 @@ public class RuntimeBytecodeExtractor {
 
     /**
      * Checks if a given data string is likely init bytecode.
+     *
      * @param data the data string to check.
      * @return true if it is init bytecode, false otherwise.
      */
@@ -81,8 +83,9 @@ public class RuntimeBytecodeExtractor {
         // CODECOPY (0x39) and RETURN (0xf3)
         boolean hasCodeCopy = data.contains(CODECOPY);
         boolean hasReturn = data.contains(RETURN);
+        boolean isValidSize = data.length() >= MINIMUM_INIT_CODE_SIZE;
 
-        // Check if both CODECOPY and RETURN opcodes are present
-        return hasCodeCopy && hasReturn;
+        // Check if both CODECOPY and RETURN opcodes are present and if the size is at least the minimum possible size.
+        return hasCodeCopy && hasReturn && isValidSize;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractor.java
@@ -75,10 +75,11 @@ public class RuntimeBytecodeExtractor {
      * @param data the data string to check.
      * @return true if it is init bytecode, false otherwise.
      */
-    public static boolean isInitBytecode(final String data) {
+    public static boolean isInitBytecode(String data) {
         if (data == null || data.isEmpty()) {
             return false;
         }
+        data = data.toLowerCase();
 
         // CODECOPY (0x39) and RETURN (0xf3)
         boolean hasCodeCopy = data.contains(CODECOPY);

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
@@ -64,6 +64,7 @@ public class ContractCallRequest {
 
     @AssertTrue(message = "must not be empty")
     private boolean hasTo() {
-        return RuntimeBytecodeExtractor.isInitBytecode(data) || StringUtils.isNotEmpty(to);
+        boolean isValidToField = value <= 0 || from == null || StringUtils.isNotEmpty(to);
+        return RuntimeBytecodeExtractor.isInitBytecode(data) || isValidToField;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hedera.mirror.web3.convert.BlockTypeDeserializer;
 import com.hedera.mirror.web3.convert.BlockTypeSerializer;
-import com.hedera.mirror.web3.utils.RuntimeBytecodeExtractor;
+import com.hedera.mirror.web3.utils.BytecodeUtils;
 import com.hedera.mirror.web3.validation.Hex;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
@@ -65,6 +65,6 @@ public class ContractCallRequest {
     @AssertTrue(message = "must not be empty")
     private boolean hasTo() {
         boolean isValidToField = value <= 0 || from == null || StringUtils.isNotEmpty(to);
-        return RuntimeBytecodeExtractor.isInitBytecode(data) || isValidToField;
+        return BytecodeUtils.isInitBytecode(data) || isValidToField;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
@@ -20,11 +20,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hedera.mirror.web3.convert.BlockTypeDeserializer;
 import com.hedera.mirror.web3.convert.BlockTypeSerializer;
+import com.hedera.mirror.web3.utils.RuntimeBytecodeExtractor;
 import com.hedera.mirror.web3.validation.Hex;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 
 @Data
 public class ContractCallRequest {
@@ -58,5 +60,10 @@ public class ContractCallRequest {
     @AssertTrue(message = "must not be empty")
     private boolean hasFrom() {
         return value <= 0 || from != null;
+    }
+
+    @AssertTrue(message = "must not be empty")
+    private boolean hasTo() {
+        return RuntimeBytecodeExtractor.isInitBytecode(data) || StringUtils.isNotEmpty(to);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
@@ -65,6 +65,6 @@ public class ContractCallRequest {
     @AssertTrue(message = "must not be empty")
     private boolean hasTo() {
         boolean isValidToField = value <= 0 || from == null || StringUtils.isNotEmpty(to);
-        return BytecodeUtils.isInitBytecode(data) || isValidToField;
+        return BytecodeUtils.isValidInitBytecode(data) || isValidToField;
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/viewmodel/ContractCallRequest.java
@@ -25,7 +25,6 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Data;
-import org.apache.commons.lang3.StringUtils;
 
 @Data
 public class ContractCallRequest {
@@ -59,10 +58,5 @@ public class ContractCallRequest {
     @AssertTrue(message = "must not be empty")
     private boolean hasFrom() {
         return value <= 0 || from != null;
-    }
-
-    @AssertTrue(message = "must not be empty")
-    private boolean hasTo() {
-        return value <= 0 || from == null || StringUtils.isNotEmpty(to);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -190,15 +190,6 @@ class ContractControllerTest {
     }
 
     @Test
-    void callInvalidToDueToTransfer() throws Exception {
-        final var request = request();
-        request.setTo(null);
-        contractCall(request)
-                .andExpect(status().isBadRequest())
-                .andExpect(content().string(new StringContains("to field")));
-    }
-
-    @Test
     void callMissingTo() throws Exception {
         final var exceptionMessage = "No such contract or token";
         final var request = request();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -128,18 +128,9 @@ class ContractControllerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"0x00000000000000000000000000000000000007e7", "0x00000000000000000000000000000000000004e2"})
-    void estimateGas(final String to) throws Exception {
-        final var request = request();
-        request.setEstimate(true);
-        request.setValue(0);
-        request.setTo(to);
-        contractCall(request).andExpect(status().isOk());
-    }
-
     @NullAndEmptySource
-    @ParameterizedTest
-    void estimateGasWithEmptyTo(String to) throws Exception {
+    @ValueSource(strings = {"0x00000000000000000000000000000000000007e7", "0x00000000000000000000000000000000000004e2"})
+    void estimateGas(String to) throws Exception {
         final var request = request();
         request.setEstimate(true);
         request.setValue(0);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -141,15 +141,15 @@ class ContractControllerTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
-                    DynamicEthCalls.BINARY,
-                    ERCTestContractHistorical.BINARY,
-                    EthCall.BINARY,
-                    EvmCodes.BINARY,
-                    EvmCodesHistorical.BINARY,
-                    ExchangeRatePrecompileHistorical.BINARY,
-                    NestedCallsHistorical.BINARY,
-                    PrecompileTestContractHistorical.BINARY,
-                    TestAddressThis.BINARY
+                DynamicEthCalls.BINARY,
+                ERCTestContractHistorical.BINARY,
+                EthCall.BINARY,
+                EvmCodes.BINARY,
+                EvmCodesHistorical.BINARY,
+                ExchangeRatePrecompileHistorical.BINARY,
+                NestedCallsHistorical.BINARY,
+                PrecompileTestContractHistorical.BINARY,
+                TestAddressThis.BINARY
             })
     void estimateGasContractDeploy(final String data) throws Exception {
         final var request = request();
@@ -203,13 +203,13 @@ class ContractControllerTest {
 
     @ValueSource(
             strings = {
-                    " ",
-                    "0x",
-                    "0xghijklmno",
-                    "0x00000000000000000000000000000000000004e",
-                    "0x00000000000000000000000000000000000004e2a",
-                    "0x000000000000000000000000000000Z0000007e7",
-                    "00000000001239847e"
+                " ",
+                "0x",
+                "0xghijklmno",
+                "0x00000000000000000000000000000000000004e",
+                "0x00000000000000000000000000000000000004e2a",
+                "0x000000000000000000000000000000Z0000007e7",
+                "00000000001239847e"
             })
     @ParameterizedTest
     void callInvalidTo(String to) throws Exception {
@@ -259,13 +259,13 @@ class ContractControllerTest {
     @EmptySource
     @ValueSource(
             strings = {
-                    " ",
-                    "0x",
-                    "0xghijklmno",
-                    "0x00000000000000000000000000000000000004e",
-                    "0x00000000000000000000000000000000000004e2a",
-                    "0x000000000000000000000000000000Z0000007e7",
-                    "00000000001239847e"
+                " ",
+                "0x",
+                "0xghijklmno",
+                "0x00000000000000000000000000000000000004e",
+                "0x00000000000000000000000000000000000004e2a",
+                "0x000000000000000000000000000000Z0000007e7",
+                "00000000001239847e"
             })
     @ParameterizedTest
     void callInvalidFrom(String from) throws Exception {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -88,7 +88,7 @@ class ContractControllerTest {
     private static final String CALL_URI = "/api/v1/contracts/call";
     private static final String ONE_BYTE_HEX = "80";
     private static final long THROTTLE_GAS_LIMIT = 10_000_000L;
-    private static final String INIT_CODE = "0x60006000556000526000526000f3";
+    private static final String INIT_CODE = "0x6080604052348015600f57600080fd5b5060a38061001c6000396000f3";
 
     @Resource
     private MockMvc mockMvc;
@@ -141,15 +141,15 @@ class ContractControllerTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
-                DynamicEthCalls.BINARY,
-                ERCTestContractHistorical.BINARY,
-                EthCall.BINARY,
-                EvmCodes.BINARY,
-                EvmCodesHistorical.BINARY,
-                ExchangeRatePrecompileHistorical.BINARY,
-                NestedCallsHistorical.BINARY,
-                PrecompileTestContractHistorical.BINARY,
-                TestAddressThis.BINARY
+                    DynamicEthCalls.BINARY,
+                    ERCTestContractHistorical.BINARY,
+                    EthCall.BINARY,
+                    EvmCodes.BINARY,
+                    EvmCodesHistorical.BINARY,
+                    ExchangeRatePrecompileHistorical.BINARY,
+                    NestedCallsHistorical.BINARY,
+                    PrecompileTestContractHistorical.BINARY,
+                    TestAddressThis.BINARY
             })
     void estimateGasContractDeploy(final String data) throws Exception {
         final var request = request();
@@ -203,13 +203,13 @@ class ContractControllerTest {
 
     @ValueSource(
             strings = {
-                " ",
-                "0x",
-                "0xghijklmno",
-                "0x00000000000000000000000000000000000004e",
-                "0x00000000000000000000000000000000000004e2a",
-                "0x000000000000000000000000000000Z0000007e7",
-                "00000000001239847e"
+                    " ",
+                    "0x",
+                    "0xghijklmno",
+                    "0x00000000000000000000000000000000000004e",
+                    "0x00000000000000000000000000000000000004e2a",
+                    "0x000000000000000000000000000000Z0000007e7",
+                    "00000000001239847e"
             })
     @ParameterizedTest
     void callInvalidTo(String to) throws Exception {
@@ -259,13 +259,13 @@ class ContractControllerTest {
     @EmptySource
     @ValueSource(
             strings = {
-                " ",
-                "0x",
-                "0xghijklmno",
-                "0x00000000000000000000000000000000000004e",
-                "0x00000000000000000000000000000000000004e2a",
-                "0x000000000000000000000000000000Z0000007e7",
-                "00000000001239847e"
+                    " ",
+                    "0x",
+                    "0xghijklmno",
+                    "0x00000000000000000000000000000000000004e",
+                    "0x00000000000000000000000000000000000004e2a",
+                    "0x000000000000000000000000000000Z0000007e7",
+                    "00000000001239847e"
             })
     @ParameterizedTest
     void callInvalidFrom(String from) throws Exception {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -45,6 +45,15 @@ import com.hedera.mirror.web3.service.ContractExecutionService;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
 import com.hedera.mirror.web3.viewmodel.GenericErrorResponse;
+import com.hedera.mirror.web3.web3j.generated.DynamicEthCalls;
+import com.hedera.mirror.web3.web3j.generated.ERCTestContractHistorical;
+import com.hedera.mirror.web3.web3j.generated.EthCall;
+import com.hedera.mirror.web3.web3j.generated.EvmCodes;
+import com.hedera.mirror.web3.web3j.generated.EvmCodesHistorical;
+import com.hedera.mirror.web3.web3j.generated.ExchangeRatePrecompileHistorical;
+import com.hedera.mirror.web3.web3j.generated.NestedCallsHistorical;
+import com.hedera.mirror.web3.web3j.generated.PrecompileTestContractHistorical;
+import com.hedera.mirror.web3.web3j.generated.TestAddressThis;
 import io.github.bucket4j.Bucket;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -118,6 +127,19 @@ class ContractControllerTest {
                 .content(convert(request)));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "0x00000000000000000000000000000000000007e7",
+            "0x00000000000000000000000000000000000004e2"
+    })
+    void estimateGas(final String to) throws Exception {
+        final var request = request();
+        request.setEstimate(true);
+        request.setValue(0);
+        request.setTo(to);
+        contractCall(request).andExpect(status().isOk());
+    }
+
     @NullAndEmptySource
     @ParameterizedTest
     void estimateGasWithEmptyTo(String to) throws Exception {
@@ -126,6 +148,28 @@ class ContractControllerTest {
         request.setValue(0);
         request.setTo(to);
         contractCall(request).andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                    DynamicEthCalls.BINARY,
+                    ERCTestContractHistorical.BINARY,
+                    EthCall.BINARY,
+                    EvmCodes.BINARY,
+                    EvmCodesHistorical.BINARY,
+                    ExchangeRatePrecompileHistorical.BINARY,
+                    NestedCallsHistorical.BINARY,
+                    PrecompileTestContractHistorical.BINARY,
+                    TestAddressThis.BINARY
+            })
+    void estimateGasContractDeploy(final String data) throws Exception {
+        final var request = request();
+        request.setEstimate(true);
+        request.setValue(0);
+        request.setTo(null);
+        request.setData(data);
+        contractCall(request).andExpect(status().isOk());
     }
 
     @ValueSource(longs = {2000, -2000, 16_000_000L, 0})
@@ -171,13 +215,13 @@ class ContractControllerTest {
 
     @ValueSource(
             strings = {
-                " ",
-                "0x",
-                "0xghijklmno",
-                "0x00000000000000000000000000000000000004e",
-                "0x00000000000000000000000000000000000004e2a",
-                "0x000000000000000000000000000000Z0000007e7",
-                "00000000001239847e"
+                    " ",
+                    "0x",
+                    "0xghijklmno",
+                    "0x00000000000000000000000000000000000004e",
+                    "0x00000000000000000000000000000000000004e2a",
+                    "0x000000000000000000000000000000Z0000007e7",
+                    "00000000001239847e"
             })
     @ParameterizedTest
     void callInvalidTo(String to) throws Exception {
@@ -218,13 +262,13 @@ class ContractControllerTest {
     @EmptySource
     @ValueSource(
             strings = {
-                " ",
-                "0x",
-                "0xghijklmno",
-                "0x00000000000000000000000000000000000004e",
-                "0x00000000000000000000000000000000000004e2a",
-                "0x000000000000000000000000000000Z0000007e7",
-                "00000000001239847e"
+                    " ",
+                    "0x",
+                    "0xghijklmno",
+                    "0x00000000000000000000000000000000000004e",
+                    "0x00000000000000000000000000000000000004e2a",
+                    "0x000000000000000000000000000000Z0000007e7",
+                    "00000000001239847e"
             })
     @ParameterizedTest
     void callInvalidFrom(String from) throws Exception {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -79,6 +79,7 @@ class ContractControllerTest {
     private static final String CALL_URI = "/api/v1/contracts/call";
     private static final String ONE_BYTE_HEX = "80";
     private static final long THROTTLE_GAS_LIMIT = 10_000_000L;
+    private static final String INIT_CODE = "0x60006000556000526000526000f3";
 
     @Resource
     private MockMvc mockMvc;
@@ -118,14 +119,13 @@ class ContractControllerTest {
     }
 
     @NullAndEmptySource
-    @ValueSource(strings = {"0x00000000000000000000000000000000000007e7"})
     @ParameterizedTest
-    void estimateGas(String to) throws Exception {
+    void estimateGasWithEmptyTo(String to) throws Exception {
         final var request = request();
         request.setEstimate(true);
         request.setValue(0);
         request.setTo(to);
-        contractCall(request).andExpect(status().isOk());
+        contractCall(request).andExpect(status().isBadRequest());
     }
 
     @ValueSource(longs = {2000, -2000, 16_000_000L, 0})
@@ -266,7 +266,7 @@ class ContractControllerTest {
         final var request = request();
         final var dataAsHex =
                 ONE_BYTE_HEX.repeat((int) evmProperties.getMaxDataSize().toBytes() + 1);
-        request.setTo(null);
+        request.setTo("0x00000000000000000000000000000000000004e2");
         request.setValue(0);
         request.setData("0x" + dataAsHex);
         request.setEstimate(true);
@@ -437,7 +437,7 @@ class ContractControllerTest {
     void callSuccessOnContractCreateWithMissingFrom() throws Exception {
         final var request = request();
         request.setFrom(null);
-        request.setTo(null);
+        request.setData(INIT_CODE);
         request.setValue(0);
         request.setEstimate(false);
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/controller/ContractControllerTest.java
@@ -128,10 +128,7 @@ class ContractControllerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-            "0x00000000000000000000000000000000000007e7",
-            "0x00000000000000000000000000000000000004e2"
-    })
+    @ValueSource(strings = {"0x00000000000000000000000000000000000007e7", "0x00000000000000000000000000000000000004e2"})
     void estimateGas(final String to) throws Exception {
         final var request = request();
         request.setEstimate(true);
@@ -147,21 +144,21 @@ class ContractControllerTest {
         request.setEstimate(true);
         request.setValue(0);
         request.setTo(to);
-        contractCall(request).andExpect(status().isBadRequest());
+        contractCall(request).andExpect(status().isOk());
     }
 
     @ParameterizedTest
     @ValueSource(
             strings = {
-                    DynamicEthCalls.BINARY,
-                    ERCTestContractHistorical.BINARY,
-                    EthCall.BINARY,
-                    EvmCodes.BINARY,
-                    EvmCodesHistorical.BINARY,
-                    ExchangeRatePrecompileHistorical.BINARY,
-                    NestedCallsHistorical.BINARY,
-                    PrecompileTestContractHistorical.BINARY,
-                    TestAddressThis.BINARY
+                DynamicEthCalls.BINARY,
+                ERCTestContractHistorical.BINARY,
+                EthCall.BINARY,
+                EvmCodes.BINARY,
+                EvmCodesHistorical.BINARY,
+                ExchangeRatePrecompileHistorical.BINARY,
+                NestedCallsHistorical.BINARY,
+                PrecompileTestContractHistorical.BINARY,
+                TestAddressThis.BINARY
             })
     void estimateGasContractDeploy(final String data) throws Exception {
         final var request = request();
@@ -215,19 +212,28 @@ class ContractControllerTest {
 
     @ValueSource(
             strings = {
-                    " ",
-                    "0x",
-                    "0xghijklmno",
-                    "0x00000000000000000000000000000000000004e",
-                    "0x00000000000000000000000000000000000004e2a",
-                    "0x000000000000000000000000000000Z0000007e7",
-                    "00000000001239847e"
+                " ",
+                "0x",
+                "0xghijklmno",
+                "0x00000000000000000000000000000000000004e",
+                "0x00000000000000000000000000000000000004e2a",
+                "0x000000000000000000000000000000Z0000007e7",
+                "00000000001239847e"
             })
     @ParameterizedTest
     void callInvalidTo(String to) throws Exception {
         final var request = request();
         request.setValue(0);
         request.setTo(to);
+        contractCall(request)
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(new StringContains("to field")));
+    }
+
+    @Test
+    void callInvalidToDueToTransfer() throws Exception {
+        final var request = request();
+        request.setTo(null);
         contractCall(request)
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string(new StringContains("to field")));
@@ -262,13 +268,13 @@ class ContractControllerTest {
     @EmptySource
     @ValueSource(
             strings = {
-                    " ",
-                    "0x",
-                    "0xghijklmno",
-                    "0x00000000000000000000000000000000000004e",
-                    "0x00000000000000000000000000000000000004e2a",
-                    "0x000000000000000000000000000000Z0000007e7",
-                    "00000000001239847e"
+                " ",
+                "0x",
+                "0xghijklmno",
+                "0x00000000000000000000000000000000000004e",
+                "0x00000000000000000000000000000000000004e2a",
+                "0x000000000000000000000000000000Z0000007e7",
+                "00000000001239847e"
             })
     @ParameterizedTest
     void callInvalidFrom(String from) throws Exception {
@@ -310,7 +316,7 @@ class ContractControllerTest {
         final var request = request();
         final var dataAsHex =
                 ONE_BYTE_HEX.repeat((int) evmProperties.getMaxDataSize().toBytes() + 1);
-        request.setTo("0x00000000000000000000000000000000000004e2");
+        request.setTo(null);
         request.setValue(0);
         request.setData("0x" + dataAsHex);
         request.setEstimate(true);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallAddressThisTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallAddressThisTest.java
@@ -141,7 +141,6 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
     void contractDeployWithValue() throws Exception {
         // Given
         final var contract = testWeb3jService.deployWithValue(TestAddressThis::deploy, BigInteger.valueOf(1000));
-
         final var request = new ContractCallRequest();
         request.setBlock(BlockType.LATEST);
         request.setData(contract.getContractBinary());

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallAddressThisTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallAddressThisTest.java
@@ -54,12 +54,16 @@ import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
 class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
 
     private static final String CALL_URI = "/api/v1/contracts/call";
+
     @Resource
     protected ContractExecutionService contractCallService;
+
     @Resource
     private MockMvc mockMvc;
+
     @Resource
     private ObjectMapper objectMapper;
+
     @SpyBean
     private ContractExecutionService contractExecutionService;
 
@@ -78,7 +82,7 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, Address.ZERO);
         final long actualGas = 57764L;
         assertThat(isWithinExpectedGasRange(
-                longValueOf.applyAsLong(contractCallService.processCall(serviceParameters)), actualGas))
+                        longValueOf.applyAsLong(contractCallService.processCall(serviceParameters)), actualGas))
                 .isTrue();
     }
 
@@ -98,11 +102,11 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
                 testWeb3jService.getContractRuntime(), Address.fromHexString(contract.getContractAddress()));
         final List<Bytes> capturedOutputs = new ArrayList<>();
         doAnswer(invocation -> {
-            HederaEvmTransactionProcessingResult result =
-                    (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
-            capturedOutputs.add(result.getOutput()); // Capture the result
-            return result;
-        })
+                    HederaEvmTransactionProcessingResult result =
+                            (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
+                    capturedOutputs.add(result.getOutput()); // Capture the result
+                    return result;
+                })
                 .when(contractExecutionService)
                 .callContract(any(), any());
 
@@ -128,8 +132,7 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
                 .andExpect(status().isOk())
                 .andExpect(result -> {
                     final var response = result.getResponse().getContentAsString();
-                    assertThat(response)
-                            .contains(BytecodeUtils.extractRuntimeBytecode(contract.getContractBinary()));
+                    assertThat(response).contains(BytecodeUtils.extractRuntimeBytecode(contract.getContractBinary()));
                 });
     }
 
@@ -148,8 +151,7 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
                 .andExpect(status().isOk())
                 .andExpect(result -> {
                     final var response = result.getResponse().getContentAsString();
-                    assertThat(response)
-                            .contains(BytecodeUtils.extractRuntimeBytecode(contract.getContractBinary()));
+                    assertThat(response).contains(BytecodeUtils.extractRuntimeBytecode(contract.getContractBinary()));
                 });
     }
 
@@ -160,7 +162,7 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, Address.ZERO);
         final long actualGas = 95401L;
         assertThat(isWithinExpectedGasRange(
-                longValueOf.applyAsLong(contractCallService.processCall(serviceParamaters)), actualGas))
+                        longValueOf.applyAsLong(contractCallService.processCall(serviceParamaters)), actualGas))
                 .isTrue();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallAddressThisTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallAddressThisTest.java
@@ -25,20 +25,49 @@ import static com.hedera.mirror.web3.utils.ContractCallTestUtil.longValueOf;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hedera.mirror.web3.utils.RuntimeBytecodeExtractor;
+import com.hedera.mirror.web3.viewmodel.BlockType;
+import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
 import com.hedera.mirror.web3.web3j.generated.TestAddressThis;
 import com.hedera.mirror.web3.web3j.generated.TestNestedAddressThis;
 import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
 import jakarta.annotation.Resource;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.SneakyThrows;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
 
+@AutoConfigureMockMvc
 class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
+
+    private static final String CALL_URI = "/api/v1/contracts/call";
+
+    @Resource
+    private MockMvc mockMvc;
+
+    @Resource
+    private ObjectMapper objectMapper;
+
+    @SneakyThrows
+    private ResultActions contractCall(ContractCallRequest request) {
+        return mockMvc.perform(post(CALL_URI)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(convert(request)));
+    }
 
     @Resource
     protected ContractExecutionService contractCallService;
@@ -48,7 +77,7 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
 
     @Test
     void deployAddressThisContract() {
-        final var contract = testWeb3jService.deploy(TestAddressThis::deploy);
+        final var contract = testWeb3jService.deployWithValue(TestAddressThis::deploy, BigInteger.valueOf(1000));
         final var serviceParameters = testWeb3jService.serviceParametersForTopLevelContractCreate(
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, Address.ZERO);
         final long actualGas = 57764L;
@@ -59,7 +88,7 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
 
     @Test
     void addressThisFromFunction() {
-        final var contract = testWeb3jService.deploy(TestAddressThis::deploy);
+        final var contract = testWeb3jService.deployWithValue(TestAddressThis::deploy, BigInteger.valueOf(1000));
         final var functionCall = contract.send_testAddressThisFunction();
         verifyEthCallAndEstimateGas(functionCall, contract);
     }
@@ -67,7 +96,8 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
     @Test
     void addressThisEthCallWithoutEvmAlias() throws Exception {
         // Given
-        final var contract = testWeb3jService.deployWithoutPersist(TestAddressThis::deploy);
+        final var contract =
+                testWeb3jService.deployWithoutPersistWithValue(TestAddressThis::deploy, BigInteger.valueOf(1000));
         addressThisContractPersist(
                 testWeb3jService.getContractRuntime(), Address.fromHexString(contract.getContractAddress()));
         final List<Bytes> capturedOutputs = new ArrayList<>();
@@ -86,6 +116,46 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
         // Then
         final var successfulResponse = "0x" + StringUtils.leftPad(result.substring(2), 64, '0');
         assertThat(successfulResponse).isEqualTo(capturedOutputs.getFirst().toHexString());
+    }
+
+    @Test
+    void contractDeployWithoutValue() throws Exception {
+        // Given
+        final var contract = testWeb3jService.deployWithValue(TestAddressThis::deploy, BigInteger.valueOf(1000));
+        final var request = new ContractCallRequest();
+        request.setBlock(BlockType.LATEST);
+        request.setData(contract.getContractBinary());
+        request.setFrom(Address.ZERO.toHexString());
+        // When
+        contractCall(request)
+                // Then
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    final var response = result.getResponse().getContentAsString();
+                    assertThat(response)
+                            .contains(RuntimeBytecodeExtractor.extractRuntimeBytecode(contract.getContractBinary()));
+                });
+    }
+
+    @Test
+    void contractDeployWithValue() throws Exception {
+        // Given
+        final var contract = testWeb3jService.deployWithValue(TestAddressThis::deploy, BigInteger.valueOf(1000));
+
+        final var request = new ContractCallRequest();
+        request.setBlock(BlockType.LATEST);
+        request.setData(contract.getContractBinary());
+        request.setFrom(Address.ZERO.toHexString());
+        request.setValue(1000);
+        // When
+        contractCall(request)
+                // Then
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    final var response = result.getResponse().getContentAsString();
+                    assertThat(response)
+                            .contains(RuntimeBytecodeExtractor.extractRuntimeBytecode(contract.getContractBinary()));
+                });
     }
 
     @Test
@@ -115,5 +185,10 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
                 .customize(c -> c.id(addressThisContractEntityId.getId()).runtimeBytecode(runtimeBytecode))
                 .persist();
         domainBuilder.recordFile().customize(f -> f.bytes(runtimeBytecode)).persist();
+    }
+
+    @SneakyThrows
+    private String convert(Object object) {
+        return objectMapper.writeValueAsString(object);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
@@ -135,8 +135,7 @@ class ContractCallServiceERCTokenModificationFunctionsTest extends AbstractContr
                 .andExpect(status().isOk())
                 .andExpect(result -> {
                     final var response = result.getResponse().getContentAsString();
-                    assertThat(response)
-                            .contains(BytecodeUtils.extractRuntimeBytecode(contract.getContractBinary()));
+                    assertThat(response).contains(BytecodeUtils.extractRuntimeBytecode(contract.getContractBinary()));
                 });
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
@@ -24,19 +24,48 @@ import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SENDER_PUBLIC_KE
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SPENDER_ALIAS;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.SPENDER_PUBLIC_KEY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
+import com.hedera.mirror.web3.utils.RuntimeBytecodeExtractor;
+import com.hedera.mirror.web3.viewmodel.BlockType;
+import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
 import com.hedera.mirror.web3.web3j.generated.ERCTestContract;
 import com.hedera.mirror.web3.web3j.generated.RedirectTestContract;
+import jakarta.annotation.Resource;
 import java.math.BigInteger;
+import lombok.SneakyThrows;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
+@AutoConfigureMockMvc
 class ContractCallServiceERCTokenModificationFunctionsTest extends AbstractContractCallServiceTest {
+
+    private static final String CALL_URI = "/api/v1/contracts/call";
+
+    @Resource
+    private MockMvc mockMvc;
+
+    @Resource
+    private ObjectMapper objectMapper;
+
+    @SneakyThrows
+    private ResultActions contractCall(ContractCallRequest request) {
+        return mockMvc.perform(post(CALL_URI)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(convert(request)));
+    }
 
     @Test
     void approveFungibleToken() {
@@ -90,6 +119,41 @@ class ContractCallServiceERCTokenModificationFunctionsTest extends AbstractContr
                 contract.send_approve(tokenAddress.toHexString(), Address.ZERO.toHexString(), BigInteger.ONE);
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract);
+    }
+
+    @Test
+    void contractDeployNonPayableWithoutValue() throws Exception {
+        // Given
+        final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
+        final var request = new ContractCallRequest();
+        request.setBlock(BlockType.LATEST);
+        request.setData(contract.getContractBinary());
+        request.setFrom(Address.ZERO.toHexString());
+        // When
+        contractCall(request)
+                // Then
+                .andExpect(status().isOk())
+                .andExpect(result -> {
+                    final var response = result.getResponse().getContentAsString();
+                    assertThat(response)
+                            .contains(RuntimeBytecodeExtractor.extractRuntimeBytecode(contract.getContractBinary()));
+                });
+    }
+
+    @Test
+    void contractDeployNonPayableWithValue() throws Exception {
+        // Given
+        final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
+
+        final var request = new ContractCallRequest();
+        request.setBlock(BlockType.LATEST);
+        request.setData(contract.getContractBinary());
+        request.setFrom(Address.ZERO.toHexString());
+        request.setValue(10);
+        // When
+        contractCall(request)
+                // Then
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -738,5 +802,10 @@ class ContractCallServiceERCTokenModificationFunctionsTest extends AbstractContr
                         .amount(amount)
                         .owner(owner.getId()))
                 .persist();
+    }
+
+    @SneakyThrows
+    private String convert(Object object) {
+        return objectMapper.writeValueAsString(object);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
@@ -144,7 +144,6 @@ class ContractCallServiceERCTokenModificationFunctionsTest extends AbstractContr
     void contractDeployNonPayableWithValue() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
-
         final var request = new ContractCallRequest();
         request.setBlock(BlockType.LATEST);
         request.setData(contract.getContractBinary());

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenModificationFunctionsTest.java
@@ -33,7 +33,7 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.token.Token;
 import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
-import com.hedera.mirror.web3.utils.RuntimeBytecodeExtractor;
+import com.hedera.mirror.web3.utils.BytecodeUtils;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
 import com.hedera.mirror.web3.web3j.generated.ERCTestContract;
@@ -136,7 +136,7 @@ class ContractCallServiceERCTokenModificationFunctionsTest extends AbstractContr
                 .andExpect(result -> {
                     final var response = result.getResponse().getContentAsString();
                     assertThat(response)
-                            .contains(RuntimeBytecodeExtractor.extractRuntimeBytecode(contract.getContractBinary()));
+                            .contains(BytecodeUtils.extractRuntimeBytecode(contract.getContractBinary()));
                 });
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/BytecodeUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/BytecodeUtilsTest.java
@@ -98,15 +98,15 @@ class BytecodeUtilsTest extends Web3IntegrationTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
-                    DynamicEthCalls.BINARY,
-                    ERCTestContractHistorical.BINARY,
-                    EthCall.BINARY,
-                    EvmCodes.BINARY,
-                    EvmCodesHistorical.BINARY,
-                    ExchangeRatePrecompileHistorical.BINARY,
-                    NestedCallsHistorical.BINARY,
-                    PrecompileTestContractHistorical.BINARY,
-                    TestAddressThis.BINARY
+                DynamicEthCalls.BINARY,
+                ERCTestContractHistorical.BINARY,
+                EthCall.BINARY,
+                EvmCodes.BINARY,
+                EvmCodesHistorical.BINARY,
+                ExchangeRatePrecompileHistorical.BINARY,
+                NestedCallsHistorical.BINARY,
+                PrecompileTestContractHistorical.BINARY,
+                TestAddressThis.BINARY
             })
     void testIsInitBytecode(final String data) {
         assertThat(BytecodeUtils.isInitBytecode(data)).isTrue();
@@ -115,19 +115,19 @@ class BytecodeUtilsTest extends Web3IntegrationTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
-                    "",
-                    "  ",
-                    "0x",
-                    "0x39", // Only CODECOPY, missing everything else
-                    "0xf30039", // Contains RETURN and CODECOPY, but in the wrong order
-                    "608060", // Starts with a partial free memory pointer setup
-                    "608060403900000", // Free memory pointer setup + CODECOPY but missing RETURN
-                    "396080604000000", // CODECOPY before free memory pointer setup
-                    "606060f3", // Free memory pointer setup + RETURN but missing CODECOPY
-                    "60404039f2", // Free memory pointer setup + CODECOPY, but invalid opcode instead of RETURN
-                    "0x0039608040f3", // CODECOPY at start, free memory pointer setup and RETURN out of order
-                    "60806040f360", // Free memory pointer setup followed by RETURN and CODECOPY out of order
-                    "0x608060f34039", // Free memory pointer setup, RETURN before CODECOPY
+                "",
+                "  ",
+                "0x",
+                "0x39", // Only CODECOPY, missing everything else
+                "0xf30039", // Contains RETURN and CODECOPY, but in the wrong order
+                "608060", // Starts with a partial free memory pointer setup
+                "608060403900000", // Free memory pointer setup + CODECOPY but missing RETURN
+                "396080604000000", // CODECOPY before free memory pointer setup
+                "606060f3", // Free memory pointer setup + RETURN but missing CODECOPY
+                "60404039f2", // Free memory pointer setup + CODECOPY, but invalid opcode instead of RETURN
+                "0x0039608040f3", // CODECOPY at start, free memory pointer setup and RETURN out of order
+                "60806040f360", // Free memory pointer setup followed by RETURN and CODECOPY out of order
+                "0x608060f34039", // Free memory pointer setup, RETURN before CODECOPY
             })
     void testIsInitBytecodeFalse(final String data) {
         assertThat(BytecodeUtils.isInitBytecode(data)).isFalse();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/BytecodeUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/BytecodeUtilsTest.java
@@ -43,7 +43,7 @@ import org.springframework.context.annotation.Import;
 
 @Import(Web3jTestConfiguration.class)
 @RequiredArgsConstructor
-class RuntimeBytecodeExtractorTest extends Web3IntegrationTest {
+class BytecodeUtilsTest extends Web3IntegrationTest {
 
     private final ContractExecutionService contractExecutionService;
     private final TestWeb3jService testWeb3jService;
@@ -57,7 +57,7 @@ class RuntimeBytecodeExtractorTest extends Web3IntegrationTest {
     void testExtractRuntimeBytecodeEvmCodes() {
         final var serviceParameters =
                 testWeb3jService.serviceParametersForTopLevelContractCreate(EvmCodes.BINARY, ETH_CALL, Address.ZERO);
-        assertThat(RuntimeBytecodeExtractor.extractRuntimeBytecode(EvmCodes.BINARY))
+        assertThat(BytecodeUtils.extractRuntimeBytecode(EvmCodes.BINARY))
                 .isEqualTo(contractExecutionService.processCall(serviceParameters));
     }
 
@@ -65,7 +65,7 @@ class RuntimeBytecodeExtractorTest extends Web3IntegrationTest {
     void testExtractRuntimeBytecodeEthCall() {
         final var serviceParameters =
                 testWeb3jService.serviceParametersForTopLevelContractCreate(EthCall.BINARY, ETH_CALL, Address.ZERO);
-        assertThat(RuntimeBytecodeExtractor.extractRuntimeBytecode(EthCall.BINARY))
+        assertThat(BytecodeUtils.extractRuntimeBytecode(EthCall.BINARY))
                 .isEqualTo(contractExecutionService.processCall(serviceParameters));
     }
 
@@ -73,7 +73,7 @@ class RuntimeBytecodeExtractorTest extends Web3IntegrationTest {
     void testExtractRuntimeBytecodeExchangeRateHistorical() {
         final var serviceParameters = testWeb3jService.serviceParametersForTopLevelContractCreate(
                 ExchangeRatePrecompileHistorical.BINARY, ETH_CALL, Address.ZERO);
-        assertThat(RuntimeBytecodeExtractor.extractRuntimeBytecode(ExchangeRatePrecompileHistorical.BINARY))
+        assertThat(BytecodeUtils.extractRuntimeBytecode(ExchangeRatePrecompileHistorical.BINARY))
                 .isEqualTo(contractExecutionService.processCall(serviceParameters));
     }
 
@@ -81,7 +81,7 @@ class RuntimeBytecodeExtractorTest extends Web3IntegrationTest {
     void testExtractRuntimeBytecodeMissingCODECOPY() {
         String initBytecode = "6080abcdef"; // No CODECOPY present
         final var exception = assertThrows(RuntimeException.class, () -> {
-            RuntimeBytecodeExtractor.extractRuntimeBytecode(initBytecode);
+            BytecodeUtils.extractRuntimeBytecode(initBytecode);
         });
         assertThat(exception.getMessage()).isEqualTo("CODECOPY instruction (39) not found in init bytecode.");
     }
@@ -90,7 +90,7 @@ class RuntimeBytecodeExtractorTest extends Web3IntegrationTest {
     void testExtractRuntimeBytecodeMissingRuntimePrefix() {
         String initBytecode = "395ff3fe"; // CODECOPY present but no runtime code prefix
         RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
-            RuntimeBytecodeExtractor.extractRuntimeBytecode(initBytecode);
+            BytecodeUtils.extractRuntimeBytecode(initBytecode);
         });
         assertThat(thrown.getMessage()).isEqualTo("Runtime code prefix (6080) not found after CODECOPY.");
     }
@@ -98,38 +98,38 @@ class RuntimeBytecodeExtractorTest extends Web3IntegrationTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
-                DynamicEthCalls.BINARY,
-                ERCTestContractHistorical.BINARY,
-                EthCall.BINARY,
-                EvmCodes.BINARY,
-                EvmCodesHistorical.BINARY,
-                ExchangeRatePrecompileHistorical.BINARY,
-                NestedCallsHistorical.BINARY,
-                PrecompileTestContractHistorical.BINARY,
-                TestAddressThis.BINARY
+                    DynamicEthCalls.BINARY,
+                    ERCTestContractHistorical.BINARY,
+                    EthCall.BINARY,
+                    EvmCodes.BINARY,
+                    EvmCodesHistorical.BINARY,
+                    ExchangeRatePrecompileHistorical.BINARY,
+                    NestedCallsHistorical.BINARY,
+                    PrecompileTestContractHistorical.BINARY,
+                    TestAddressThis.BINARY
             })
     void testIsInitBytecode(final String data) {
-        assertThat(RuntimeBytecodeExtractor.isInitBytecode(data)).isTrue();
+        assertThat(BytecodeUtils.isInitBytecode(data)).isTrue();
     }
 
     @ParameterizedTest
     @ValueSource(
             strings = {
-                "",
-                "  ",
-                "0x",
-                "0x39", // Only CODECOPY, missing everything else
-                "0xf30039", // Contains RETURN and CODECOPY, but in the wrong order
-                "608060", // Starts with a partial free memory pointer setup
-                "608060403900000", // Free memory pointer setup + CODECOPY but missing RETURN
-                "396080604000000", // CODECOPY before free memory pointer setup
-                "606060f3", // Free memory pointer setup + RETURN but missing CODECOPY
-                "60404039f2", // Free memory pointer setup + CODECOPY, but invalid opcode instead of RETURN
-                "0x0039608040f3", // CODECOPY at start, free memory pointer setup and RETURN out of order
-                "60806040f360", // Free memory pointer setup followed by RETURN and CODECOPY out of order
-                "0x608060f34039", // Free memory pointer setup, RETURN before CODECOPY
+                    "",
+                    "  ",
+                    "0x",
+                    "0x39", // Only CODECOPY, missing everything else
+                    "0xf30039", // Contains RETURN and CODECOPY, but in the wrong order
+                    "608060", // Starts with a partial free memory pointer setup
+                    "608060403900000", // Free memory pointer setup + CODECOPY but missing RETURN
+                    "396080604000000", // CODECOPY before free memory pointer setup
+                    "606060f3", // Free memory pointer setup + RETURN but missing CODECOPY
+                    "60404039f2", // Free memory pointer setup + CODECOPY, but invalid opcode instead of RETURN
+                    "0x0039608040f3", // CODECOPY at start, free memory pointer setup and RETURN out of order
+                    "60806040f360", // Free memory pointer setup followed by RETURN and CODECOPY out of order
+                    "0x608060f34039", // Free memory pointer setup, RETURN before CODECOPY
             })
     void testIsInitBytecodeFalse(final String data) {
-        assertThat(RuntimeBytecodeExtractor.isInitBytecode(data)).isFalse();
+        assertThat(BytecodeUtils.isInitBytecode(data)).isFalse();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractorTest.java
@@ -24,13 +24,21 @@ import com.hedera.mirror.web3.Web3IntegrationTest;
 import com.hedera.mirror.web3.service.ContractExecutionService;
 import com.hedera.mirror.web3.web3j.TestWeb3jService;
 import com.hedera.mirror.web3.web3j.TestWeb3jService.Web3jTestConfiguration;
+import com.hedera.mirror.web3.web3j.generated.DynamicEthCalls;
+import com.hedera.mirror.web3.web3j.generated.ERCTestContractHistorical;
 import com.hedera.mirror.web3.web3j.generated.EthCall;
 import com.hedera.mirror.web3.web3j.generated.EvmCodes;
+import com.hedera.mirror.web3.web3j.generated.EvmCodesHistorical;
 import com.hedera.mirror.web3.web3j.generated.ExchangeRatePrecompileHistorical;
+import com.hedera.mirror.web3.web3j.generated.NestedCallsHistorical;
+import com.hedera.mirror.web3.web3j.generated.PrecompileTestContractHistorical;
+import com.hedera.mirror.web3.web3j.generated.TestAddressThis;
 import lombok.RequiredArgsConstructor;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.context.annotation.Import;
 
 @Import(Web3jTestConfiguration.class)
@@ -85,5 +93,22 @@ class RuntimeBytecodeExtractorTest extends Web3IntegrationTest {
             RuntimeBytecodeExtractor.extractRuntimeBytecode(initBytecode);
         });
         assertThat(thrown.getMessage()).isEqualTo("Runtime code prefix (6080) not found after CODECOPY.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                DynamicEthCalls.BINARY,
+                ERCTestContractHistorical.BINARY,
+                EthCall.BINARY,
+                EvmCodes.BINARY,
+                EvmCodesHistorical.BINARY,
+                ExchangeRatePrecompileHistorical.BINARY,
+                NestedCallsHistorical.BINARY,
+                PrecompileTestContractHistorical.BINARY,
+                TestAddressThis.BINARY
+            })
+    void testIsInitBytecode(final String data) {
+        assertThat(RuntimeBytecodeExtractor.isInitBytecode(data)).isTrue();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractorTest.java
@@ -111,4 +111,16 @@ class RuntimeBytecodeExtractorTest extends Web3IntegrationTest {
     void testIsInitBytecode(final String data) {
         assertThat(RuntimeBytecodeExtractor.isInitBytecode(data)).isTrue();
     }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "  ",
+                "0x",
+                "0x39",
+                "0xf30039",
+            })
+    void testIsInitBytecodeFalse(final String data) {
+        assertThat(RuntimeBytecodeExtractor.isInitBytecode(data)).isFalse();
+    }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/RuntimeBytecodeExtractorTest.java
@@ -115,10 +115,19 @@ class RuntimeBytecodeExtractorTest extends Web3IntegrationTest {
     @ParameterizedTest
     @ValueSource(
             strings = {
+                "",
                 "  ",
                 "0x",
-                "0x39",
-                "0xf30039",
+                "0x39", // Only CODECOPY, missing everything else
+                "0xf30039", // Contains RETURN and CODECOPY, but in the wrong order
+                "608060", // Starts with a partial free memory pointer setup
+                "608060403900000", // Free memory pointer setup + CODECOPY but missing RETURN
+                "396080604000000", // CODECOPY before free memory pointer setup
+                "606060f3", // Free memory pointer setup + RETURN but missing CODECOPY
+                "60404039f2", // Free memory pointer setup + CODECOPY, but invalid opcode instead of RETURN
+                "0x0039608040f3", // CODECOPY at start, free memory pointer setup and RETURN out of order
+                "60806040f360", // Free memory pointer setup followed by RETURN and CODECOPY out of order
+                "0x608060f34039", // Free memory pointer setup, RETURN before CODECOPY
             })
     void testIsInitBytecodeFalse(final String data) {
         assertThat(RuntimeBytecodeExtractor.isInitBytecode(data)).isFalse();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/web3j/TestWeb3jService.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/web3j/TestWeb3jService.java
@@ -133,6 +133,12 @@ public class TestWeb3jService implements Web3jService {
     }
 
     @SneakyThrows(Exception.class)
+    public <T extends Contract> T deployWithoutPersistWithValue(DeployerWithValue<T> deployer, BigInteger value) {
+        persistContract = false;
+        return deployer.deploy(web3j, credentials, contractGasProvider, value).send();
+    }
+
+    @SneakyThrows(Exception.class)
     public <T extends Contract> T deployWithValue(DeployerWithValue<T> deployer, BigInteger value) {
         return deployer.deploy(web3j, credentials, contractGasProvider, value).send();
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/web3j/TestWeb3jService.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/web3j/TestWeb3jService.java
@@ -30,7 +30,7 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.web3.service.ContractExecutionService;
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.service.model.ContractExecutionParameters;
-import com.hedera.mirror.web3.utils.RuntimeBytecodeExtractor;
+import com.hedera.mirror.web3.utils.BytecodeUtils;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.node.app.service.evm.store.models.HederaEvmAccount;
 import com.hederahashgraph.api.proto.java.Key.KeyCase;
@@ -176,7 +176,7 @@ public class TestWeb3jService implements Web3jService {
                     serviceParametersForTopLevelContractCreate(rawTransaction.getData(), ETH_CALL, sender);
             runtimeCode = contractExecutionService.processCall(serviceParameters);
         } else {
-            runtimeCode = RuntimeBytecodeExtractor.extractRuntimeBytecode(rawTransaction.getData());
+            runtimeCode = BytecodeUtils.extractRuntimeBytecode(rawTransaction.getData());
         }
         try {
             final var contractInstance = deployInternal(runtimeCode, persistContract);

--- a/hedera-mirror-web3/src/test/solidity/TestAddressThis.sol
+++ b/hedera-mirror-web3/src/test/solidity/TestAddressThis.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.18;
 
 contract TestAddressThis {
 
-    constructor() {
+    constructor() payable {
         address test = address(this);
         if (test == address(0)) {
             revert("Zero address.");


### PR DESCRIPTION
**Description**:

This PR fixes contract deployment when the contract deployment is made with value.

This PR modifies :
Modified `ContractCallRequest` - change the 'to' validation to check if the call is for contract deployment

`BytecodeUtils` - Added a new method `isInitBytecode` which checks if a given data is an init bytecode - needed in `ContractCallRequest` validation

`ContractControllerTest` - Added new test and modified a few existing ones based on the new changes to the validation of the to field.

Modified `ContractCallAddressThisTest` - added tests for deployment of payable contract with and without value
Modified `ContractCallServiceERCTokenModificationFunctionsTest` - added tests for deployment of non payable contract with and without value.


**Related issue(s)**:

Fixes #9636 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
