### PR TITLE
Fix restjava topics info endpoint ingress path regex

### DIFF
--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -82,7 +82,7 @@ ingress:
         - path: '/api/v1/accounts/(\d+\.){0,2}(\d+|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))/allowances/nfts'
         - path: '/api/v1/accounts/(\d+\.){0,2}(\d+|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))/airdrops/outstanding'
         - path: '/api/v1/accounts/(\d+\.){0,2}(\d+|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))/airdrops/pending'
-        - path: '/api/v1/topics/(\d+\.){0,2}\d+'
+        - path: '/api/v1/topics/(\d+\.){0,2}\d+$'
   tls:
     enabled: false
     secretName: ""


### PR DESCRIPTION
**Description**:
This PR fixes the ingress path regex for restjava topics info endpoint

- Add `$` at the end
 
**Related issue(s)**:

Fixes #9669 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
Ideally, we should use `^/api/v1/topics/(\d+\.){0,2}\d+$`, so traefik matches using `PathRegexp(``^/api/v1/topics/(\d+\.){0,2}\d+$``)`. However, k8s ingress spec mandates `path` begins with `/`.

The change has been manually applied to previewnet:

https://previewnet.mirrornode.hedera.com/api/v1/topics/0.0.3886/messages
https://previewnet.mirrornode.hedera.com/api/v1/topics/0.0.3886/messages/100

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
