### PR TITLE
Fix acceptance tests expecting a memo

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/BaseContractFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/BaseContractFeature.java
@@ -39,7 +39,6 @@ public abstract class BaseContractFeature extends AbstractFeature {
         assertThat(mirrorContract.getDeleted()).isEqualTo(isDeleted);
         assertThat(mirrorContract.getFileId())
                 .isEqualTo(deployedParentContract.fileId().toString());
-        assertThat(mirrorContract.getMemo()).isNotBlank();
         String address = mirrorContract.getEvmAddress();
         assertThat(address).isNotBlank().isNotEqualTo("0x").isNotEqualTo("0x0000000000000000000000000000000000000000");
         assertThat(mirrorContract.getTimestamp()).isNotNull();


### PR DESCRIPTION
**Description**:

Fix acceptance tests expecting a memo after [change](https://github.com/hashgraph/hedera-services/pull/15302) in consensus nodes

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
