### PR TITLE
Set ZFS ARC max/min before importing zpool

### DIFF
--- a/charts/hedera-mirror-common/templates/zfs/configmap-init.yaml
+++ b/charts/hedera-mirror-common/templates/zfs/configmap-init.yaml
@@ -194,6 +194,13 @@ data:
       echo "Configuring zpool ${POOL}"
       partprobe
 
+      ARC_SIZE_GB="${ARC_SIZE_GB:-2}"
+      echo "Configuring arc max to ${ARC_SIZE_GB}GB and arc min to 1/4 of max"
+      ARC_MAX="$((ARC_SIZE_GB*1073741824))"
+      ARC_MIN="$((ARC_MAX/4))"
+      echo $ARC_MIN >> /sys/module/zfs/parameters/zfs_arc_min
+      echo $ARC_MAX >> /sys/module/zfs/parameters/zfs_arc_max
+
       if (zfs list | grep -q "${POOL}"); then
           echo "Found existing pool. Skipping creation"
       elif (zpool create -o autoexpand=on "${POOL}" /dev/sdb); then
@@ -234,11 +241,6 @@ data:
       else
         echo "No L2 cache device specified. Skipping ..."
       fi
-
-      ARC_SIZE_GB="${ARC_SIZE_GB:-2}"
-      echo "Configuring arc to ${ARC_SIZE_GB}GB"
-      ARC_SIZE="$((ARC_SIZE_GB*1073741824))"
-      echo $ARC_SIZE >> /sys/module/zfs/parameters/zfs_arc_max
 
       zfs set primarycache=metadata xattr=sa "${POOL}"
       zpool set autoexpand=on "${POOL}"


### PR DESCRIPTION
**Description**:

This PR fixes the ZFS ARC max issue

- Set ZFS ARC max/min before importing zpool

**Related issue(s)**:

Fixes #9629

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Tested with mainnet disk / pool size, arc_summary with the fix

```
ARC status:                                                      HEALTHY
        Memory throttle count:                                         0

ARC size (current):                                     1.2 %   23.6 MiB
        Target size (adaptive):                       100.0 %    2.0 GiB
        Min size (hard limit):                         25.0 %  512.0 MiB
        Max size (high water):                            4:1    2.0 GiB
        Most Frequently Used (MFU) cache size:          2.9 %  639.0 KiB
        Most Recently Used (MRU) cache size:           97.1 %   21.0 MiB
        Metadata cache size (hard limit):              75.0 %    1.5 GiB
        Metadata cache size (current):                  1.5 %   23.6 MiB
        Dnode cache size (hard limit):                 10.0 %  153.6 MiB
        Dnode cache size (current):                     0.6 %  981.3 KiB
```

Note the value of ARC min isn't important, 1/4 is kind of a randomly picked ratio. However we want to set it before setting max, since the new max value will get ignored if it's smaller than the current min value.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
