### PR TITLE
Fixes to the bootstrap flow

### DIFF
--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -94,15 +94,6 @@ Edit the `bootstrap.env` file to set your own credentials and passwords for data
 
   - Otherwise, leave it as `false`.
 
-- **Set the `CREATE_MIRROR_API_USER` variable to `true` if you are bootstrapping a DB versioned 0.113.2 or earlier:**
-
-  ```bash
-  # Create mirror_api user for DBs versioned 0.113.2 or earlier
-  export CREATE_MIRROR_API_USER="true"
-  ```
-
-  - Otherwise, leave it as `false`.
-
 - **Set Database User Passwords:**
 
   ```bash
@@ -301,6 +292,10 @@ If you need to stop the script before it completes:
   ```
 
   - The script will resume where it left off, skipping files that have already been imported successfully.
+
+#### **Start the Mirrornode Importer**
+
+  - Once the bootstrap process completes without errors, you may start the Mirrornode Importer.
 
 ---
 

--- a/docs/database/bootstrap.md
+++ b/docs/database/bootstrap.md
@@ -94,6 +94,15 @@ Edit the `bootstrap.env` file to set your own credentials and passwords for data
 
   - Otherwise, leave it as `false`.
 
+- **Set the `CREATE_MIRROR_API_USER` variable to `true` if you are bootstrapping a DB versioned 0.113.2 or earlier:**
+
+  ```bash
+  # Create mirror_api user for DBs versioned 0.113.2 or earlier
+  export CREATE_MIRROR_API_USER="true"
+  ```
+
+  - Otherwise, leave it as `false`.
+
 - **Set Database User Passwords:**
 
   ```bash

--- a/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.env
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.env
@@ -7,6 +7,8 @@ export PGPORT="5432"
 
 # Is the DB a GCP Cloud SQL instance?
 export IS_GCP_CLOUD_SQL="false"
+# Create mirror_api user for DBs versioned 0.113.2 or earlier
+export CREATE_MIRROR_API_USER="false"
 
 # Set DB users' passwords
 export GRAPHQL_PASSWORD="SET_PASSWORD"

--- a/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.env
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.env
@@ -7,8 +7,8 @@ export PGPORT="5432"
 
 # Is the DB a GCP Cloud SQL instance?
 export IS_GCP_CLOUD_SQL="false"
-# Create mirror_api user for DBs versioned 0.113.2 or earlier
-export CREATE_MIRROR_API_USER="false"
+
+export CREATE_MIRROR_API_USER="true"
 
 # Set DB users' passwords
 export GRAPHQL_PASSWORD="SET_PASSWORD"

--- a/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.sh
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/bootstrap.sh
@@ -150,17 +150,8 @@ initialize_database() {
     exit 1
   fi
 
-  # Check for MIRRORNODE_VERSION in $IMPORT_DIR
-  if [[ -f "$IMPORT_DIR/MIRRORNODE_VERSION" ]]; then
-    MIRRORNODE_VERSION=$(cat "$IMPORT_DIR/MIRRORNODE_VERSION")
-    log "Found MIRRORNODE_VERSION: $MIRRORNODE_VERSION"
-  else
-    log "Error: MIRRORNODE_VERSION file not found in $IMPORT_DIR" "ERROR"
-    exit 1
-  fi
-
   # Construct the URL for init.sh
-  INIT_SH_URL="https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/refs/tags/v$MIRRORNODE_VERSION/hedera-mirror-importer/src/main/resources/db/scripts/init.sh"
+  INIT_SH_URL="https://raw.githubusercontent.com/hashgraph/hedera-mirror-node/refs/heads/main/hedera-mirror-importer/src/main/resources/db/scripts/init.sh"
 
   # Download init.sh
   log "Downloading init.sh from $INIT_SH_URL"

--- a/hedera-mirror-importer/src/main/resources/db/scripts/init.sh
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/init.sh
@@ -7,6 +7,7 @@ export PGHOST="${PGHOST}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${POSTGRES_USER:-postgres}"
 export IS_GCP_CLOUD_SQL="${IS_GCP_CLOUD_SQL:-false}"
+export CREATE_MIRROR_API_USER="${CREATE_MIRROR_API_USER:-false}"
 
 DB_SPECIFIC_EXTENSION_SQL="create extension btree_gist;
                            create extension pg_trgm;"
@@ -51,6 +52,7 @@ psql --set ON_ERROR_STOP=1 \
   --set "web3Username=${WEB3_USERNAME:-mirror_web3}" \
   --set "tempSchema=${DB_TEMPSCHEMA:-temporary}" \
   --set "isGcpCloudSql=${IS_GCP_CLOUD_SQL}" \
+  --set "createMirrorApiUser=${CREATE_MIRROR_API_USER}" \
   --set "pgUser=${PGUSER}" <<__SQL__
 
 -- Create database & owner
@@ -78,6 +80,10 @@ create user :importerUsername with login password :'importerPassword' in role re
 create user :restJavaUsername with login password :'restJavaPassword' in role readonly;
 create user :rosettaUsername with login password :'rosettaPassword' in role readonly;
 create user :web3Username with login password :'web3Password' in role readonly;
+
+\if :createMirrorApiUser
+  create user :restUsername with login password :'restPassword' in role readonly;
+\endif
 
 -- Grant temp schema admin privileges
 grant temporary_admin to :ownerUsername;

--- a/hedera-mirror-importer/src/main/resources/db/scripts/init.sh
+++ b/hedera-mirror-importer/src/main/resources/db/scripts/init.sh
@@ -7,7 +7,6 @@ export PGHOST="${PGHOST}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${POSTGRES_USER:-postgres}"
 export IS_GCP_CLOUD_SQL="${IS_GCP_CLOUD_SQL:-false}"
-export CREATE_MIRROR_API_USER="${CREATE_MIRROR_API_USER:-false}"
 
 DB_SPECIFIC_EXTENSION_SQL="create extension btree_gist;
                            create extension pg_trgm;"
@@ -28,6 +27,9 @@ if [[ "${SCHEMA_V2}" == "true" ]]; then
                              alter type timestamptz owner to :ownerUsername;
                              "
   DB_SPECIFIC_MIRROR_IMPORTER_ROLE_ADMIN=
+fi
+
+if [[ "${SCHEMA_V2}" == "true" || "${CREATE_MIRROR_API_USER}" == "true" ]]; then
   DB_SPECIFIC_SQL="create user :restUsername with login password :'restPassword' in role readonly;"
 fi
 
@@ -52,7 +54,6 @@ psql --set ON_ERROR_STOP=1 \
   --set "web3Username=${WEB3_USERNAME:-mirror_web3}" \
   --set "tempSchema=${DB_TEMPSCHEMA:-temporary}" \
   --set "isGcpCloudSql=${IS_GCP_CLOUD_SQL}" \
-  --set "createMirrorApiUser=${CREATE_MIRROR_API_USER}" \
   --set "pgUser=${PGUSER}" <<__SQL__
 
 -- Create database & owner
@@ -80,10 +81,6 @@ create user :importerUsername with login password :'importerPassword' in role re
 create user :restJavaUsername with login password :'restJavaPassword' in role readonly;
 create user :rosettaUsername with login password :'rosettaPassword' in role readonly;
 create user :web3Username with login password :'web3Password' in role readonly;
-
-\if :createMirrorApiUser
-  create user :restUsername with login password :'restPassword' in role readonly;
-\endif
 
 -- Grant temp schema admin privileges
 grant temporary_admin to :ownerUsername;


### PR DESCRIPTION
**Description**:
- Added the `CREATE_MIRROR_API_USER` env var to `bootstrap.env`, defaults to `true`
- Add `CREATE_MIRROR_API_USER` as an OR condition to `init.sh` for the creation of the `mirror_api` user if $SCHEMA_V2 or $CREATE_MIRROR_API_USER are true.
- Update `INIT_SH_URL` in `bootstrap.sh` to download the init script from `main` branch rather than the respective version tags where it still contains the old version of init.sh.
- Remove the `MIRRORNODE_VERSION` variable from `bootstrap.sh` as it is no longer being used anywhere in the script following the change to `INIT_SH_URL`.
- Update `bootstrap.md` docs: add an entry at the end of the process to start the mirrornode importer.

**Related issue(s)**:

- Fixes https://github.com/swirlds/infrastructure/issues/6949

**Notes for reviewer**:
I've used this process to test the changes:
- Setup a Cloud SQL DB
- Download the small table files from the GCS bucket (0.111.0 to match Quicknode's)
- Use the bootstrap.sh and init.sh updated code in this PR to bootstrap the tables' data into the cloud sql instance while setting CREATE_MIRROR_API_USER to `true` for the `mirror_api` user to be created.
- Queried `flyway_schema_history` table to verify there's no entry "0"; The results begin with "1.0" from 2019-09-09.
- Started a local mirrornode-importer configured to work against mainnet's bucket and the bootstrapped DB instance, everything looks normal:

```
2024-11-08T17:18:18.499Z  INFO main c.h.m.i.ImporterApplication No active profile set, falling back to 1 default profile: "default"
2024-11-08T17:18:21.813Z  INFO main o.f.c.i.c.DbMigrate Current version of schema "public": 1.99.1
2024-11-08T17:18:21.825Z  INFO main o.f.c.i.c.DbMigrate Migrating schema "public" with repeatable migration "01 temp tables"
2024-11-08T17:18:22.014Z  INFO main o.f.c.i.c.DbMigrate Successfully applied 1 migration to schema "public" (execution time 00:00.128s)
2024-11-08T17:18:25.998Z  INFO main c.h.m.i.c.CloudStorageConfiguration Configured to download from bucket hedera-mainnet-streams
2024-11-08T17:18:26.057Z  INFO main c.h.m.i.c.CloudStorageConfiguration Setting up GCP client using provided access/secret key
2024-11-08T17:18:26.339Z  INFO main c.h.m.i.c.CloudStorageConfiguration Setting up S3 client using provided access/secret key
2024-11-08T17:18:28.124Z  INFO main c.h.m.i.c.MetricsConfiguration Collecting 59 table metrics: [custom_fee, entity_stake_history, ethereum_transaction, file_data, prng, crypto_allowance_history, address_book_entry, contract_action, transaction_hash, contract_state, entity_transaction, live_hash, assessed_custom_fee, token_balance, contract, token_account, account_balance_file, node_history, record_file, entity_stake, entity_history, topic_message_lookup, node, address_book_service_endpoint, nft, non_fee_transfer, account_balance, contract_state_change, transaction_signature, custom_fee_history, nft_history, nft_allowance_history, staking_reward_transfer, token_allowance_history, contract_transaction_hash, sidecar_file, node_stake, contract_result, crypto_transfer, network_stake, contract_transaction, transaction_child, entity_bkup, reconciliation_job, token_account_history, token_history, network_freeze, token_transfer, address_book, token, schedule, topic_message, contract_log, flyway_schema_history, token_allowance, crypto_allowance, nft_allowance, entity, transaction]
2024-11-08T17:18:28.253Z  INFO main c.h.m.i.ImporterApplication Started ImporterApplication in 10.531 seconds (process running for 10.834)
2024-11-08T17:18:28.369Z  INFO main c.h.m.i.d.PartitionMaintenance Running partition maintenance
2024-11-08T17:18:28.415Z  INFO main c.h.m.i.d.PartitionMaintenance Partition maintenance completed successfully in 46.06 ms
2024-11-08T17:18:28.427Z  INFO task-1 c.h.m.i.p.r.e.s.EntityStakeCalculatorImpl Skipping since the entity stake is up-to-date
2024-11-08T17:18:28.451Z  WARN scheduling-1 c.h.m.i.a.AddressBookServiceImpl Using address book 1724363804236820004 with 31 nodes and node stake 1724716800004544831 with 32 nodes
2024-11-08T17:18:28.457Z  INFO scheduling-1 c.h.m.i.c.DateRangeCalculator RECORD: downloader will download files in time range (2024-08-27T17:03:28.009025003Z, 2262-04-11T23:47:16.854775807Z]
2024-11-08T17:18:30.178Z  INFO scheduling-1 c.h.m.i.d.r.RecordFileDownloader Downloaded 775 signatures in 1.922 s (404/s): {2024-08-27T17_03_34.006507599Z.rcd_sig=30, 2024-08-27T17_03_36.017236201Z.rcd_sig=30, 2024-08-27T17_03_38.009493757Z.rcd_sig=30, 2024-08-27T17_03_30.004115003Z.rcd_sig=30, 2024-08-27T17_03_46.008792003Z.rcd_sig=30, 2024-08-27T17_03_42.022197003Z.rcd_sig=30, 2024-08-27T17_03_40.000203252Z.rcd_sig=30, 2024-08-27T17_03_32.004991003Z.rcd_sig=30, 2024-08-27T17_03_44.000035744Z.rcd_sig=30, 2024-08-27T17_03_48.021740678Z.rcd_sig=30}
2024-11-08T17:18:30.404Z  INFO pool-7-thread-2 c.h.m.i.c.DateRangeCalculator RECORD: parser will parse items in DateRangeFilter([2024-08-27T17:03:28.009025003Z, 2262-04-11T23:47:16.854775807Z])
2024-11-08T17:18:30.466Z  INFO pool-7-thread-2 c.h.m.i.p.b.BatchInserter Copied 1 rows to contract_log table in 10.13 ms
2024-11-08T17:18:30.502Z  INFO pool-7-thread-2 c.h.m.i.p.b.BatchInserter Copied 1680 rows to crypto_transfer table in 34.53 ms
2024-11-08T17:18:30.602Z  INFO pool-7-thread-2 c.h.m.i.p.b.BatchInserter Copied 35 rows to entity_temp table in 24.21 ms
2024-11-08T17:18:30.608Z  INFO pool-7-thread-2 c.h.m.i.p.b.BatchInserter Copied 1 rows to record_file table in 3.588 ms
2024-11-08T17:18:30.622Z  INFO pool-7-thread-2 c.h.m.i.p.b.BatchInserter Copied 411 rows to topic_message table in 13.52 ms
2024-11-08T17:18:30.639Z  INFO pool-7-thread-2 c.h.m.i.p.b.TransactionHashBatchInserter Copied 8 rows from 8 shards to transaction_hash table in 17.06 ms
2024-11-08T17:18:30.669Z  INFO pool-7-thread-2 c.h.m.i.p.b.BatchInserter Copied 3 rows to token_account_temp table in 16.39 ms
2024-11-08T17:18:30.689Z  INFO pool-7-thread-2 c.h.m.i.p.b.BatchInserter Copied 419 rows to transaction table in 18.24 ms
2024-11-08T17:18:30.695Z  INFO pool-7-thread-2 c.h.m.i.p.b.BatchInserter Copied 2 rows to token_transfer table in 4.392 ms
2024-11-08T17:18:30.696Z  INFO pool-7-thread-2 c.h.m.i.p.r.e.s.SqlEntityListener Completed batch inserts in 242.9 ms
2024-11-08T17:18:30.709Z  INFO pool-7-thread-2 c.h.m.i.p.r.RecordFileParser Successfully processed 419 items from 2024-08-27T17_03_30.004115003Z.rcd.gz in 322.0 ms
```

**Checklist**

- [x] Documented (Code comments and bootstrap.md)
- [x] Tested (test process steps described in the notes section)
