### PR TITLE
Remove -deprecation JVM flag

### DIFF
--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -52,9 +52,9 @@ dependencies {
 }
 
 tasks.compileJava {
-    // Disable deprecation, serial, and this-escape warnings due to errors in generated code
+    // Disable serial, and this-escape warnings due to errors in generated code
     options.compilerArgs.addAll(
-        listOf("-Werror", "-Xlint:all", "-Xlint:-deprecation,-serial,-this-escape,-preview")
+        listOf("-Werror", "-Xlint:all", "-Xlint:-serial,-this-escape,-preview")
     )
     options.encoding = "UTF-8"
     sourceCompatibility = "21"


### PR DESCRIPTION
**Description**:

Remove `-deprecation` JVM flag after fixing upstream library

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
