### PR TITLE
Fix openapi validator validateResponses config (0.117)

### DIFF
--- a/hedera-mirror-rest/__tests__/service/contractService.test.js
+++ b/hedera-mirror-rest/__tests__/service/contractService.test.js
@@ -972,14 +972,14 @@ describe('ContractService.getContractStateChangesByTimestamps tests', () => {
 
 describe('ContractService.getContractIdByEvmAddress tests', () => {
   test('No match', async () => {
-    const evmAddressFilter = {shard: 0, realm: 0, create2_evm_address: Buffer.from('123', 'hex')};
+    const evmAddressFilter = {shard: 0, realm: 0, create2_evm_address: 'deadbeaf'};
     await expect(() => ContractService.getContractIdByEvmAddress(evmAddressFilter)).rejects.toThrow(
-      new NotFoundError(`No contract with the given evm address: ${JSON.stringify(evmAddressFilter)} has been found.`)
+      new NotFoundError(`No contract with the given evm address 0xdeadbeaf has been found.`)
     );
   });
 
   test('Multiple rows match', async () => {
-    const evmAddress = Buffer.from('3d4ffd867fac5d9c228d1dbeb7f218a29c94b', 'hex');
+    const evmAddress = 'a25db2e7595e094b1074122a048030f90b76d526';
     await integrationDomainOps.loadContracts([
       {
         auto_renew_period: 7890000,
@@ -1042,7 +1042,7 @@ describe('ContractService.getContractIdByEvmAddress tests', () => {
 
     const evmAddressFilter = {shard: 0, realm: 0, create2_evm_address: evmAddress};
     await expect(() => ContractService.getContractIdByEvmAddress(evmAddressFilter)).rejects.toThrow(
-      new Error(`More than one contract with the evm address ${JSON.stringify(evmAddressFilter)} have been found.`)
+      new Error(`More than one contract with the evm address 0x${evmAddress} have been found.`)
     );
   });
 

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/logs/not-found.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/results/logs/not-found.json
@@ -1,23 +1,19 @@
 {
-  "description": "Contract results api call for a specific contract using contract id with varied filters and no matching results",
+  "description": "Contract logs api call for a specific contract using contract id with varied filters and no matching results",
   "setup": {},
   "tests": [
     {
-      "urls": [
-        "/api/v1/contracts/0.0.5001/results",
-        "/api/v1/contracts/0.0.5001/results?from=987654",
-        "/api/v1/contracts/0.0.5001/results?timestamp=987654.000123456"
-      ],
+      "url": "/api/v1/contracts/0.0.5001/results/logs",
       "responseStatus": 200,
       "responseJson": {
-        "results": [],
+        "logs": [],
         "links": {
           "next": null
         }
       }
     },
     {
-      "url": "/api/v1/contracts/0x5555555555555555555555555555555555555555/results",
+      "url": "/api/v1/contracts/0x5555555555555555555555555555555555555555/results/logs",
       "responseStatus": 404,
       "responseJson": {
         "_status": {

--- a/hedera-mirror-rest/__tests__/specs/contracts/{id}/state/not-found.json
+++ b/hedera-mirror-rest/__tests__/specs/contracts/{id}/state/not-found.json
@@ -19,7 +19,7 @@
     "_status": {
       "messages": [
         {
-          "message": "No contract with the given evm address: {\"shard\":null,\"realm\":null,\"create2_evm_address\":{\"type\":\"Buffer\",\"data\":[94,23,201,136,204,20,174,95,11,243,40,36,94,175,136,240,129,195,166,20]}} has been found."
+          "message": "No contract with the given evm address 0x5e17c988cc14ae5f0bf328245eaf88f081c3a614 has been found."
         }
       ]
     }

--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -534,6 +534,8 @@ paths:
                 $ref: "#/components/schemas/ContractResultsResponse"
         400:
           $ref: "#/components/responses/InvalidParameterError"
+        404:
+          $ref: "#/components/responses/NotFoundError"
       tags:
         - contracts
   /api/v1/contracts/{contractIdOrAddress}/state:
@@ -758,6 +760,8 @@ paths:
                 $ref: "#/components/schemas/ContractLogsResponse"
         400:
           $ref: "#/components/responses/InvalidParameterError"
+        404:
+          $ref: "#/components/responses/NotFoundError"
       tags:
         - contracts
   /api/v1/contracts/results/logs:

--- a/hedera-mirror-rest/middleware/openapiHandler.js
+++ b/hedera-mirror-rest/middleware/openapiHandler.js
@@ -159,14 +159,13 @@ const serveSwaggerDocs = (app) => {
 };
 
 const openApiValidator = (app) => {
+  const validateResponses = isTestEnv() ? {allErrors: true} : false;
   app.use(
     OpenApiValidator.middleware({
       apiSpec: path.resolve(process.cwd(), getSpecPath(1)),
       ignoreUndocumented: true,
       validateRequests: false,
-      validateResponses: {
-        allErrors: isTestEnv(),
-      },
+      validateResponses,
     })
   );
 };

--- a/hedera-mirror-rest/service/contractService.js
+++ b/hedera-mirror-rest/service/contractService.js
@@ -510,19 +510,17 @@ class ContractService extends BaseService {
   }
 
   async getContractIdByEvmAddress(evmAddressFilter) {
+    const create2EvmAddress = evmAddressFilter.create2_evm_address;
+    evmAddressFilter.create2_evm_address = Buffer.from(create2EvmAddress, 'hex');
     const {params, conditions} = this.computeConditionsAndParamsFromEvmAddressFilter({evmAddressFilter});
     const query = `${ContractService.contractIdByEvmAddressQuery} and ${conditions.join(' and ')}`;
     const rows = await super.getRows(query, params);
     if (rows.length === 0) {
-      throw new NotFoundError(
-        `No contract with the given evm address: ${JSONStringify(evmAddressFilter)} has been found.`
-      );
+      throw new NotFoundError(`No contract with the given evm address 0x${create2EvmAddress} has been found.`);
     }
     // since evm_address is not a unique index, it is important to make this check.
     if (rows.length > 1) {
-      throw new Error(
-        `More than one contract with the evm address ${JSONStringify(evmAddressFilter)} have been found.`
-      );
+      throw new Error(`More than one contract with the evm address 0x${create2EvmAddress} have been found.`);
     }
 
     return rows[0].id;
@@ -532,7 +530,6 @@ class ContractService extends BaseService {
     const contractIdParts = EntityId.computeContractIdPartsFromContractIdValue(contractIdValue);
 
     if (contractIdParts.hasOwnProperty('create2_evm_address')) {
-      contractIdParts.create2_evm_address = Buffer.from(contractIdParts.create2_evm_address, 'hex');
       return this.getContractIdByEvmAddress(contractIdParts);
     }
 


### PR DESCRIPTION
**Description**:
This PR backports the fix to `release/0.117`

- Fix openapi validator validateResponses config
- Change create2 evm address not found message
- Fix openapi spec

**Related issue(s)**:

Fixes #9733 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
