### PR TITLE
Add Cancun evm support web3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,6 +104,7 @@ dependencies {
         api("software.amazon.awssdk:bom:2.29.9")
         api("uk.org.webcompere:system-stubs-jupiter:2.1.7")
         api("org.web3j:core:4.12.2")
+        api("tech.pegasys:jc-kzg-4844:0.8.0")
     }
 }
 

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -64,7 +64,7 @@ web3j {
 }
 
 val historicalSolidityVersion = "0.8.7"
-val latestSolidityVersion = "0.8.24"
+val latestSolidityVersion = "0.8.25"
 
 // Define "testHistorical" source set needed for the test historical solidity contracts and web3j
 sourceSets {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -409,7 +409,7 @@ public class EvmConfiguration {
 
     @Bean
     HederaSelfDestructOperationV046 hederaSelfDestructOperationV046(final GasCalculator gasCalculator) {
-        return new HederaSelfDestructOperationV046(gasCalculator, addressValidator, systemAccountDetector);
+        return new HederaSelfDestructOperationV046(gasCalculator, addressValidator, systemAccountDetector, false);
     }
 
     @Bean

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -22,6 +22,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.mirror.web3.evm.contracts.execution.MirrorEvmMessageCallProcessor;
 import com.hedera.mirror.web3.evm.contracts.execution.MirrorEvmMessageCallProcessorV30;
+import com.hedera.mirror.web3.evm.contracts.execution.MirrorEvmMessageCallProcessorV50;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.MirrorOperationTracer;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.OpcodeTracer;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.TracerType;
@@ -48,6 +49,7 @@ import com.hedera.services.evm.contracts.operations.HederaPrngSeedOperation;
 import com.hedera.services.evm.contracts.operations.HederaSelfDestructOperation;
 import com.hedera.services.evm.contracts.operations.HederaSelfDestructOperationV038;
 import com.hedera.services.evm.contracts.operations.HederaSelfDestructOperationV046;
+import com.hedera.services.evm.contracts.operations.HederaSelfDestructOperationV050;
 import com.hedera.services.txns.crypto.AbstractAutoCreationLogic;
 import com.hedera.services.txns.util.PrngLogic;
 import java.util.EnumMap;
@@ -70,6 +72,7 @@ import org.hyperledger.besu.evm.operation.BalanceOperation;
 import org.hyperledger.besu.evm.operation.ExtCodeHashOperation;
 import org.hyperledger.besu.evm.operation.OperationRegistry;
 import org.hyperledger.besu.evm.operation.SelfDestructOperation;
+import org.hyperledger.besu.evm.precompile.KZGPointEvalPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.processor.ContractCreationProcessor;
 import org.hyperledger.besu.evm.processor.MessageCallProcessor;
@@ -115,7 +118,8 @@ public class EvmConfiguration {
     public static final SemanticVersion EVM_VERSION_0_34 = new SemanticVersion(0, 34, 0, "", "");
     public static final SemanticVersion EVM_VERSION_0_38 = new SemanticVersion(0, 38, 0, "", "");
     public static final SemanticVersion EVM_VERSION_0_46 = new SemanticVersion(0, 46, 0, "", "");
-    public static final SemanticVersion EVM_VERSION = EVM_VERSION_0_46;
+    public static final SemanticVersion EVM_VERSION_0_50 = new SemanticVersion(0, 50, 0, "", "");
+    public static final SemanticVersion EVM_VERSION = EVM_VERSION_0_50;
     private final CacheProperties cacheProperties;
     private final MirrorNodeEvmProperties mirrorNodeEvmProperties;
     private final GasCalculatorHederaV22 gasCalculator;
@@ -243,12 +247,14 @@ public class EvmConfiguration {
             final ContractCreationProcessor contractCreationProcessor30,
             final ContractCreationProcessor contractCreationProcessor34,
             final ContractCreationProcessor contractCreationProcessor38,
-            final ContractCreationProcessor contractCreationProcessor46) {
+            final ContractCreationProcessor contractCreationProcessor46,
+            final ContractCreationProcessor contractCreationProcessor50) {
         Map<SemanticVersion, Provider<ContractCreationProcessor>> processorsMap = new HashMap<>();
         processorsMap.put(EVM_VERSION_0_30, () -> contractCreationProcessor30);
         processorsMap.put(EVM_VERSION_0_34, () -> contractCreationProcessor34);
         processorsMap.put(EVM_VERSION_0_38, () -> contractCreationProcessor38);
         processorsMap.put(EVM_VERSION_0_46, () -> contractCreationProcessor46);
+        processorsMap.put(EVM_VERSION_0_50, () -> contractCreationProcessor50);
         return processorsMap;
     }
 
@@ -257,13 +263,14 @@ public class EvmConfiguration {
             MirrorEvmMessageCallProcessorV30 mirrorEvmMessageCallProcessor30,
             MirrorEvmMessageCallProcessor mirrorEvmMessageCallProcessor34,
             MirrorEvmMessageCallProcessor mirrorEvmMessageCallProcessor38,
-            MirrorEvmMessageCallProcessor mirrorEvmMessageCallProcessor46) {
+            MirrorEvmMessageCallProcessor mirrorEvmMessageCallProcessor46,
+            MirrorEvmMessageCallProcessorV50 mirrorEvmMessageCallProcessor50) {
         Map<SemanticVersion, Provider<MessageCallProcessor>> processorsMap = new HashMap<>();
         processorsMap.put(EVM_VERSION_0_30, () -> mirrorEvmMessageCallProcessor30);
         processorsMap.put(EVM_VERSION_0_34, () -> mirrorEvmMessageCallProcessor34);
         processorsMap.put(EVM_VERSION_0_38, () -> mirrorEvmMessageCallProcessor38);
         processorsMap.put(EVM_VERSION_0_46, () -> mirrorEvmMessageCallProcessor46);
-
+        processorsMap.put(EVM_VERSION_0_50, () -> mirrorEvmMessageCallProcessor50);
         return processorsMap;
     }
 
@@ -357,6 +364,24 @@ public class EvmConfiguration {
     }
 
     @Bean
+    EVM evm050(
+            final HederaPrngSeedOperation prngSeedOperation,
+            final HederaSelfDestructOperationV050 hederaSelfDestructOperationV050,
+            final HederaBalanceOperationV038 hederaBalanceOperationV038) {
+        KZGPointEvalPrecompiledContract.init();
+        return evm(
+                gasCalculator,
+                mirrorNodeEvmProperties,
+                prngSeedOperation,
+                hederaBlockHashOperation,
+                hederaExtCodeHashOperationV038,
+                hederaSelfDestructOperationV050,
+                hederaBalanceOperationV038,
+                EvmSpecVersion.CANCUN,
+                MainnetEVMs::registerCancunOperations);
+    }
+
+    @Bean
     HederaPrngSeedOperation hederaPrngSeedOperation(final GasCalculator gasCalculator, final PrngLogic prngLogic) {
         return new HederaPrngSeedOperation(gasCalculator, prngLogic);
     }
@@ -388,6 +413,11 @@ public class EvmConfiguration {
     }
 
     @Bean
+    HederaSelfDestructOperationV050 hederaSelfDestructOperationV050(final GasCalculator gasCalculator) {
+        return new HederaSelfDestructOperationV050(gasCalculator, addressValidator, systemAccountDetector);
+    }
+
+    @Bean
     PrecompileContractRegistry precompileContractRegistry() {
         return new PrecompileContractRegistry();
     }
@@ -409,6 +439,11 @@ public class EvmConfiguration {
 
     @Bean
     public ContractCreationProcessor contractCreationProcessor46(@Qualifier("evm046") EVM evm) {
+        return contractCreationProcessor(evm);
+    }
+
+    @Bean
+    public ContractCreationProcessor contractCreationProcessor50(@Qualifier("evm050") EVM evm) {
         return contractCreationProcessor(evm);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/PrecompilesHolder.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/PrecompilesHolder.java
@@ -21,7 +21,6 @@ import static com.hedera.services.store.contracts.precompile.ExchangeRatePrecomp
 import static com.hedera.services.store.contracts.precompile.PrngSystemPrecompiledContract.PRNG_PRECOMPILE_ADDRESS;
 
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
-import com.hedera.services.contracts.gascalculator.GasCalculatorHederaV22;
 import com.hedera.services.fees.BasicHbarCentExchange;
 import com.hedera.services.store.contracts.precompile.ExchangeRatePrecompiledContract;
 import com.hedera.services.store.contracts.precompile.HTSPrecompiledContract;
@@ -31,6 +30,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 
 @Named
@@ -42,7 +42,7 @@ public class PrecompilesHolder implements PrecompiledContractProvider {
     PrecompilesHolder(
             final MirrorNodeEvmProperties mirrorNodeEvmProperties,
             final PrngSystemPrecompiledContract prngSystemPrecompiledContract,
-            final GasCalculatorHederaV22 gasCalculator,
+            final GasCalculator gasCalculator,
             final BasicHbarCentExchange basicHbarCentExchange,
             final HTSPrecompiledContract htsPrecompiledContract) {
         hederaPrecompiles = new HashMap<>();

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
@@ -141,6 +141,22 @@ public class ServicesConfiguration {
     private static final int STRICT_SYSTEM_ACCOUNT_BOUNDARY = 999;
 
     @Bean
+    static Predicate<Address> systemAccountDetector() {
+        // all addresses between 0-750 (inclusive) are treated as system accounts
+        // from the perspective of the EVM when executing Call, Balance, and SelfDestruct operations
+        return address -> address.numberOfLeadingZeroBytes() >= 18
+                && Integer.compareUnsigned(address.getInt(16), SYSTEM_ACCOUNT_BOUNDARY) <= 0;
+    }
+
+    @Bean
+    static Predicate<Address> strictSystemAccountDetector() {
+        // all addresses between 0-999 (inclusive) are treated as system accounts
+        // from the perspective of the EVM when executing ExtCode operations
+        return address -> address.numberOfLeadingZeroBytes() >= 18
+                && Integer.compareUnsigned(address.getInt(16), STRICT_SYSTEM_ACCOUNT_BOUNDARY) <= 0;
+    }
+
+    @Bean
     GasCalculatorHederaV22 gasCalculatorHederaV22(
             final BasicFcfsUsagePrices usagePricesProvider, final BasicHbarCentExchange hbarCentExchange) {
         return new GasCalculatorHederaV22(usagePricesProvider, hbarCentExchange);
@@ -686,12 +702,11 @@ public class ServicesConfiguration {
 
     @Bean
     PrngSystemPrecompiledContract prngSystemPrecompiledContract(
-            final GasCalculatorHederaV22 gasCalculatorHederaV22,
+            final GasCalculator gasCalculator,
             final PrngLogic prngLogic,
             final LivePricesSource livePricesSource,
             final PrecompilePricingUtils precompilePricingUtils) {
-        return new PrngSystemPrecompiledContract(
-                gasCalculatorHederaV22, prngLogic, livePricesSource, precompilePricingUtils);
+        return new PrngSystemPrecompiledContract(gasCalculator, prngLogic, livePricesSource, precompilePricingUtils);
     }
 
     @Bean
@@ -779,22 +794,6 @@ public class ServicesConfiguration {
     @Bean
     BiPredicate<Address, MessageFrame> preV38AddressValidator() {
         return (address, frame) -> frame.getWorldUpdater().get(address) != null;
-    }
-
-    @Bean
-    static Predicate<Address> systemAccountDetector() {
-        // all addresses between 0-750 (inclusive) are treated as system accounts
-        // from the perspective of the EVM when executing Call, Balance, and SelfDestruct operations
-        return address -> address.numberOfLeadingZeroBytes() >= 18
-                && Integer.compareUnsigned(address.getInt(16), SYSTEM_ACCOUNT_BOUNDARY) <= 0;
-    }
-
-    @Bean
-    static Predicate<Address> strictSystemAccountDetector() {
-        // all addresses between 0-999 (inclusive) are treated as system accounts
-        // from the perspective of the EVM when executing ExtCode operations
-        return address -> address.numberOfLeadingZeroBytes() >= 18
-                && Integer.compareUnsigned(address.getInt(16), STRICT_SYSTEM_ACCOUNT_BOUNDARY) <= 0;
     }
 
     @Bean

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessor.java
@@ -24,7 +24,6 @@ import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT
 import com.hedera.mirror.web3.evm.config.PrecompiledContractProvider;
 import com.hedera.mirror.web3.evm.store.contract.EntityAddressSequencer;
 import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
-import com.hedera.services.contracts.gascalculator.GasCalculatorHederaV22;
 import com.hedera.services.ledger.BalanceChange;
 import com.hedera.services.txns.crypto.AbstractAutoCreationLogic;
 import com.hedera.services.utils.EntityIdUtils;
@@ -40,6 +39,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
@@ -54,7 +54,7 @@ public class MirrorEvmMessageCallProcessor extends AbstractEvmMessageCallProcess
             final EVM evm,
             final PrecompileContractRegistry precompiles,
             final PrecompiledContractProvider precompilesHolder,
-            final GasCalculatorHederaV22 gasCalculator,
+            final GasCalculator gasCalculator,
             final Predicate<Address> systemAccountDetector) {
         super(evm, precompiles, precompilesHolder.getHederaPrecompiles(), systemAccountDetector);
         this.autoCreationLogic = autoCreationLogic;
@@ -65,6 +65,7 @@ public class MirrorEvmMessageCallProcessor extends AbstractEvmMessageCallProcess
 
     /**
      * This logic is copied from hedera-services HederaMessageCallProcessor.
+     *
      * @param frame
      * @param operationTracer
      */

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorV50.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorV50.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 
 @Named
+@SuppressWarnings("java:S110")
 public class MirrorEvmMessageCallProcessorV50 extends MirrorEvmMessageCallProcessor {
     public MirrorEvmMessageCallProcessorV50(
             final AbstractAutoCreationLogic autoCreationLogic,

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorV50.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorV50.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package com.hedera.mirror.web3.evm.contracts.execution;
 
 import com.hedera.mirror.web3.evm.config.PrecompiledContractProvider;
+import com.hedera.mirror.web3.evm.store.contract.EntityAddressSequencer;
+import com.hedera.services.txns.crypto.AbstractAutoCreationLogic;
 import jakarta.inject.Named;
 import java.util.function.Predicate;
 import org.hyperledger.besu.datatypes.Address;
@@ -26,15 +28,24 @@ import org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 
 @Named
-public class MirrorEvmMessageCallProcessorV30 extends AbstractEvmMessageCallProcessor {
-
-    public MirrorEvmMessageCallProcessorV30(
-            @Named("evm030") EVM v30,
-            PrecompileContractRegistry precompiles,
+public class MirrorEvmMessageCallProcessorV50 extends MirrorEvmMessageCallProcessor {
+    public MirrorEvmMessageCallProcessorV50(
+            final AbstractAutoCreationLogic autoCreationLogic,
+            final EntityAddressSequencer entityAddressSequencer,
+            @Named("evm050") EVM v50,
+            final PrecompileContractRegistry precompiles,
             final PrecompiledContractProvider precompilesHolder,
             final GasCalculator gasCalculator,
             final Predicate<Address> systemAccountDetector) {
-        super(v30, precompiles, precompilesHolder.getHederaPrecompiles(), systemAccountDetector);
-        MainnetPrecompiledContracts.populateForIstanbul(precompiles, gasCalculator);
+        super(
+                autoCreationLogic,
+                entityAddressSequencer,
+                v50,
+                precompiles,
+                precompilesHolder,
+                gasCalculator,
+                systemAccountDetector);
+
+        MainnetPrecompiledContracts.populateForCancun(precompiles, gasCalculator);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -21,6 +21,7 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_3
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_34;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_38;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_46;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_50;
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static com.swirlds.state.spi.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
 
@@ -84,7 +85,7 @@ public class MirrorNodeEvmProperties implements EvmProperties {
 
     @Getter
     @NotNull
-    private EvmSpecVersion evmSpecVersion = EvmSpecVersion.SHANGHAI;
+    private EvmSpecVersion evmSpecVersion = EvmSpecVersion.CANCUN;
 
     @Getter
     @NotNull
@@ -331,6 +332,8 @@ public class MirrorNodeEvmProperties implements EvmProperties {
             evmVersionsMap.put(44029066L, EVM_VERSION_0_34);
             evmVersionsMap.put(49117794L, EVM_VERSION_0_38);
             evmVersionsMap.put(60258042L, EVM_VERSION_0_46);
+            evmVersionsMap.put(65435845L, EVM_VERSION_0_50);
+
             return Collections.unmodifiableNavigableMap(evmVersionsMap);
         }
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/node/app/service/evm/contracts/execution/HederaEvmTxProcessor.java
@@ -42,12 +42,11 @@ import org.hyperledger.besu.evm.processor.MessageCallProcessor;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 /**
- * Stateless invariant copy of its hedera-services counterpart. It is used to process EVM transactions in
- * an asynchronous manner.
- *
+ * Stateless invariant copy of its hedera-services counterpart. It is used to process EVM transactions in an
+ * asynchronous manner.
+ * <p>
  * All class fields are final and immutable and some of them moved in the execute method.
- *
- * */
+ */
 public class HederaEvmTxProcessor {
     private static final int MAX_STACK_SIZE = 1024;
 
@@ -85,17 +84,15 @@ public class HederaEvmTxProcessor {
     /**
      * Executes the {@link MessageFrame} of the EVM transaction and fills execution results into a field.
      *
-     * @param sender The origin {@link MutableAccount} that initiates the transaction
-     * @param receiver the priority form of the receiving {@link Address} (i.e., EIP-1014 if
-     *     present); or the newly created address
-     * @param gasPrice GasPrice to use for gas calculations
-     * @param gasLimit Externally provided gas limit
-     * @param value transaction value
-     * @param payload transaction payload. For Create transactions, the bytecode + constructor
-     *     arguments
-     * @param isStatic Whether the execution is static
-     * @param mirrorReceiver the mirror form of the receiving {@link Address}; or the newly created
-     *     address
+     * @param sender         The origin {@link MutableAccount} that initiates the transaction
+     * @param receiver       the priority form of the receiving {@link Address} (i.e., EIP-1014 if present); or the
+     *                       newly created address
+     * @param gasPrice       GasPrice to use for gas calculations
+     * @param gasLimit       Externally provided gas limit
+     * @param value          transaction value
+     * @param payload        transaction payload. For Create transactions, the bytecode + constructor arguments
+     * @param isStatic       Whether the execution is static
+     * @param mirrorReceiver the mirror form of the receiving {@link Address}; or the newly created address
      */
     @SuppressWarnings("java:S107")
     public HederaEvmTransactionProcessingResult execute(

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperation.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperation.java
@@ -30,13 +30,12 @@ import org.hyperledger.besu.evm.operation.SelfDestructOperation;
  * Hedera adapted version of the {@link SelfDestructOperation}.
  *
  * <p>Performs an existence check on the beneficiary {@link Address} Halts the execution of the EVM
- * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does
- * not exist, or it is deleted.
+ * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does not exist, or it is
+ * deleted.
  *
  * <p>Halts the execution of the EVM transaction with {@link
- * HederaExceptionalHaltReason#SELF_DESTRUCT_TO_SELF} if the beneficiary address is the same as the
- * address being destructed
- * This class is a copy of HederaSelfDestructOperation from hedera-services mono
+ * HederaExceptionalHaltReason#SELF_DESTRUCT_TO_SELF} if the beneficiary address is the same as the address being
+ * destructed This class is a copy of HederaSelfDestructOperation from hedera-services mono
  */
 public class HederaSelfDestructOperation extends HederaSelfDestructOperationBase {
 
@@ -44,7 +43,7 @@ public class HederaSelfDestructOperation extends HederaSelfDestructOperationBase
 
     public HederaSelfDestructOperation(
             final GasCalculator gasCalculator, final BiPredicate<Address, MessageFrame> addressValidator) {
-        super(gasCalculator);
+        super(gasCalculator, false);
         this.addressValidator = addressValidator;
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationBase.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationBase.java
@@ -28,8 +28,8 @@ import org.hyperledger.besu.evm.operation.SelfDestructOperation;
 
 public class HederaSelfDestructOperationBase extends SelfDestructOperation {
 
-    public HederaSelfDestructOperationBase(final GasCalculator gasCalculator) {
-        super(gasCalculator);
+    public HederaSelfDestructOperationBase(final GasCalculator gasCalculator, final boolean eip6780Semantics) {
+        super(gasCalculator, eip6780Semantics);
     }
 
     @Nullable

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV038.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV038.java
@@ -31,13 +31,12 @@ import org.hyperledger.besu.evm.operation.SelfDestructOperation;
  * Hedera adapted version of the {@link SelfDestructOperation}.
  *
  * <p>Performs an existence check on the beneficiary {@link Address} Halts the execution of the EVM
- * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does
- * not exist, or it is deleted.
+ * transaction with {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} if the account does not exist, or it is
+ * deleted.
  *
  * <p>Halts the execution of the EVM transaction with {@link
- * HederaExceptionalHaltReason#SELF_DESTRUCT_TO_SELF} if the beneficiary address is the same as the
- * address being destructed
- * This class is a copy of HederaSelfDestructOperationV038 from hedera-services mono
+ * HederaExceptionalHaltReason#SELF_DESTRUCT_TO_SELF} if the beneficiary address is the same as the address being
+ * destructed This class is a copy of HederaSelfDestructOperationV038 from hedera-services mono
  */
 public class HederaSelfDestructOperationV038 extends HederaSelfDestructOperationBase {
 
@@ -49,7 +48,7 @@ public class HederaSelfDestructOperationV038 extends HederaSelfDestructOperation
             final GasCalculator gasCalculator,
             final BiPredicate<Address, MessageFrame> addressValidator,
             Predicate<Address> systemAccountDetector) {
-        super(gasCalculator);
+        super(gasCalculator, false);
         this.addressValidator = addressValidator;
         this.systemAccountDetector = systemAccountDetector;
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV046.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV046.java
@@ -47,8 +47,9 @@ public class HederaSelfDestructOperationV046 extends HederaSelfDestructOperation
     public HederaSelfDestructOperationV046(
             final GasCalculator gasCalculator,
             final BiPredicate<Address, MessageFrame> addressValidator,
-            final Predicate<Address> systemAccountDetector) {
-        super(gasCalculator, false);
+            final Predicate<Address> systemAccountDetector,
+            final boolean useEIP6780Semantics) {
+        super(gasCalculator, useEIP6780Semantics);
         this.addressValidator = addressValidator;
         this.systemAccountDetector = systemAccountDetector;
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV050.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV050.java
@@ -16,16 +16,12 @@
 
 package com.hedera.services.evm.contracts.operations;
 
-import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExceptionalHaltReason;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
-import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.operation.SelfDestructOperation;
 
 /**
@@ -39,38 +35,12 @@ import org.hyperledger.besu.evm.operation.SelfDestructOperation;
  * HederaExceptionalHaltReason#SELF_DESTRUCT_TO_SELF} if the beneficiary address is the same as the address being
  * destructed.
  */
-public class HederaSelfDestructOperationV050 extends HederaSelfDestructOperationBase {
-
-    private final BiPredicate<Address, MessageFrame> addressValidator;
-    private final Predicate<Address> systemAccountDetector;
+public class HederaSelfDestructOperationV050 extends HederaSelfDestructOperationV046 {
 
     public HederaSelfDestructOperationV050(
             GasCalculator gasCalculator,
             final BiPredicate<Address, MessageFrame> addressValidator,
             final Predicate<Address> systemAccountDetector) {
-        super(gasCalculator, true);
-        this.addressValidator = addressValidator;
-        this.systemAccountDetector = systemAccountDetector;
-    }
-
-    @Override
-    public OperationResult execute(final MessageFrame frame, final EVM evm) {
-        final var updater = (HederaEvmStackedWorldStateUpdater) frame.getWorldUpdater();
-        final var beneficiaryAddress = Words.toAddress(frame.getStackItem(0));
-        final var toBeDeleted = frame.getRecipientAddress();
-        if (frame.isStatic()) {
-            return reversionWith(null, ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
-        }
-        if (systemAccountDetector.test(beneficiaryAddress) || !addressValidator.test(beneficiaryAddress, frame)) {
-            return reversionWith(null, HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS);
-        }
-        final var beneficiary = updater.get(beneficiaryAddress);
-
-        final var exceptionalHaltReason = reasonToHalt(toBeDeleted, beneficiaryAddress, updater);
-        if (exceptionalHaltReason != null) {
-            return reversionWith(beneficiary, exceptionalHaltReason);
-        }
-
-        return super.execute(frame, evm);
+        super(gasCalculator, addressValidator, systemAccountDetector, true);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV050.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV050.java
@@ -37,18 +37,18 @@ import org.hyperledger.besu.evm.operation.SelfDestructOperation;
  *
  * <p>Halts the execution of the EVM transaction with {@link
  * HederaExceptionalHaltReason#SELF_DESTRUCT_TO_SELF} if the beneficiary address is the same as the address being
- * destructed. This class is a copy of HederaSelfDestructOperationV046 from hedera-services mono
+ * destructed.
  */
-public class HederaSelfDestructOperationV046 extends HederaSelfDestructOperationBase {
+public class HederaSelfDestructOperationV050 extends HederaSelfDestructOperationBase {
 
     private final BiPredicate<Address, MessageFrame> addressValidator;
     private final Predicate<Address> systemAccountDetector;
 
-    public HederaSelfDestructOperationV046(
-            final GasCalculator gasCalculator,
+    public HederaSelfDestructOperationV050(
+            GasCalculator gasCalculator,
             final BiPredicate<Address, MessageFrame> addressValidator,
             final Predicate<Address> systemAccountDetector) {
-        super(gasCalculator, false);
+        super(gasCalculator, true);
         this.addressValidator = addressValidator;
         this.systemAccountDetector = systemAccountDetector;
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesTest.java
@@ -21,6 +21,7 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_3
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_34;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_38;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_46;
+import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_50;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mockStatic;
@@ -66,6 +67,7 @@ class MirrorNodeEvmPropertiesTest {
         evmVersions.put(50L, EVM_VERSION_0_34);
         evmVersions.put(100L, EVM_VERSION_0_38);
         evmVersions.put(150L, EVM_VERSION_0_46);
+        evmVersions.put(200L, EVM_VERSION_0_50);
         return Collections.unmodifiableNavigableMap(evmVersions);
     }
 
@@ -75,6 +77,7 @@ class MirrorNodeEvmPropertiesTest {
         evmVersions.put(44029066L, EVM_VERSION_0_34);
         evmVersions.put(49117794L, EVM_VERSION_0_38);
         evmVersions.put(60258042L, EVM_VERSION_0_46);
+        evmVersions.put(65435845L, EVM_VERSION_0_50);
         return Collections.unmodifiableNavigableMap(evmVersions);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
@@ -208,11 +208,11 @@ class ContractCallEvmCodesTest extends AbstractContractCallServiceTest {
 
     @ParameterizedTest
     @CsvSource({
-        // function getCodeHash with parameter hedera system accounts, expected 0 bytes
-        "0000000000000000000000000000000000000000000000000000000000000167",
-        "0000000000000000000000000000000000000000000000000000000000000168",
-        "00000000000000000000000000000000000000000000000000000000000002ee",
-        "00000000000000000000000000000000000000000000000000000000000002e4",
+            // function getCodeHash with parameter hedera system accounts, expected 0 bytes
+            "0000000000000000000000000000000000000000000000000000000000000167",
+            "0000000000000000000000000000000000000000000000000000000000000168",
+            "00000000000000000000000000000000000000000000000000000000000002ee",
+            "00000000000000000000000000000000000000000000000000000000000002e4",
     })
     void testSystemContractCodeHash(String input) throws Exception {
         final var contract = testWeb3jService.deploy(EvmCodes::deploy);
@@ -229,11 +229,11 @@ class ContractCallEvmCodesTest extends AbstractContractCallServiceTest {
 
         final List<Bytes> capturedOutputs = new ArrayList<>();
         doAnswer(invocation -> {
-                    HederaEvmTransactionProcessingResult result =
-                            (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
-                    capturedOutputs.add(result.getOutput()); // Capture the result
-                    return result;
-                })
+            HederaEvmTransactionProcessingResult result =
+                    (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
+            capturedOutputs.add(result.getOutput()); // Capture the result
+            return result;
+        })
                 .when(contractExecutionService)
                 .callContract(any(), any());
 
@@ -313,7 +313,7 @@ class ContractCallEvmCodesTest extends AbstractContractCallServiceTest {
 
         // Then
         assertThatThrownBy(() -> contract.send_destroyContract(systemAccountAddress.toUnprefixedHexString())
-                        .send())
+                .send())
                 .isInstanceOf(MirrorEvmTransactionException.class)
                 .satisfies(ex -> {
                     MirrorEvmTransactionException exception = (MirrorEvmTransactionException) ex;
@@ -364,7 +364,7 @@ class ContractCallEvmCodesTest extends AbstractContractCallServiceTest {
         testWeb3jService.setHistoricalRange(
                 Range.closedOpen(recordFile.getConsensusStart(), recordFile.getConsensusEnd()));
         final var contract = testWeb3jService.deploy(EvmCodes::deploy);
-        // When
+        // Then
         final var functionCall = contract.send_tryTransientStorage();
         MirrorEvmTransactionException exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
         AssertionsForClassTypes.assertThat(exception.getMessage())
@@ -389,7 +389,7 @@ class ContractCallEvmCodesTest extends AbstractContractCallServiceTest {
         testWeb3jService.setHistoricalRange(
                 Range.closedOpen(recordFile.getConsensusStart(), recordFile.getConsensusEnd()));
         final var contract = testWeb3jService.deploy(EvmCodes::deploy);
-        // When
+        // Then
         final var functionCall = contract.send_tryMcopy();
         MirrorEvmTransactionException exception = assertThrows(MirrorEvmTransactionException.class, functionCall::send);
         AssertionsForClassTypes.assertThat(exception.getMessage())

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallSystemPrecompileHistoricalTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 public class ContractCallSystemPrecompileHistoricalTest extends AbstractContractCallServiceTest {
 
     @ParameterizedTest
-    @CsvSource({"150", "100", "50", "49"})
+    @CsvSource({"200", "150", "100", "50", "49"})
     void exchangeRatePrecompileTinycentsToTinybars(long blockNumber) throws Exception {
         // Given
         final var recordFile =
@@ -47,7 +47,7 @@ public class ContractCallSystemPrecompileHistoricalTest extends AbstractContract
     }
 
     @ParameterizedTest
-    @CsvSource({"150", "100", "50", "49"})
+    @CsvSource({"200", "150", "100", "50", "49"})
     void exchangeRatePrecompileTinybarsToTinycents(long blockNumber) throws Exception {
         // Given
         final var recordFile =
@@ -64,7 +64,7 @@ public class ContractCallSystemPrecompileHistoricalTest extends AbstractContract
     }
 
     @ParameterizedTest
-    @CsvSource({"150", "100", "50", "49"})
+    @CsvSource({"200", "150", "100", "50", "49"})
     void pseudoRandomGeneratorPrecompileFunctionsTestEthCallHistorical(long blockNumber) throws Exception {
         // Given
         final var recordFile =

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV046Test.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV046Test.java
@@ -71,7 +71,7 @@ class HederaSelfDestructOperationV046Test {
 
     @BeforeEach
     void setUp() {
-        subject = new HederaSelfDestructOperationV046(gasCalculator, addressValidator, systemAccountDetector);
+        subject = new HederaSelfDestructOperationV046(gasCalculator, addressValidator, systemAccountDetector, false);
 
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
         given(gasCalculator.selfDestructOperationGasCost(any(), eq(Wei.ONE))).willReturn(2L);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV050Test.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV050Test.java
@@ -39,7 +39,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class HederaSelfDestructOperationV050Test {
+class HederaSelfDestructOperationV050Test {
 
     static final Address BENEFICIARY = Address.fromHexString("0x0000000000000000000000000000000000000929");
     static final Address BENEFICIARY_SYSTEM_ACCOUNT =

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV050Test.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/evm/contracts/operations/HederaSelfDestructOperationV050Test.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.evm.contracts.operations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.hedera.mirror.web3.evm.store.contract.HederaEvmStackedWorldStateUpdater;
+import com.hedera.node.app.service.evm.contracts.operations.HederaExceptionalHaltReason;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.EVM;
+import org.hyperledger.besu.evm.account.MutableAccount;
+import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class HederaSelfDestructOperationV050Test {
+
+    static final Address BENEFICIARY = Address.fromHexString("0x0000000000000000000000000000000000000929");
+    static final Address BENEFICIARY_SYSTEM_ACCOUNT =
+            Address.fromHexString("0x00000000000000000000000000000000000002ED");
+    static final String ETH_ADDRESS = "0xc257274276a4e539741ca11b590b9447b26a8051";
+    static final Address EIP_1014_ETH_ADDRESS = Address.fromHexString(ETH_ADDRESS);
+
+    @Mock
+    private HederaEvmStackedWorldStateUpdater worldUpdater;
+
+    @Mock
+    private GasCalculator gasCalculator;
+
+    @Mock
+    private MessageFrame frame;
+
+    @Mock
+    private EVM evm;
+
+    @Mock
+    private MutableAccount account;
+
+    @Mock
+    private BiPredicate<Address, MessageFrame> addressValidator;
+
+    @Mock
+    private Predicate<Address> systemAccountDetector;
+
+    private HederaSelfDestructOperationV050 subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new HederaSelfDestructOperationV050(gasCalculator, addressValidator, systemAccountDetector);
+
+        given(frame.getWorldUpdater()).willReturn(worldUpdater);
+        given(gasCalculator.selfDestructOperationGasCost(any(), eq(Wei.ONE))).willReturn(2L);
+    }
+
+    @Test
+    void delegatesToSuperWhenValid() {
+        given(frame.getStackItem(0)).willReturn(BENEFICIARY);
+        given(frame.getRecipientAddress()).willReturn(EIP_1014_ETH_ADDRESS);
+
+        given(frame.isStatic()).willReturn(true);
+
+        final var opResult = subject.execute(frame, evm);
+
+        assertEquals(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE, opResult.getHaltReason());
+        assertEquals(2L, opResult.getGasCost());
+    }
+
+    @Test
+    void rejectsSelfDestructToSelf() {
+        givenRubberstampValidator();
+
+        given(frame.getStackItem(0)).willReturn(EIP_1014_ETH_ADDRESS);
+        given(frame.getRecipientAddress()).willReturn(EIP_1014_ETH_ADDRESS);
+
+        final var opResult = subject.execute(frame, evm);
+
+        assertEquals(HederaExceptionalHaltReason.SELF_DESTRUCT_TO_SELF, opResult.getHaltReason());
+        assertEquals(2L, opResult.getGasCost());
+    }
+
+    @Test
+    void executeInvalidSolidityAddress() {
+        givenRejectingValidator();
+
+        given(frame.getStackItem(0)).willReturn(BENEFICIARY_SYSTEM_ACCOUNT);
+
+        final var opResult = subject.execute(frame, evm);
+
+        assertEquals(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS, opResult.getHaltReason());
+        assertEquals(2L, opResult.getGasCost());
+    }
+
+    @Test
+    void haltsWhenBeneficiaryIsSystemAccount() {
+        given(frame.getStackItem(0)).willReturn(BENEFICIARY);
+        given(frame.getRecipientAddress()).willReturn(EIP_1014_ETH_ADDRESS);
+        given(systemAccountDetector.test(any())).willReturn(true);
+        // when
+        final var result = subject.execute(frame, evm);
+        // then
+        assertEquals(HederaExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS, result.getHaltReason());
+        assertEquals(2L, result.getGasCost());
+    }
+
+    @Test
+    void rejectsSelfDestructIfTreasury() {
+        givenRubberstampValidator();
+
+        given(frame.getStackItem(0)).willReturn(BENEFICIARY);
+        given(frame.getRecipientAddress()).willReturn(EIP_1014_ETH_ADDRESS);
+        given(worldUpdater.contractIsTokenTreasury(EIP_1014_ETH_ADDRESS)).willReturn(true);
+
+        final var opResult = subject.execute(frame, evm);
+
+        assertEquals(HederaExceptionalHaltReason.CONTRACT_IS_TREASURY, opResult.getHaltReason());
+        assertEquals(2L, opResult.getGasCost());
+    }
+
+    @Test
+    void rejectsSelfDestructIfContractHasAnyTokenBalance() {
+        givenRubberstampValidator();
+        given(frame.getStackItem(0)).willReturn(BENEFICIARY);
+        given(frame.getRecipientAddress()).willReturn(EIP_1014_ETH_ADDRESS);
+        given(worldUpdater.contractHasAnyBalance(EIP_1014_ETH_ADDRESS)).willReturn(true);
+
+        final var opResult = subject.execute(frame, evm);
+
+        assertEquals(HederaExceptionalHaltReason.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES, opResult.getHaltReason());
+        assertEquals(2L, opResult.getGasCost());
+    }
+
+    @Test
+    void rejectsSelfDestructIfContractHasAnyNfts() {
+        givenRubberstampValidator();
+
+        given(frame.getStackItem(0)).willReturn(BENEFICIARY);
+        given(frame.getRecipientAddress()).willReturn(EIP_1014_ETH_ADDRESS);
+        given(worldUpdater.contractOwnsNfts(EIP_1014_ETH_ADDRESS)).willReturn(true);
+
+        final var opResult = subject.execute(frame, evm);
+
+        assertEquals(HederaExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS, opResult.getHaltReason());
+        assertEquals(2L, opResult.getGasCost());
+    }
+
+    private void givenRubberstampValidator() {
+        given(addressValidator.test(any(), any())).willReturn(true);
+    }
+
+    private void givenRejectingValidator() {
+        given(addressValidator.test(any(), any())).willReturn(false);
+    }
+}

--- a/hedera-mirror-web3/src/test/resources/config/application.yml
+++ b/hedera-mirror-web3/src/test/resources/config/application.yml
@@ -11,6 +11,7 @@ hedera:
           50: 0.34.0
           100: 0.38.0
           150: 0.46.0
+          200: 0.50.0
         network: OTHER
       opcode:
         tracer:

--- a/hedera-mirror-web3/src/test/solidity/EvmCodes.sol
+++ b/hedera-mirror-web3/src/test/solidity/EvmCodes.sol
@@ -130,7 +130,7 @@ contract EvmCodes {
         assembly {
             success := call(sub(gas(), 2000), 0x06, 0, input, 0xc0, r, 0x60)
         // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            switch success case 0 {invalid()}
         }
         require(success);
     }
@@ -146,9 +146,9 @@ contract EvmCodes {
         assembly {
             success := call(sub(gas(), 2000), 0x07, 0, input, 0x80, r, 0x60)
         // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            switch success case 0 {invalid()}
         }
-        require (success);
+        require(success);
     }
 
     // Function to perform a pairing check using AltBN128PairingPrecompiledContract.
@@ -175,7 +175,7 @@ contract EvmCodes {
         assembly {
             success := call(sub(gas(), 2000), 8, 0, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
         // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            switch success case 0 {invalid()}
         }
         require(success);
         return out[0] != 0;
@@ -232,5 +232,24 @@ contract EvmCodes {
 
     function destroyContract(address payable beneficiary) public {
         selfdestruct(beneficiary);
+    }
+
+    function tryKZGPrecompile() public view {
+        bytes memory byts = "Hello, World!";
+        address(0x0A).staticcall(byts);
+    }
+
+    function tryTransientStorage() public {
+        assembly {
+            tstore(10, 11111)
+            pop(tload(10))
+        }
+    }
+
+    function tryMcopy() public pure {
+        bytes memory byts = "Hello, World!";
+        assembly {
+            mcopy(0, 0, 32)
+        }
     }
 }


### PR DESCRIPTION
**Description**:
This PR adds cancun evm version to the mirror node web3

This PR modifies:

`EvmConfiguration.java ` - Added evm050 - bean config 
Add `HederaSelfDestructOperationV050` - added flag - useEIP6780Semantics - set to true only for V050

Add `MirrorEvmMessageCallProcessorV50` - using populateForCancun method

`MirrorNodeEvmProperties` - change evmSpecVersion to CANCUN and add block number for EVM_VERSION_0_50 for mainnet block configurations.

Added unit and modified integration tests.


**Related issue(s)**:

Fixes #8058 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
