### PR TITLE
Fix file readable kv state for latest file

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/FileReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/FileReadableKVState.java
@@ -23,6 +23,7 @@ import com.hedera.hapi.node.state.file.File;
 import com.hedera.mirror.common.domain.entity.AbstractEntity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.file.FileData;
+import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.repository.EntityRepository;
 import com.hedera.mirror.web3.repository.FileDataRepository;
@@ -31,6 +32,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.spi.ReadableKVStateBase;
 import jakarta.annotation.Nonnull;
 import jakarta.inject.Named;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Optional;
@@ -38,8 +40,8 @@ import java.util.function.Supplier;
 
 /**
  * This class serves as a repository layer between hedera app services read only state and the Postgres database in
- * mirror-node. The file data, which is read from the database is converted to the PBJ generated format, so that it can properly be
- * utilized by the hedera app components
+ * mirror-node. The file data, which is read from the database is converted to the PBJ generated format, so that it can
+ * properly be utilized by the hedera app components
  */
 @Named
 public class FileReadableKVState extends ReadableKVStateBase<FileID, File> {
@@ -57,10 +59,9 @@ public class FileReadableKVState extends ReadableKVStateBase<FileID, File> {
     protected File readFromDataSource(@Nonnull FileID key) {
         final var timestamp = ContractCallContext.get().getTimestamp();
         final var fileId = toEntityId(key).getId();
-
         return timestamp
                 .map(t -> fileDataRepository.getFileAtTimestamp(fileId, t))
-                .orElseGet(() -> fileDataRepository.findById(fileId))
+                .orElseGet(() -> fileDataRepository.getFileAtTimestamp(fileId, getCurrentTimestamp()))
                 .map(fileData -> mapToFile(fileData, key, timestamp))
                 .orElse(null);
     }
@@ -90,5 +91,10 @@ public class FileReadableKVState extends ReadableKVStateBase<FileID, File> {
                 .orElseGet(() -> entityRepository.findByIdAndDeletedIsFalse(entityId.getId()))
                 .map(AbstractEntity::getExpirationTimestamp)
                 .orElse(null));
+    }
+
+    private long getCurrentTimestamp() {
+        final var now = Instant.now();
+        return DomainUtils.convertToNanos(now.getEpochSecond(), now.getNano());
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/FileReadableKVStateIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/FileReadableKVStateIntegrationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.state.file.File;
+import com.hedera.mirror.web3.Web3IntegrationTest;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+@RequiredArgsConstructor
+class FileReadableKVStateIntegrationTest extends Web3IntegrationTest {
+
+    private final FileReadableKVState fileReadableKVState;
+
+    @Test
+    void testGetFile() {
+        // Given
+        final var fileDataLatest = domainBuilder.fileData().persist();
+        // persist second file data with the same entity id but older timestamp
+        domainBuilder
+                .fileData()
+                .customize(f -> f.consensusTimestamp(fileDataLatest.getConsensusTimestamp() - 1)
+                        .entityId(fileDataLatest.getEntityId()))
+                .persist();
+
+        final var entityId = fileDataLatest.getEntityId();
+        FileID fileID = new FileID(entityId.getShard(), entityId.getRealm(), entityId.getNum());
+        File expected = new File(fileID, () -> null, null, Bytes.wrap(fileDataLatest.getFileData()), "", false, 0);
+
+        // When
+        File actual = fileReadableKVState.readFromDataSource(fileID);
+        // Then
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/FileReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/FileReadableKVStateTest.java
@@ -19,6 +19,7 @@ package com.hedera.mirror.web3.state;
 import static com.hedera.services.utils.EntityIdUtils.toEntityId;
 import static com.hedera.services.utils.EntityIdUtils.toFileId;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -51,8 +52,8 @@ class FileReadableKVStateTest {
     private static final long REALM = 1L;
     private static final long FILE_NUM = 123L;
     private static final FileID FILE_ID = toFileId(SHARD, REALM, FILE_NUM);
-    private static final long EXPIRATION_TIMESTAMP = 2_000_000_000L;
     private static final long FILE_ID_LONG = toEntityId(FILE_ID).getId();
+    private static final long EXPIRATION_TIMESTAMP = 2_000_000_000L;
     private static final Optional<Long> TIMESTAMP = Optional.of(1234L);
     private static MockedStatic<ContractCallContext> contextMockedStatic;
     private FileData fileData;
@@ -149,7 +150,7 @@ class FileReadableKVStateTest {
     @Test
     void readFromDataSourceWithoutTimestamp() {
         when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
-        when(fileDataRepository.findById(FILE_ID_LONG)).thenReturn(Optional.of(fileData));
+        when(fileDataRepository.getFileAtTimestamp(anyLong(), anyLong())).thenReturn(Optional.of(fileData));
         when(entityRepository.findByIdAndDeletedIsFalse(toEntityId(FILE_ID).getId()))
                 .thenReturn(Optional.of(entity));
 


### PR DESCRIPTION
**Description**:
Seems like there is an issue with the `FileReadableKVState` when we try to find latest file by id.

`FileDataRepository.findById` does not work with entity id since the primary key of the table is the consensus timestamp column and currently we pass as a parameter the entity id from the `FileID` object which is incorrect.

To fix it we can use the existing method `getFileAtTimestamp` which uses both the entity id and the consensus timestamp.
We will just pass current timestamp as a parameter and the entity id.

 

FileReadableKVState - For latest data we now use `getFileAtTimestamp` method passing current time.
Added FileReadableKVStateIntegrationTest which adds integration test for the latest scenario

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
