### PR TITLE
Rename CustomCallOperation 

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/EvmConfiguration.java
@@ -30,7 +30,7 @@ import com.hedera.mirror.web3.evm.contracts.operations.HederaBlockHashOperation;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.store.contract.EntityAddressSequencer;
 import com.hedera.mirror.web3.repository.properties.CacheProperties;
-import com.hedera.node.app.service.contract.impl.exec.operations.CustomCallOperation;
+import com.hedera.node.app.service.contract.impl.exec.operations.HederaCustomCallOperation;
 import com.hedera.node.app.service.evm.contracts.execution.traceability.HederaEvmOperationTracer;
 import com.hedera.node.app.service.evm.contracts.operations.CreateOperationExternalizer;
 import com.hedera.node.app.service.evm.contracts.operations.HederaBalanceOperation;
@@ -489,7 +489,7 @@ public class EvmConfiguration {
                         new HederaEvmSLoadOperation(gasCalculator),
                         new HederaExtCodeCopyOperation(gasCalculator, validator),
                         new HederaExtCodeSizeOperation(gasCalculator, validator),
-                        new CustomCallOperation(gasCalculator),
+                        new HederaCustomCallOperation(gasCalculator),
                         prngSeedOperation,
                         hederaBlockHashOperation,
                         extCodeHashOperation,

--- a/hedera-mirror-web3/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/HederaCustomCallOperation.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/HederaCustomCallOperation.java
@@ -25,11 +25,11 @@ import org.hyperledger.besu.evm.internal.UnderflowException;
 import org.hyperledger.besu.evm.operation.CallOperation;
 import org.hyperledger.besu.evm.operation.Operation;
 
-public class CustomCallOperation extends CallOperation {
+public class HederaCustomCallOperation extends CallOperation {
     private static final Operation.OperationResult UNDERFLOW_RESPONSE =
             new Operation.OperationResult(0, ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS);
 
-    public CustomCallOperation(@Nonnull final GasCalculator gasCalculator) {
+    public HederaCustomCallOperation(@Nonnull final GasCalculator gasCalculator) {
         super(gasCalculator);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/node/app/service/contract/impl/exec/operations/HederaCustomCallOperationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/node/app/service/contract/impl/exec/operations/HederaCustomCallOperationTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class CustomCallOperationTest {
+class HederaCustomCallOperationTest {
 
     @Mock
     private MessageFrame frame;
@@ -49,16 +49,16 @@ class CustomCallOperationTest {
     @Mock
     private WorldUpdater worldUpdater;
 
-    private CustomCallOperation subject;
+    private HederaCustomCallOperation subject;
 
     @BeforeEach
     void setUp() {
-        subject = new CustomCallOperation(gasCalculator);
+        subject = new HederaCustomCallOperation(gasCalculator);
     }
 
     @Test
     void testHappyPath() {
-        given(frame.getStackItem(anyInt())).willReturn(Bytes.wrap(new byte[] {1}));
+        given(frame.getStackItem(anyInt())).willReturn(Bytes.wrap(new byte[]{1}));
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
         given(frame.getRemainingGas()).willReturn(200L);
         given(frame.stackSize()).willReturn(7);
@@ -72,7 +72,7 @@ class CustomCallOperationTest {
 
     @Test
     void testInsufficientGas() {
-        given(frame.getStackItem(anyInt())).willReturn(Bytes.wrap(new byte[] {1}));
+        given(frame.getStackItem(anyInt())).willReturn(Bytes.wrap(new byte[]{1}));
         given(frame.getWorldUpdater()).willReturn(worldUpdater);
         given(frame.getRemainingGas()).willReturn(50L);
         given(subject.cost(frame, false)).willReturn(100L);


### PR DESCRIPTION
**Description**:

Currently when trying to run transaction using Reusables services transactionExecutor 
we are getting the following error - 

`java.lang.RuntimeException: java.lang.NoSuchMethodError: 'void com.hedera.node.app.service.contract.impl.exec.operations.CustomCallOperation.<init>(com.hedera.node.app.service.contract.impl.exec.FeatureFlags, org.hyperledger.besu.evm.gascalculator.GasCalculator, com.hedera.node.app.service.contract.impl.exec.AddressChecks)'`

Services `CustomCallOperation` clashes with our CustomCallOperation.java causing the issue.
Renaming our CustomCallOperation to `HederaCustomCallOperation` similar to the other custom operations that we have fixes the conflict. 

This PR modifies
Rename CustomCallOperation to HederaCustomCallOperation

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
