### PR TITLE
Add support for Kubernetes Gateway API

### DIFF
--- a/charts/hedera-mirror-graphql/templates/gcpbackendpolicy.yaml
+++ b/charts/hedera-mirror-graphql/templates/gcpbackendpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.backendPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  labels: {{ include "hedera-mirror-graphql.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-graphql.fullname" . }}
+  namespace: {{ include "hedera-mirror-graphql.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.backendPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-graphql.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-graphql/templates/healthcheckpolicy.yaml
+++ b/charts/hedera-mirror-graphql/templates/healthcheckpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.healthCheckPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  labels: {{ include "hedera-mirror-graphql.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-graphql.fullname" . }}
+  namespace: {{ include "hedera-mirror-graphql.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.healthCheckPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-graphql.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-graphql/templates/httproute-http.yaml
+++ b/charts/hedera-mirror-graphql/templates/httproute-http.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.http.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels: {{ include "hedera-mirror-graphql.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-graphql.fullname" . }}-http
+  namespace: {{ include "hedera-mirror-graphql.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.http.port }}
+  rules:
+    {{- if .Values.global.gateway.http.redirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    {{- tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/hedera-mirror-graphql/templates/httproute-https.yaml
+++ b/charts/hedera-mirror-graphql/templates/httproute-https.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.https.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels: {{ include "hedera-mirror-graphql.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-graphql.fullname" . }}-https
+  namespace: {{ include "hedera-mirror-graphql.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.https.port }}
+  rules: {{ tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+{{- end }}

--- a/charts/hedera-mirror-graphql/values.yaml
+++ b/charts/hedera-mirror-graphql/values.yaml
@@ -44,7 +44,43 @@ envFrom: []
 
 fullnameOverride: ""
 
+gateway:
+  gcp:
+    backendPolicy:
+      connectionDraining:
+        drainingTimeoutSec: 10
+      logging:
+        enabled: false
+      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
+      sessionAffinity:
+        type: CLIENT_IP
+      timeoutSec: 20
+    enabled: true
+    healthCheckPolicy:
+      config:
+        httpHealthCheck:
+          port: 8083
+          requestPath: "{{ .Values.readinessProbe.httpGet.path }}"
+        type: HTTP
+      healthyThreshold: 1
+  rules:
+    - backendRefs:
+        - group: "{{ .Values.gateway.target.group }}"
+          kind: "{{ .Values.gateway.target.kind }}"
+          name: "{{ include \"hedera-mirror-graphql.fullname\" $ }}"
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /graphql/alpha
+  target:
+    group: ""
+    kind: Service
+
 global:
+  gateway:
+    enabled: false
+    hostnames: []
   image: {}
   middleware: false
   namespaceOverride: ""

--- a/charts/hedera-mirror-grpc/templates/gcpbackendpolicy.yaml
+++ b/charts/hedera-mirror-grpc/templates/gcpbackendpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.backendPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-grpc.fullname" . }}
+  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.backendPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-grpc.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-grpc/templates/grpcroute.yaml
+++ b/charts/hedera-mirror-grpc/templates/grpcroute.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.http.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: GrpcRoute
+metadata:
+  labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-grpc.fullname" . }}
+  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.http.port }}
+  rules:
+    {{- tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+{{- end }}

--- a/charts/hedera-mirror-grpc/templates/healthcheckpolicy.yaml
+++ b/charts/hedera-mirror-grpc/templates/healthcheckpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.healthCheckPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  labels: {{ include "hedera-mirror-grpc.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-grpc.fullname" . }}
+  namespace: {{ include "hedera-mirror-grpc.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.healthCheckPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-grpc.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-grpc/values.yaml
+++ b/charts/hedera-mirror-grpc/values.yaml
@@ -57,7 +57,46 @@ envFrom: []
 
 fullnameOverride: ""
 
+gateway:
+  gcp:
+    backendPolicy:
+      connectionDraining:
+        drainingTimeoutSec: 10
+      logging:
+        enabled: false
+      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
+      sessionAffinity:
+        type: CLIENT_IP
+      timeoutSec: 20
+    enabled: true
+    healthCheckPolicy:
+      config:
+        httpHealthCheck:
+          port: 8081
+          requestPath: "{{ .Values.readinessProbe.httpGet.path }}"
+        type: HTTP
+      healthyThreshold: 1
+  rules:
+    - backendRefs:
+        - group: "{{ .Values.gateway.target.group }}"
+          kind: "{{ .Values.gateway.target.kind }}"
+          name: "{{ include \"hedera-mirror-grpc.fullname\" $ }}"
+          port: 5600
+      matches:
+        - method:
+            service: com.hedera.mirror.api.proto.ConsensusService
+        - method:
+            service: com.hedera.mirror.api.proto.NetworkService
+        - method:
+            service: grpc.reflection.v1alpha.ServerReflection
+  target:
+    group: ""
+    kind: Service
+
 global:
+  gateway:
+    enabled: false
+    hostnames: []
   image: {}
   middleware: false
   namespaceOverride: ""

--- a/charts/hedera-mirror-rest-java/templates/gcpbackendpolicy.yaml
+++ b/charts/hedera-mirror-rest-java/templates/gcpbackendpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.backendPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  labels: {{ include "hedera-mirror-rest-java.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest-java.fullname" . }}
+  namespace: {{ include "hedera-mirror-rest-java.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.backendPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-rest-java.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-rest-java/templates/healthcheckpolicy.yaml
+++ b/charts/hedera-mirror-rest-java/templates/healthcheckpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.healthCheckPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  labels: {{ include "hedera-mirror-rest-java.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest-java.fullname" . }}
+  namespace: {{ include "hedera-mirror-rest-java.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.healthCheckPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-rest-java.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-rest-java/templates/httproute-http.yaml
+++ b/charts/hedera-mirror-rest-java/templates/httproute-http.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.http.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels: {{ include "hedera-mirror-rest-java.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest-java.fullname" . }}-http
+  namespace: {{ include "hedera-mirror-rest-java.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.http.port }}
+  rules:
+    {{- if .Values.global.gateway.http.redirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    {{- tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/hedera-mirror-rest-java/templates/httproute-https.yaml
+++ b/charts/hedera-mirror-rest-java/templates/httproute-https.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.https.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels: {{ include "hedera-mirror-rest-java.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest-java.fullname" . }}-https
+  namespace: {{ include "hedera-mirror-rest-java.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.https.port }}
+  rules: {{ tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+{{- end }}

--- a/charts/hedera-mirror-rest-java/values.yaml
+++ b/charts/hedera-mirror-rest-java/values.yaml
@@ -44,7 +44,52 @@ envFrom: []
 
 fullnameOverride: ""
 
+gateway:
+  gcp:
+    backendPolicy:
+      connectionDraining:
+        drainingTimeoutSec: 10
+      logging:
+        enabled: false
+      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
+      sessionAffinity:
+        type: CLIENT_IP
+      timeoutSec: 20
+    enabled: true
+    healthCheckPolicy:
+      config:
+        httpHealthCheck:
+          port: 8084
+          requestPath: "{{ .Values.readinessProbe.httpGet.path }}"
+        type: HTTP
+      healthyThreshold: 1
+  rules:
+    - backendRefs:
+        - group: "{{ .Values.gateway.target.group }}"
+          kind: "{{ .Values.gateway.target.kind }}"
+          name: "{{ include \"hedera-mirror-rest-java.fullname\" $ }}"
+          port: 80
+      matches:
+        - path:
+            type: RegularExpression  # GKE does not yet support RegularExpression type
+            value: '/api/v1/accounts/(\d+\.){0,2}(\d+|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))/allowances/nfts'
+        - path:
+            type: RegularExpression
+            value: '/api/v1/accounts/(\d+\.){0,2}(\d+|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))/airdrops/outstanding'
+        - path:
+            type: RegularExpression
+            value: '/api/v1/accounts/(\d+\.){0,2}(\d+|(0x)?[A-Fa-f0-9]{40}|(?:[A-Z2-7]{8})*(?:[A-Z2-7]{2}|[A-Z2-7]{4,5}|[A-Z2-7]{7,8}))/airdrops/pending'
+        - path:
+            type: RegularExpression
+            value: '/api/v1/topics/(\d+\.){0,2}\d+$'
+  target:
+    group: ""
+    kind: Service
+
 global:
+  gateway:
+    enabled: false
+    hostnames: []
   image: {}
   middleware: false
   namespaceOverride: ""

--- a/charts/hedera-mirror-rest/templates/gcpbackendpolicy.yaml
+++ b/charts/hedera-mirror-rest/templates/gcpbackendpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.backendPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest.fullname" . }}
+  namespace: {{ include "hedera-mirror-rest.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.backendPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-rest.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-rest/templates/healthcheckpolicy.yaml
+++ b/charts/hedera-mirror-rest/templates/healthcheckpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.healthCheckPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest.fullname" . }}
+  namespace: {{ include "hedera-mirror-rest.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.healthCheckPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-rest.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-rest/templates/httproute-http.yaml
+++ b/charts/hedera-mirror-rest/templates/httproute-http.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.http.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest.fullname" . }}-http
+  namespace: {{ include "hedera-mirror-rest.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.http.port }}
+  rules:
+    {{- if .Values.global.gateway.http.redirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    {{- tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/hedera-mirror-rest/templates/httproute-https.yaml
+++ b/charts/hedera-mirror-rest/templates/httproute-https.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.https.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels: {{ include "hedera-mirror-rest.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rest.fullname" . }}-https
+  namespace: {{ include "hedera-mirror-rest.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.https.port }}
+  rules: {{ tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+{{- end }}

--- a/charts/hedera-mirror-rest/values.yaml
+++ b/charts/hedera-mirror-rest/values.yaml
@@ -44,7 +44,43 @@ envFrom: []
 
 fullnameOverride: ""
 
+gateway:
+  gcp:
+    backendPolicy:
+      connectionDraining:
+        drainingTimeoutSec: 10
+      logging:
+        enabled: false
+      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
+      sessionAffinity:
+        type: CLIENT_IP
+      timeoutSec: 20
+    enabled: true
+    healthCheckPolicy:
+      config:
+        httpHealthCheck:
+          port: 5551
+          requestPath: "{{ .Values.readinessProbe.httpGet.path }}"
+        type: HTTP
+      healthyThreshold: 1
+  rules:
+    - backendRefs:
+        - group: "{{ .Values.gateway.target.group }}"
+          kind: "{{ .Values.gateway.target.kind }}"
+          name: "{{ include \"hedera-mirror-rest.fullname\" $ }}"
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1
+  target:
+    group: ""
+    kind: Service
+
 global:
+  gateway:
+    enabled: false
+    hostnames: []
   image: {}
   middleware: false
   namespaceOverride: ""

--- a/charts/hedera-mirror-rosetta/templates/gcpbackendpolicy.yaml
+++ b/charts/hedera-mirror-rosetta/templates/gcpbackendpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.backendPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rosetta.fullname" . }}
+  namespace: {{ include "hedera-mirror-rosetta.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.backendPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-rosetta.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-rosetta/templates/healthcheckpolicy.yaml
+++ b/charts/hedera-mirror-rosetta/templates/healthcheckpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.healthCheckPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rosetta.fullname" . }}
+  namespace: {{ include "hedera-mirror-rosetta.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.healthCheckPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-rosetta.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-rosetta/templates/httproute-http.yaml
+++ b/charts/hedera-mirror-rosetta/templates/httproute-http.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.http.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rosetta.fullname" . }}-http
+  namespace: {{ include "hedera-mirror-rosetta.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.http.port }}
+  rules:
+    {{- if .Values.global.gateway.http.redirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    {{- tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/hedera-mirror-rosetta/templates/httproute-https.yaml
+++ b/charts/hedera-mirror-rosetta/templates/httproute-https.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.https.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels: {{ include "hedera-mirror-rosetta.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-rosetta.fullname" . }}-https
+  namespace: {{ include "hedera-mirror-rosetta.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.https.port }}
+  rules: {{ tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+{{- end }}

--- a/charts/hedera-mirror-rosetta/values.yaml
+++ b/charts/hedera-mirror-rosetta/values.yaml
@@ -44,7 +44,49 @@ envFrom: []
 
 fullnameOverride: ""
 
+gateway:
+  gcp:
+    backendPolicy:
+      connectionDraining:
+        drainingTimeoutSec: 10
+      logging:
+        enabled: false
+      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
+      sessionAffinity:
+        type: CLIENT_IP
+      timeoutSec: 20
+    enabled: true
+    healthCheckPolicy:
+      config:
+        httpHealthCheck:
+          port: 5700
+          requestPath: "{{ .Values.readinessProbe.httpGet.path }}"
+        type: HTTP
+      healthyThreshold: 1
+  rules:
+    - backendRefs:
+        - group: "{{ .Values.gateway.target.group }}"
+          kind: "{{ .Values.gateway.target.kind }}"
+          name: "{{ include \"hedera-mirror-rosetta.fullname\" $ }}"
+          port: 80
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              replacePrefixMatch: "/"
+              type: ReplacePrefixMatch
+      matches:
+        - path:
+            type: PathPrefix
+            value: /rosetta
+  target:
+    group: ""
+    kind: Service
+
 global:
+  gateway:
+    enabled: false
+    hostnames: []
   image: {}
   middleware: false
   namespaceOverride: ""

--- a/charts/hedera-mirror-web3/templates/gcpbackendpolicy.yaml
+++ b/charts/hedera-mirror-web3/templates/gcpbackendpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.backendPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: GCPBackendPolicy
+metadata:
+  labels: {{ include "hedera-mirror-web3.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-web3.fullname" . }}
+  namespace: {{ include "hedera-mirror-web3.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.backendPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-web3.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-web3/templates/healthcheckpolicy.yaml
+++ b/charts/hedera-mirror-web3/templates/healthcheckpolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled .Values.gateway.gcp.enabled (not (empty .Values.gateway.gcp.healthCheckPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  labels: {{ include "hedera-mirror-web3.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-web3.fullname" . }}
+  namespace: {{ include "hedera-mirror-web3.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.gateway.gcp.healthCheckPolicy) $ | nindent 4 }}
+  targetRef:
+    group: {{ .Values.gateway.target.group | quote }}
+    kind: {{ .Values.gateway.target.kind }}
+    name: {{ include "hedera-mirror-web3.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror-web3/templates/httproute-http.yaml
+++ b/charts/hedera-mirror-web3/templates/httproute-http.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.http.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels: {{ include "hedera-mirror-web3.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-web3.fullname" . }}-http
+  namespace: {{ include "hedera-mirror-web3.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.http.port }}
+  rules:
+    {{- if .Values.global.gateway.http.redirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    {{- tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/hedera-mirror-web3/templates/httproute-https.yaml
+++ b/charts/hedera-mirror-web3/templates/httproute-https.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.global.gateway.enabled .Values.global.gateway.https.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels: {{ include "hedera-mirror-web3.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror-web3.fullname" . }}-https
+  namespace: {{ include "hedera-mirror-web3.namespace" . }}
+spec:
+  hostnames:
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - {{ $hostname | quote }}
+  {{- end }}
+  parentRefs:
+    - name: {{ .Release.Name }}
+      port: {{ .Values.global.gateway.https.port }}
+  rules: {{ tpl (toYaml .Values.gateway.rules) $ | nindent 4 }}
+{{- end }}

--- a/charts/hedera-mirror-web3/values.yaml
+++ b/charts/hedera-mirror-web3/values.yaml
@@ -44,7 +44,46 @@ envFrom: []
 
 fullnameOverride: ""
 
+gateway:
+  gcp:
+    backendPolicy:
+      connectionDraining:
+        drainingTimeoutSec: 10
+      logging:
+        enabled: false
+      maxRatePerEndpoint: 250  # Requires a change to HPA to take effect
+      sessionAffinity:
+        type: CLIENT_IP
+      timeoutSec: 20
+    enabled: true
+    healthCheckPolicy:
+      config:
+        httpHealthCheck:
+          port: 8545
+          requestPath: "{{ .Values.readinessProbe.httpGet.path }}"
+        type: HTTP
+      healthyThreshold: 1
+  rules:
+    - backendRefs:
+        - group: "{{ .Values.gateway.target.group }}"
+          kind: "{{ .Values.gateway.target.kind }}"
+          name: "{{ include \"hedera-mirror-web3.fullname\" $ }}"
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/contracts/call
+#        - path:
+#            type: RegularExpression
+#            value: '/api/v1/contracts/results/((0x)?[A-Fa-f0-9]{64}|\d+\.\d+\.\d+-\d+-\d+)/opcodes'
+  target:
+    group: ""
+    kind: Service
+
 global:
+  gateway:
+    enabled: false
+    hostnames: []
   image: {}
   middleware: false
   namespaceOverride: ""

--- a/charts/hedera-mirror/templates/gateway.yaml
+++ b/charts/hedera-mirror/templates/gateway.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.global.gateway.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations: {{- toYaml .Values.global.gateway.annotations | nindent 4 }}
+  labels: {{ include "hedera-mirror.labels" . | nindent 4 }}
+  name: {{ .Release.Name }}
+  namespace: {{ include "hedera-mirror.namespace" . }}
+spec:
+  gatewayClassName: {{ .Values.global.gateway.className }}
+  listeners:
+  {{- if .Values.global.gateway.http.enabled }}
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - hostname: {{ $hostname }}
+      name: http-{{ $hostname | replace "." "-" }}
+      protocol: HTTP
+      port: {{ $.Values.global.gateway.http.port }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.global.gateway.https.enabled }}
+  {{- range $hostname := .Values.global.gateway.hostnames }}
+    - hostname: {{ $hostname }}
+      name: https-{{ $hostname | replace "." "-" }}
+      port: {{ $.Values.global.gateway.https.port }}
+      protocol: HTTPS
+      tls: {{ tpl (toYaml $.Values.global.gateway.https.tls ) $ | nindent 8 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/hedera-mirror/templates/gcpgatewaypolicy.yaml
+++ b/charts/hedera-mirror/templates/gcpgatewaypolicy.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.gateway.enabled (not (empty .Values.global.gateway.gcpGatewayPolicy)) -}}
+apiVersion: networking.gke.io/v1
+kind: GCPGatewayPolicy
+metadata:
+  labels: {{ include "hedera-mirror.labels" . | nindent 4 }}
+  name: {{ include "hedera-mirror.fullname" . }}
+  namespace: {{ include "hedera-mirror.namespace" . }}
+spec:
+  default: {{ tpl (toYaml .Values.global.gateway.gcpGatewayPolicy) $ | nindent 4 }}
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ include "hedera-mirror.fullname" . }}
+{{- end }}

--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -72,6 +72,21 @@ db:
 fullnameOverride: ""
 
 global:
+  gateway:
+    annotations: {}
+    className: "gke-l7-global-external-managed"
+    enabled: false
+    gcpGatewayPolicy: {}
+    hostnames: []
+    http:
+      enabled: true
+      port: 80
+      redirect: false
+    https:
+      enabled: false
+      port: 443
+      tls:
+        mode: Terminate
   hostname: ""
   image: {}
   namespaceOverride: ""

--- a/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicator.java
+++ b/hedera-mirror-monitor/src/main/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicator.java
@@ -50,7 +50,7 @@ public class ReleaseHealthIndicator implements ReactiveHealthIndicator {
             .withKind("HelmRelease")
             .withNamespaced(true)
             .withPlural("helmreleases")
-            .withVersion("v2beta1")
+            .withVersion("v2")
             .build();
     private final KubernetesClient client;
     private final ReleaseHealthProperties properties;

--- a/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicatorTest.java
+++ b/hedera-mirror-monitor/src/test/java/com/hedera/mirror/monitor/health/ReleaseHealthIndicatorTest.java
@@ -49,7 +49,7 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 class ReleaseHealthIndicatorTest {
 
     private static final String HELM_RELEASE_PATH =
-            "/apis/helm.toolkit.fluxcd.io/v2beta1/namespaces/test/helmreleases/mirror";
+            "/apis/helm.toolkit.fluxcd.io/v2/namespaces/test/helmreleases/mirror";
     private static final String HOSTNAME = "test-pod";
     private static final String POD_REQUEST_PATH = "/api/v1/namespaces/test/pods/" + HOSTNAME;
     private static final Map<String, String> POD_LABELS = Map.of("app.kubernetes.io/instance", "mirror");


### PR DESCRIPTION
**Description**:

* Add support for Kubernetes Gateway API
* Fix HelmRelease version in monitor

**Related issue(s)**:

Fixes #9574

**Notes for reviewer**:

Unfortunately GKE does not yet support `GrpcRoute` or `RegularExpression` path matching.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
