### PR TITLE
Bump com.hedera.hashgraph:app from 0.55.2 to 0.56.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
         api("com.graphql-java-generator:graphql-java-client-runtime:2.8")
         api("com.graphql-java:graphql-java-extended-scalars:22.0")
         api("com.graphql-java:graphql-java-extended-validation:22.0")
-        api("com.hedera.hashgraph:app:0.55.2")
+        api("com.hedera.hashgraph:app:0.56.6")
         api("com.hedera.evm:hedera-evm:0.54.2")
         api("com.hedera.hashgraph:hedera-protobuf-java-api:0.56.2")
         api("com.hedera.hashgraph:sdk:2.44.0")

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/NetworkInfoImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/NetworkInfoImpl.java
@@ -17,23 +17,21 @@
 package com.hedera.mirror.web3.state.components;
 
 import com.hedera.hapi.node.base.AccountID;
-import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
-import com.hedera.node.app.info.SelfNodeInfoImpl;
+import com.hedera.hapi.node.base.ServiceEndpoint;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.state.State;
 import com.swirlds.state.spi.info.NetworkInfo;
 import com.swirlds.state.spi.info.NodeInfo;
-import com.swirlds.state.spi.info.SelfNodeInfo;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Named;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @Named
 @RequiredArgsConstructor
 public class NetworkInfoImpl implements NetworkInfo {
-
-    private final MirrorNodeEvmProperties mirrorNodeEvmProperties;
 
     @Nonnull
     @Override
@@ -43,14 +41,14 @@ public class NetworkInfoImpl implements NetworkInfo {
 
     @Nonnull
     @Override
-    public SelfNodeInfo selfNodeInfo() {
-        return mockSelfNodeInfo();
+    public NodeInfo selfNodeInfo() {
+        return nodeInfo();
     }
 
     @Nonnull
     @Override
     public List<NodeInfo> addressBook() {
-        return List.of(mockSelfNodeInfo());
+        return List.of(nodeInfo());
     }
 
     @Nullable
@@ -64,25 +62,48 @@ public class NetworkInfoImpl implements NetworkInfo {
         return nodeInfo(nodeId) != null;
     }
 
+    @Override
+    public void updateFrom(State state) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
     /**
-     * Returns a {@link SelfNodeInfo} that is a complete mock other than the software version present in the given
+     * Returns a {@link NodeInfo} that is a complete mock other than the software version present in the given
      * configuration.
      *
      * @return a mock self node info
      */
-    private SelfNodeInfo mockSelfNodeInfo() {
-        return new SelfNodeInfoImpl(
-                0,
-                AccountID.DEFAULT,
-                0,
-                "",
-                0,
-                "",
-                0,
-                "",
-                "",
-                Bytes.EMPTY,
-                mirrorNodeEvmProperties.getSemanticEvmVersion(),
-                "");
+    private NodeInfo nodeInfo() {
+        return new NodeInfo() {
+            @Override
+            public long nodeId() {
+                return 0;
+            }
+
+            @Override
+            public AccountID accountId() {
+                return AccountID.DEFAULT;
+            }
+
+            @Override
+            public long stake() {
+                return 0;
+            }
+
+            @Override
+            public Bytes sigCertBytes() {
+                return Bytes.EMPTY;
+            }
+
+            @Override
+            public List<ServiceEndpoint> gossipEndpoints() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public String hexEncodedPublicKey() {
+                return "";
+            }
+        };
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
@@ -217,6 +217,5 @@ public class SchemaRegistryImpl implements SchemaRegistry {
      * @param beforeStates the writable states before applying the schema's state definitions
      * @param afterStates  the writable states after applying the schema's state definitions
      */
-    private record RedefinedWritableStates(WritableStates beforeStates, WritableStates afterStates) {
-    }
+    private record RedefinedWritableStates(WritableStates beforeStates, WritableStates afterStates) {}
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
@@ -169,7 +169,7 @@ public class SchemaRegistryImpl implements SchemaRegistry {
             }
 
             @Override
-            public NetworkInfo networkInfo() {
+            public NetworkInfo genesisNetworkInfo() {
                 return networkInfo;
             }
 
@@ -217,5 +217,6 @@ public class SchemaRegistryImpl implements SchemaRegistry {
      * @param beforeStates the writable states before applying the schema's state definitions
      * @param afterStates  the writable states after applying the schema's state definitions
      */
-    private record RedefinedWritableStates(WritableStates beforeStates, WritableStates afterStates) {}
+    private record RedefinedWritableStates(WritableStates beforeStates, WritableStates afterStates) {
+    }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/NetworkInfoImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/NetworkInfoImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.mirror.web3.Web3IntegrationTest;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.spi.info.NodeInfo;
 import jakarta.annotation.Resource;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,17 @@ class NetworkInfoImplTest extends Web3IntegrationTest {
         assertThat(selfNodeInfo).isNotNull().satisfies(info -> {
             assertThat(info.nodeId()).isZero();
             assertThat(info.accountId()).isEqualTo(AccountID.DEFAULT);
+            assertThat(info.stake()).isZero();
+            assertThat(info.sigCertBytes()).isEqualTo(Bytes.EMPTY);
+            assertThat(info.gossipEndpoints()).isEmpty();
+            assertThat(info.hexEncodedPublicKey()).isEmpty();
         });
+    }
+
+    @Test
+    void testUpdateFrom() {
+        final var exception = assertThrows(UnsupportedOperationException.class, () -> networkInfoImpl.updateFrom(null));
+        assertThat(exception.getMessage()).isEqualTo("Not implemented");
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/NetworkInfoImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/NetworkInfoImplTest.java
@@ -21,18 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.mirror.web3.Web3IntegrationTest;
-import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.swirlds.state.spi.info.NodeInfo;
-import com.swirlds.state.spi.info.SelfNodeInfo;
 import jakarta.annotation.Resource;
 import org.junit.jupiter.api.Test;
 
 class NetworkInfoImplTest extends Web3IntegrationTest {
 
     private static final int NODE_ID = 2;
-
-    @Resource
-    private MirrorNodeEvmProperties mirrorNodeEvmProperties;
 
     @Resource
     private NetworkInfoImpl networkInfoImpl;
@@ -45,11 +40,10 @@ class NetworkInfoImplTest extends Web3IntegrationTest {
 
     @Test
     void testSelfNodeInfo() {
-        SelfNodeInfo selfNodeInfo = networkInfoImpl.selfNodeInfo();
+        NodeInfo selfNodeInfo = networkInfoImpl.selfNodeInfo();
         assertThat(selfNodeInfo).isNotNull().satisfies(info -> {
             assertThat(info.nodeId()).isZero();
             assertThat(info.accountId()).isEqualTo(AccountID.DEFAULT);
-            assertThat(info.hapiVersion()).isEqualTo(mirrorNodeEvmProperties.getSemanticEvmVersion());
         });
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
@@ -180,7 +180,7 @@ class SchemaRegistryImplTest {
             assertThat(c.previousStates()).isEqualTo(readableStates);
             assertThat(c.newStates()).isEqualTo(writableStates);
             assertThat(c.configuration()).isEqualTo(config);
-            assertThat(c.networkInfo()).isEqualTo(networkInfo);
+            assertThat(c.genesisNetworkInfo()).isEqualTo(networkInfo);
             assertThat(c.newEntityNum()).isEqualTo(1);
             assertThat(c.sharedValues()).isEqualTo(EMPTY_MAP);
         });


### PR DESCRIPTION
**Description**:
Bump hedera app to 56.6

This PR modifies:
NetworkInfo - SelfNodeInfoImpl class is removed

**Related issue(s)**:
Related pr - 
https://github.com/hashgraph/hedera-mirror-node/pull/9813

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
