### PR TITLE
Add entity type filtering in Token and Account kv states

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AccountReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/AccountReadableKVState.java
@@ -17,6 +17,7 @@
 package com.hedera.mirror.web3.state;
 
 import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
+import static com.hedera.mirror.common.domain.entity.EntityType.TOKEN;
 import static com.hedera.mirror.web3.state.Utils.DEFAULT_AUTO_RENEW_PERIOD;
 import static com.hedera.mirror.web3.state.Utils.parseKey;
 import static com.hedera.services.utils.EntityIdUtils.toAccountId;
@@ -92,6 +93,7 @@ public class AccountReadableKVState extends ReadableKVStateBase<AccountID, Accou
         final var timestamp = ContractCallContext.get().getTimestamp();
         return commonEntityAccessor
                 .get(key, timestamp)
+                .filter(entity -> entity.getType() != TOKEN)
                 .map(entity -> accountFromEntity(entity, timestamp))
                 .orElse(null);
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/TokenReadableKVState.java
@@ -33,6 +33,7 @@ import com.hedera.hapi.node.transaction.FractionalFee;
 import com.hedera.hapi.node.transaction.RoyaltyFee;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.common.domain.token.TokenPauseStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenTypeEnum;
 import com.hedera.mirror.web3.common.ContractCallContext;
@@ -83,7 +84,7 @@ public class TokenReadableKVState extends ReadableKVStateBase<TokenID, Token> {
         final var timestamp = ContractCallContext.get().getTimestamp();
         final var entity = commonEntityAccessor.get(key, timestamp).orElse(null);
 
-        if (entity == null) {
+        if (entity == null || entity.getType() != EntityType.TOKEN) {
             return null;
         }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AccountReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AccountReadableKVStateTest.java
@@ -50,6 +50,7 @@ import com.hedera.mirror.web3.repository.TokenAllowanceRepository;
 import com.hedera.mirror.web3.repository.projections.TokenAccountAssociationsCount;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.services.utils.EntityIdUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -153,7 +154,7 @@ class AccountReadableKVStateTest {
     @BeforeEach
     void setup() {
         entity = new Entity();
-        entity.setId(NUM);
+        entity.setId(EntityIdUtils.toAccountId(SHARD, REALM, TOKEN_NUM).accountNum());
         entity.setCreatedTimestamp(timestamp.get());
         entity.setShard(SHARD);
         entity.setRealm(REALM);
@@ -168,7 +169,7 @@ class AccountReadableKVStateTest {
         entity.setType(EntityType.ACCOUNT);
 
         token = new Entity();
-        token.setId(TOKEN_NUM);
+        token.setId(EntityIdUtils.toAccountId(SHARD, REALM, TOKEN_NUM).accountNum());
         token.setCreatedTimestamp(timestamp.get());
         token.setShard(SHARD);
         token.setRealm(REALM);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AccountReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AccountReadableKVStateTest.java
@@ -154,7 +154,7 @@ class AccountReadableKVStateTest {
     @BeforeEach
     void setup() {
         entity = new Entity();
-        entity.setId(EntityIdUtils.toAccountId(SHARD, REALM, TOKEN_NUM).accountNum());
+        entity.setId(EntityIdUtils.toAccountId(SHARD, REALM, NUM).accountNum());
         entity.setCreatedTimestamp(timestamp.get());
         entity.setShard(SHARD);
         entity.setRealm(REALM);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AccountReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AccountReadableKVStateTest.java
@@ -72,8 +72,12 @@ class AccountReadableKVStateTest {
     private static final long SHARD = 0L;
     private static final long REALM = 1L;
     private static final long NUM = 1252L;
+    private static final long TOKEN_NUM = 1253L;
+    ;
     private static final AccountID ACCOUNT_ID =
             new AccountID(SHARD, REALM, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, NUM));
+    private static final AccountID ACCOUNT_ID_TOKEN =
+            new AccountID(SHARD, REALM, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, TOKEN_NUM));
     private static final EntityId AUTO_RENEW_ACCOUNT_ID = EntityId.of(SHARD, REALM, NUM + 1);
     private static final long EXPIRATION_TIMESTAMP = 2_000_000_000L;
     private static final long BALANCE = 3L;
@@ -108,6 +112,7 @@ class AccountReadableKVStateTest {
             });
     private static MockedStatic<ContractCallContext> contextMockedStatic;
     private Entity entity;
+    private Entity token;
 
     @InjectMocks
     private AccountReadableKVState accountReadableKVState;
@@ -163,6 +168,14 @@ class AccountReadableKVStateTest {
         entity.setMaxAutomaticTokenAssociations(MAX_AUTOMATIC_TOKEN_ASSOCIATIONS);
         entity.setType(EntityType.ACCOUNT);
 
+        token = new Entity();
+        token.setId(TOKEN_NUM);
+        token.setCreatedTimestamp(timestamp.get());
+        token.setShard(SHARD);
+        token.setRealm(REALM);
+        token.setNum(TOKEN_NUM);
+        token.setType(EntityType.TOKEN);
+
         contextMockedStatic.when(ContractCallContext::get).thenReturn(contractCallContext);
     }
 
@@ -183,6 +196,13 @@ class AccountReadableKVStateTest {
                 .returns(entity.getBalance(), Account::tinybarBalance)
                 .returns(entity.getAutoRenewPeriod(), Account::autoRenewSeconds)
                 .returns(entity.getMaxAutomaticTokenAssociations(), Account::maxAutoAssociations));
+    }
+
+    @Test
+    void accountIsNullWhenTheAccountIdIsToken() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        when(commonEntityAccessor.get(ACCOUNT_ID_TOKEN, Optional.empty())).thenReturn(Optional.ofNullable(token));
+        assertThat(accountReadableKVState.get(ACCOUNT_ID_TOKEN)).isNull();
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AccountReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/AccountReadableKVStateTest.java
@@ -73,7 +73,6 @@ class AccountReadableKVStateTest {
     private static final long REALM = 1L;
     private static final long NUM = 1252L;
     private static final long TOKEN_NUM = 1253L;
-    ;
     private static final AccountID ACCOUNT_ID =
             new AccountID(SHARD, REALM, new OneOf<>(AccountOneOfType.ACCOUNT_NUM, NUM));
     private static final AccountID ACCOUNT_ID_TOKEN =

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
@@ -70,6 +70,8 @@ class TokenReadableKVStateTest {
 
     private static final TokenID TOKEN_ID =
             TokenID.newBuilder().shardNum(0L).realmNum(0L).tokenNum(1252L).build();
+    private static final TokenID TOKEN_ID_ACCOUNT =
+            TokenID.newBuilder().shardNum(0L).realmNum(0L).tokenNum(1253L).build();
     private static final Long TOKEN_ENCODED_ID = EntityId.of(
                     TOKEN_ID.shardNum(), TOKEN_ID.realmNum(), TOKEN_ID.tokenNum())
             .getId();
@@ -106,6 +108,7 @@ class TokenReadableKVStateTest {
 
     private DomainBuilder domainBuilder;
     private Entity entity;
+    private Entity account;
     private Entity collector;
 
     @Spy
@@ -130,6 +133,14 @@ class TokenReadableKVStateTest {
                     e.id(TOKEN_ID.tokenNum());
                     e.num(TOKEN_ID.tokenNum());
                     e.type(EntityType.TOKEN);
+                })
+                .get();
+        account = domainBuilder
+                .entity()
+                .customize(e -> {
+                    e.id(TOKEN_ID_ACCOUNT.tokenNum());
+                    e.num(TOKEN_ID_ACCOUNT.tokenNum());
+                    e.type(EntityType.ACCOUNT);
                 })
                 .get();
         collector = domainBuilder
@@ -180,6 +191,13 @@ class TokenReadableKVStateTest {
                 .returns(entity.getAutoRenewPeriod(), Token::autoRenewSeconds);
 
         assertThat(token.totalSupplySupplier().get()).isEqualTo(databaseToken.getTotalSupply());
+    }
+
+    @Test
+    void getTokenReturnsNullWhenIdIsAnAccount() {
+        when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
+        when(commonEntityAccessor.get(TOKEN_ID_ACCOUNT, Optional.empty())).thenReturn(Optional.ofNullable(account));
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID_ACCOUNT)).isNull();
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/TokenReadableKVStateTest.java
@@ -70,7 +70,7 @@ class TokenReadableKVStateTest {
 
     private static final TokenID TOKEN_ID =
             TokenID.newBuilder().shardNum(0L).realmNum(0L).tokenNum(1252L).build();
-    private static final TokenID TOKEN_ID_ACCOUNT =
+    private static final TokenID TOKEN_ID_FOR_NEGATIVE_TEST =
             TokenID.newBuilder().shardNum(0L).realmNum(0L).tokenNum(1253L).build();
     private static final Long TOKEN_ENCODED_ID = EntityId.of(
                     TOKEN_ID.shardNum(), TOKEN_ID.realmNum(), TOKEN_ID.tokenNum())
@@ -138,8 +138,8 @@ class TokenReadableKVStateTest {
         account = domainBuilder
                 .entity()
                 .customize(e -> {
-                    e.id(TOKEN_ID_ACCOUNT.tokenNum());
-                    e.num(TOKEN_ID_ACCOUNT.tokenNum());
+                    e.id(TOKEN_ID_FOR_NEGATIVE_TEST.tokenNum());
+                    e.num(TOKEN_ID_FOR_NEGATIVE_TEST.tokenNum());
                     e.type(EntityType.ACCOUNT);
                 })
                 .get();
@@ -196,8 +196,10 @@ class TokenReadableKVStateTest {
     @Test
     void getTokenReturnsNullWhenIdIsAnAccount() {
         when(contractCallContext.getTimestamp()).thenReturn(Optional.empty());
-        when(commonEntityAccessor.get(TOKEN_ID_ACCOUNT, Optional.empty())).thenReturn(Optional.ofNullable(account));
-        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID_ACCOUNT)).isNull();
+        when(commonEntityAccessor.get(TOKEN_ID_FOR_NEGATIVE_TEST, Optional.empty()))
+                .thenReturn(Optional.ofNullable(account));
+        assertThat(tokenReadableKVState.readFromDataSource(TOKEN_ID_FOR_NEGATIVE_TEST))
+                .isNull();
     }
 
     @Test


### PR DESCRIPTION
**Description**:
This PR adds filtering for entity type in the account and token readable kv states.


This PR modifies ... in order to support ...
TokenReadableKVState - return token only if the entity type return from entity table is of type token
AccountReadableKVState - return the account when the entity type is not token
Unit test for the new cases

**Related issue(s)**:

Fixes #9862 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
