### PR TITLE
feat: Add StartupNetworks component and bump hedera-app to 0.57

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
         api("com.graphql-java-generator:graphql-java-client-runtime:2.8")
         api("com.graphql-java:graphql-java-extended-scalars:22.0")
         api("com.graphql-java:graphql-java-extended-validation:22.0")
-        api("com.hedera.hashgraph:app:0.56.6")
+        api("com.hedera.hashgraph:app:0.57.0")
         api("com.hedera.evm:hedera-evm:0.54.2")
         api("com.hedera.hashgraph:hedera-protobuf-java-api:0.56.2")
         api("com.hedera.hashgraph:sdk:2.45.0")

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -23,7 +23,7 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_3
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_46;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_50;
 import static com.swirlds.common.utility.CommonUtils.unhex;
-import static com.swirlds.state.spi.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
+import static com.swirlds.state.lifecycle.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.mirror.common.domain.entity.EntityType;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/MirrorNodeState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/MirrorNodeState.java
@@ -17,6 +17,8 @@
 package com.hedera.mirror.web3.state;
 
 import static com.hedera.node.app.util.FileUtilities.createFileID;
+import static com.hedera.node.app.workflows.handle.metric.UnavailableMetrics.UNAVAILABLE_METRICS;
+import static com.hedera.node.app.workflows.standalone.TransactionExecutors.DEFAULT_NODE_INFO;
 import static com.swirlds.state.StateChangeListener.StateType.MAP;
 import static com.swirlds.state.StateChangeListener.StateType.QUEUE;
 import static com.swirlds.state.StateChangeListener.StateType.SINGLETON;
@@ -28,6 +30,7 @@ import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.KeyList;
 import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.state.file.File;
+import com.hedera.hapi.node.transaction.ThrottleDefinitions;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.state.core.ListReadableQueueState;
 import com.hedera.mirror.web3.state.core.ListWritableQueueState;
@@ -51,7 +54,9 @@ import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.app.spi.AppContext.Gossip;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import com.hedera.node.app.state.recordcache.RecordCacheService;
+import com.hedera.node.app.throttle.AppThrottleFactory;
 import com.hedera.node.app.throttle.CongestionThrottleService;
+import com.hedera.node.app.throttle.ThrottleAccumulator;
 import com.hedera.node.app.version.ServicesSoftwareVersion;
 import com.hedera.node.app.workflows.handle.metric.UnavailableMetrics;
 import com.hedera.node.config.data.FilesConfig;
@@ -60,6 +65,8 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.state.State;
 import com.swirlds.state.StateChangeListener;
+import com.swirlds.state.lifecycle.StartupNetworks;
+import com.swirlds.state.lifecycle.info.NetworkInfo;
 import com.swirlds.state.spi.CommittableWritableStates;
 import com.swirlds.state.spi.EmptyWritableStates;
 import com.swirlds.state.spi.KVChangeListener;
@@ -71,8 +78,6 @@ import com.swirlds.state.spi.WritableKVStateBase;
 import com.swirlds.state.spi.WritableQueueStateBase;
 import com.swirlds.state.spi.WritableSingletonStateBase;
 import com.swirlds.state.spi.WritableStates;
-import com.swirlds.state.spi.info.NetworkInfo;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
@@ -108,6 +113,7 @@ public class MirrorNodeState implements State {
     private final ServicesRegistry servicesRegistry;
     private final ServiceMigrator serviceMigrator;
     private final NetworkInfo networkInfo;
+    private final StartupNetworks startupNetworks;
 
     @PostConstruct
     private void init() {
@@ -121,8 +127,10 @@ public class MirrorNodeState implements State {
                     new ServicesSoftwareVersion(
                             bootstrapConfig.getConfigData(VersionConfig.class).servicesVersion()),
                     new ConfigProviderImpl().getConfiguration(),
+                    new ConfigProviderImpl().getConfiguration(),
                     networkInfo,
-                    UnavailableMetrics.UNAVAILABLE_METRICS);
+                    UnavailableMetrics.UNAVAILABLE_METRICS,
+                    startupNetworks);
 
             final var fileServiceStates = this.getWritableStates(FileService.NAME);
             final var files = fileServiceStates.<FileID, File>get(V0490FileSchema.BLOBS_KEY);
@@ -141,7 +149,7 @@ public class MirrorNodeState implements State {
         });
     }
 
-    public MirrorNodeState addService(@NonNull final String serviceName, @NonNull final Map<String, ?> dataSources) {
+    public MirrorNodeState addService(@Nonnull final String serviceName, @Nonnull final Map<String, ?> dataSources) {
         final var serviceStates = this.states.computeIfAbsent(serviceName, k -> new ConcurrentHashMap<>());
         dataSources.forEach((k, b) -> {
             if (!serviceStates.containsKey(k)) {
@@ -160,9 +168,9 @@ public class MirrorNodeState implements State {
      * Removes the state with the given key for the service with the given name.
      *
      * @param serviceName the name of the service
-     * @param stateKey the key of the state
+     * @param stateKey    the key of the state
      */
-    public void removeServiceState(@NonNull final String serviceName, @NonNull final String stateKey) {
+    public void removeServiceState(@Nonnull final String serviceName, @Nonnull final String stateKey) {
         requireNonNull(serviceName);
         requireNonNull(stateKey);
         this.states.computeIfPresent(serviceName, (k, v) -> {
@@ -240,13 +248,13 @@ public class MirrorNodeState implements State {
     }
 
     @Override
-    public void registerCommitListener(@NonNull final StateChangeListener listener) {
+    public void registerCommitListener(@Nonnull final StateChangeListener listener) {
         requireNonNull(listener);
         listeners.add(listener);
     }
 
     @Override
-    public void unregisterCommitListener(@NonNull final StateChangeListener listener) {
+    public void unregisterCommitListener(@Nonnull final StateChangeListener listener) {
         requireNonNull(listener);
         listeners.remove(listener);
     }
@@ -260,7 +268,7 @@ public class MirrorNodeState implements State {
     }
 
     private <V> WritableSingletonStateBase<V> withAnyRegisteredListeners(
-            @NonNull final String serviceName, @NonNull final String stateKey, @NonNull final AtomicReference<V> ref) {
+            @Nonnull final String serviceName, @Nonnull final String stateKey, @Nonnull final AtomicReference<V> ref) {
         final var state = new WritableSingletonStateBase<>(stateKey, ref::get, ref::set);
         listeners.forEach(listener -> {
             if (listener.stateTypes().contains(SINGLETON)) {
@@ -271,7 +279,7 @@ public class MirrorNodeState implements State {
     }
 
     private <K, V> MapWritableKVState<K, V> withAnyRegisteredListeners(
-            @NonNull final String serviceName, @NonNull final MapWritableKVState<K, V> state) {
+            @Nonnull final String serviceName, @Nonnull final MapWritableKVState<K, V> state) {
         listeners.forEach(listener -> {
             if (listener.stateTypes().contains(MAP)) {
                 registerKVListener(serviceName, state, listener);
@@ -281,7 +289,7 @@ public class MirrorNodeState implements State {
     }
 
     private <T> ListWritableQueueState<T> withAnyRegisteredListeners(
-            @NonNull final String serviceName, @NonNull final ListWritableQueueState<T> state) {
+            @Nonnull final String serviceName, @Nonnull final ListWritableQueueState<T> state) {
         listeners.forEach(listener -> {
             if (listener.stateTypes().contains(QUEUE)) {
                 registerQueueListener(serviceName, state, listener);
@@ -291,21 +299,21 @@ public class MirrorNodeState implements State {
     }
 
     private <V> void registerSingletonListener(
-            @NonNull final String serviceName,
-            @NonNull final WritableSingletonStateBase<V> singletonState,
-            @NonNull final StateChangeListener listener) {
+            @Nonnull final String serviceName,
+            @Nonnull final WritableSingletonStateBase<V> singletonState,
+            @Nonnull final StateChangeListener listener) {
         final var stateId = listener.stateIdFor(serviceName, singletonState.getStateKey());
         singletonState.registerListener(value -> listener.singletonUpdateChange(stateId, value));
     }
 
     private <V> void registerQueueListener(
-            @NonNull final String serviceName,
-            @NonNull final WritableQueueStateBase<V> queueState,
-            @NonNull final StateChangeListener listener) {
+            @Nonnull final String serviceName,
+            @Nonnull final WritableQueueStateBase<V> queueState,
+            @Nonnull final StateChangeListener listener) {
         final var stateId = listener.stateIdFor(serviceName, queueState.getStateKey());
         queueState.registerListener(new QueueChangeListener<>() {
             @Override
-            public void queuePushChange(@NonNull final V value) {
+            public void queuePushChange(@Nonnull final V value) {
                 listener.queuePushChange(stateId, value);
             }
 
@@ -317,16 +325,16 @@ public class MirrorNodeState implements State {
     }
 
     private <K, V> void registerKVListener(
-            @NonNull final String serviceName, WritableKVStateBase<K, V> state, StateChangeListener listener) {
+            @Nonnull final String serviceName, WritableKVStateBase<K, V> state, StateChangeListener listener) {
         final var stateId = listener.stateIdFor(serviceName, state.getStateKey());
         state.registerListener(new KVChangeListener<>() {
             @Override
-            public void mapUpdateChange(@NonNull final K key, @NonNull final V value) {
+            public void mapUpdateChange(@Nonnull final K key, @Nonnull final V value) {
                 listener.mapUpdateChange(stateId, key, value);
             }
 
             @Override
-            public void mapDeleteChange(@NonNull final K key) {
+            public void mapDeleteChange(@Nonnull final K key) {
                 listener.mapDeleteChange(stateId, key);
             }
         });
@@ -364,8 +372,18 @@ public class MirrorNodeState implements State {
 
     private void registerServices(ServicesRegistry servicesRegistry) {
         // Register all service schema RuntimeConstructable factories before platform init
-        final var appContext =
-                new AppContextImpl(InstantSource.system(), signatureVerifier(), Gossip.UNAVAILABLE_GOSSIP);
+        final var appContext = new AppContextImpl(
+                InstantSource.system(),
+                signatureVerifier(),
+                Gossip.UNAVAILABLE_GOSSIP,
+                () -> new ConfigProviderImpl().getConfiguration(),
+                () -> DEFAULT_NODE_INFO,
+                () -> UNAVAILABLE_METRICS,
+                new AppThrottleFactory(
+                        () -> new ConfigProviderImpl().getConfiguration(),
+                        () -> this,
+                        () -> ThrottleDefinitions.DEFAULT,
+                        ThrottleAccumulator::new));
         Set.of(
                         new EntityIdService(),
                         new TokenServiceImpl(),

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/NetworkInfoImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/NetworkInfoImpl.java
@@ -18,10 +18,11 @@ package com.hedera.mirror.web3.state.components;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ServiceEndpoint;
+import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.State;
-import com.swirlds.state.spi.info.NetworkInfo;
-import com.swirlds.state.spi.info.NodeInfo;
+import com.swirlds.state.lifecycle.info.NetworkInfo;
+import com.swirlds.state.lifecycle.info.NodeInfo;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Named;
@@ -65,6 +66,11 @@ public class NetworkInfoImpl implements NetworkInfo {
     @Override
     public void updateFrom(State state) {
         throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public Roster roster() {
+        return Roster.DEFAULT;
     }
 
     /**

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
@@ -86,6 +86,7 @@ public class SchemaRegistryImpl implements SchemaRegistry {
                 startupNetworks);
     }
 
+    @SuppressWarnings("java:S107")
     public void migrate(
             @Nonnull final String serviceName,
             @Nonnull final MirrorNodeState state,
@@ -142,6 +143,7 @@ public class SchemaRegistryImpl implements SchemaRegistry {
         }
     }
 
+    @SuppressWarnings("java:S107")
     public MigrationContext newMigrationContext(
             @Nullable final SemanticVersion previousVersion,
             @Nonnull final ReadableStates previousStates,
@@ -240,5 +242,6 @@ public class SchemaRegistryImpl implements SchemaRegistry {
      * @param beforeStates the writable states before applying the schema's state definitions
      * @param afterStates  the writable states after applying the schema's state definitions
      */
-    private record RedefinedWritableStates(WritableStates beforeStates, WritableStates afterStates) {}
+    private record RedefinedWritableStates(WritableStates beforeStates, WritableStates afterStates) {
+    }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
@@ -242,6 +242,5 @@ public class SchemaRegistryImpl implements SchemaRegistry {
      * @param beforeStates the writable states before applying the schema's state definitions
      * @param afterStates  the writable states after applying the schema's state definitions
      */
-    private record RedefinedWritableStates(WritableStates beforeStates, WritableStates afterStates) {
-    }
+    private record RedefinedWritableStates(WritableStates beforeStates, WritableStates afterStates) {}
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/ServicesRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/ServicesRegistryImpl.java
@@ -18,7 +18,7 @@ package com.hedera.mirror.web3.state.components;
 
 import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.app.state.merkle.SchemaApplications;
-import com.swirlds.state.spi.Service;
+import com.swirlds.state.lifecycle.Service;
 import jakarta.annotation.Nonnull;
 import jakarta.inject.Named;
 import java.util.Collections;

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/StartupNetworksImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/StartupNetworksImpl.java
@@ -35,10 +35,14 @@ public class StartupNetworksImpl implements StartupNetworks {
     }
 
     @Override
-    public void setOverrideRound(long roundNumber) {}
+    public void setOverrideRound(long roundNumber) {
+        // This is a no-op in the current context, and other implementations may provide behavior.
+    }
 
     @Override
-    public void archiveStartupNetworks() {}
+    public void archiveStartupNetworks() {
+        // This is a no-op in the current context, and other implementations may provide behavior.
+    }
 
     @SuppressWarnings("deprecation")
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/StartupNetworksImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/StartupNetworksImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state.components;
+
+import com.hedera.node.internal.network.Network;
+import com.swirlds.state.lifecycle.StartupNetworks;
+import jakarta.inject.Named;
+import java.util.Optional;
+
+@Named
+public class StartupNetworksImpl implements StartupNetworks {
+
+    @Override
+    public Network genesisNetworkOrThrow() {
+        return Network.DEFAULT;
+    }
+
+    @Override
+    public Optional<Network> overrideNetworkFor(long roundNumber) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void setOverrideRound(long roundNumber) {}
+
+    @Override
+    public void archiveStartupNetworks() {}
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public Network migrationNetworkOrThrow() {
+        return Network.DEFAULT;
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/MirrorNodeStateIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/MirrorNodeStateIntegrationTest.java
@@ -31,7 +31,7 @@ import com.hedera.node.app.service.token.impl.TokenServiceImpl;
 import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.app.state.recordcache.RecordCacheService;
 import com.hedera.node.app.throttle.CongestionThrottleService;
-import com.swirlds.state.spi.Service;
+import com.swirlds.state.lifecycle.Service;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/MirrorNodeStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/MirrorNodeStateTest.java
@@ -33,9 +33,10 @@ import com.hedera.node.app.services.ServiceMigrator;
 import com.hedera.node.app.services.ServicesRegistry;
 import com.swirlds.state.StateChangeListener;
 import com.swirlds.state.StateChangeListener.StateType;
+import com.swirlds.state.lifecycle.StartupNetworks;
+import com.swirlds.state.lifecycle.info.NetworkInfo;
 import com.swirlds.state.spi.ReadableKVState;
 import com.swirlds.state.spi.WritableStates;
-import com.swirlds.state.spi.info.NetworkInfo;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -93,6 +94,9 @@ class MirrorNodeStateTest {
 
     @Mock
     private NetworkInfo networkInfo;
+
+    @Mock
+    private StartupNetworks startupNetworks;
 
     @Mock
     private StateChangeListener listener;
@@ -441,6 +445,6 @@ class MirrorNodeStateTest {
     }
 
     private MirrorNodeState buildStateObject() {
-        return new MirrorNodeState(readableKVStates, servicesRegistry, serviceMigrator, networkInfo);
+        return new MirrorNodeState(readableKVStates, servicesRegistry, serviceMigrator, networkInfo, startupNetworks);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/NetworkInfoImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/NetworkInfoImplTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.mirror.web3.Web3IntegrationTest;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.state.spi.info.NodeInfo;
+import com.swirlds.state.lifecycle.info.NodeInfo;
 import jakarta.annotation.Resource;
 import org.junit.jupiter.api.Test;
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/NetworkInfoImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/NetworkInfoImplTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.mirror.web3.Web3IntegrationTest;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.lifecycle.info.NodeInfo;
@@ -56,6 +57,11 @@ class NetworkInfoImplTest extends Web3IntegrationTest {
     void testUpdateFrom() {
         final var exception = assertThrows(UnsupportedOperationException.class, () -> networkInfoImpl.updateFrom(null));
         assertThat(exception.getMessage()).isEqualTo("Not implemented");
+    }
+
+    @Test
+    void testRoster() {
+        assertThat(networkInfoImpl.roster()).isEqualTo(Roster.DEFAULT);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
@@ -32,11 +32,12 @@ import com.hedera.node.app.state.merkle.SchemaApplicationType;
 import com.hedera.node.app.state.merkle.SchemaApplications;
 import com.hedera.pbj.runtime.Codec;
 import com.swirlds.config.api.Configuration;
-import com.swirlds.state.spi.MigrationContext;
+import com.swirlds.state.lifecycle.MigrationContext;
+import com.swirlds.state.lifecycle.Schema;
+import com.swirlds.state.lifecycle.StartupNetworks;
+import com.swirlds.state.lifecycle.StateDefinition;
+import com.swirlds.state.lifecycle.info.NetworkInfo;
 import com.swirlds.state.spi.ReadableStates;
-import com.swirlds.state.spi.Schema;
-import com.swirlds.state.spi.StateDefinition;
-import com.swirlds.state.spi.info.NetworkInfo;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Set;
@@ -73,6 +74,9 @@ class SchemaRegistryImplTest {
     private SchemaApplications schemaApplications;
 
     @Mock
+    private StartupNetworks startupNetworks;
+
+    @Mock
     private Codec<String> mockCodec;
 
     private Configuration config;
@@ -93,7 +97,7 @@ class SchemaRegistryImplTest {
 
     @Test
     void testMigrateWithNoSchemas() {
-        schemaRegistry.migrate(serviceName, mirrorNodeState, networkInfo);
+        schemaRegistry.migrate(serviceName, mirrorNodeState, networkInfo, startupNetworks);
         verify(mirrorNodeState, never()).getWritableStates(any());
     }
 
@@ -107,7 +111,14 @@ class SchemaRegistryImplTest {
         schemaRegistry.register(schema);
 
         schemaRegistry.migrate(
-                serviceName, mirrorNodeState, previousVersion, networkInfo, config, new HashMap<>(), new AtomicLong());
+                serviceName,
+                mirrorNodeState,
+                previousVersion,
+                networkInfo,
+                config,
+                new HashMap<>(),
+                new AtomicLong(),
+                startupNetworks);
         verify(mirrorNodeState, times(1)).getWritableStates(serviceName);
         verify(mirrorNodeState, times(1)).getReadableStates(serviceName);
         verify(writableStates, times(1)).commit();
@@ -121,7 +132,14 @@ class SchemaRegistryImplTest {
                 .thenReturn(EnumSet.of(SchemaApplicationType.MIGRATION));
         schemaRegistry.register(schema);
         schemaRegistry.migrate(
-                serviceName, mirrorNodeState, previousVersion, networkInfo, config, new HashMap<>(), new AtomicLong());
+                serviceName,
+                mirrorNodeState,
+                previousVersion,
+                networkInfo,
+                config,
+                new HashMap<>(),
+                new AtomicLong(),
+                startupNetworks);
 
         verify(schema).migrate(any());
         verify(writableStates, times(1)).commit();
@@ -147,7 +165,14 @@ class SchemaRegistryImplTest {
 
         schemaRegistry.register(schema);
         schemaRegistry.migrate(
-                serviceName, mirrorNodeState, previousVersion, networkInfo, config, new HashMap<>(), new AtomicLong());
+                serviceName,
+                mirrorNodeState,
+                previousVersion,
+                networkInfo,
+                config,
+                new HashMap<>(),
+                new AtomicLong(),
+                startupNetworks);
         verify(mirrorNodeState, times(1)).getWritableStates(serviceName);
         verify(mirrorNodeState, times(1)).getReadableStates(serviceName);
         verify(schema).migrate(any());
@@ -164,7 +189,14 @@ class SchemaRegistryImplTest {
 
         schemaRegistry.register(schema);
         schemaRegistry.migrate(
-                serviceName, mirrorNodeState, previousVersion, networkInfo, config, new HashMap<>(), new AtomicLong());
+                serviceName,
+                mirrorNodeState,
+                previousVersion,
+                networkInfo,
+                config,
+                new HashMap<>(),
+                new AtomicLong(),
+                startupNetworks);
 
         verify(schema).restart(any());
         verify(writableStates, times(1)).commit();
@@ -173,7 +205,14 @@ class SchemaRegistryImplTest {
     @Test
     void testNewMigrationContext() {
         MigrationContext context = schemaRegistry.newMigrationContext(
-                previousVersion, readableStates, writableStates, config, networkInfo, new AtomicLong(1), EMPTY_MAP);
+                previousVersion,
+                readableStates,
+                writableStates,
+                config,
+                networkInfo,
+                new AtomicLong(1),
+                EMPTY_MAP,
+                startupNetworks);
 
         assertThat(context).satisfies(c -> {
             assertThat(c.previousVersion()).isEqualTo(previousVersion);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.web3.state.components;
 
 import static java.util.Collections.EMPTY_MAP;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -215,6 +216,9 @@ class SchemaRegistryImplTest {
                 startupNetworks);
 
         assertThat(context).satisfies(c -> {
+            assertDoesNotThrow(() -> c.copyAndReleaseOnDiskState(""));
+            assertThat(c.roundNumber()).isZero();
+            assertThat(c.startupNetworks()).isEqualTo(startupNetworks);
             assertThat(c.previousVersion()).isEqualTo(previousVersion);
             assertThat(c.previousStates()).isEqualTo(readableStates);
             assertThat(c.newStates()).isEqualTo(writableStates);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/ServiceMigratorImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/ServiceMigratorImplTest.java
@@ -32,9 +32,10 @@ import com.hedera.node.config.VersionedConfiguration;
 import com.hedera.node.config.data.VersionConfig;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.State;
-import com.swirlds.state.spi.SchemaRegistry;
-import com.swirlds.state.spi.Service;
-import com.swirlds.state.spi.info.NetworkInfo;
+import com.swirlds.state.lifecycle.SchemaRegistry;
+import com.swirlds.state.lifecycle.Service;
+import com.swirlds.state.lifecycle.StartupNetworks;
+import com.swirlds.state.lifecycle.info.NetworkInfo;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,6 +66,9 @@ class ServiceMigratorImplTest {
 
     @Mock
     private ServicesRegistry mockServicesRegistry;
+
+    @Mock
+    private StartupNetworks startupNetworks;
 
     @Mock
     private State mockState;
@@ -102,8 +106,10 @@ class ServiceMigratorImplTest {
                 new ServicesSoftwareVersion(
                         bootstrapConfig.getConfigData(VersionConfig.class).servicesVersion()),
                 new ConfigProviderImpl().getConfiguration(),
+                new ConfigProviderImpl().getConfiguration(),
                 networkInfo,
-                metrics));
+                metrics,
+                startupNetworks));
     }
 
     @Test
@@ -125,8 +131,10 @@ class ServiceMigratorImplTest {
                 new ServicesSoftwareVersion(
                         bootstrapConfig.getConfigData(VersionConfig.class).servicesVersion()),
                 new ConfigProviderImpl().getConfiguration(),
+                new ConfigProviderImpl().getConfiguration(),
                 networkInfo,
-                metrics));
+                metrics,
+                startupNetworks));
     }
 
     @Test
@@ -154,8 +162,10 @@ class ServiceMigratorImplTest {
                     null,
                     servicesSoftwareVersion,
                     configuration,
+                    configuration,
                     networkInfo,
-                    metrics);
+                    metrics,
+                    startupNetworks);
         });
 
         assertThat(exception.getMessage()).isEqualTo("Can only be used with SchemaRegistryImpl instances");
@@ -169,7 +179,15 @@ class ServiceMigratorImplTest {
 
         var exception = assertThrows(IllegalArgumentException.class, () -> {
             serviceMigrator.doMigrations(
-                    mockState, servicesRegistry, null, servicesSoftwareVersion, configuration, networkInfo, metrics);
+                    mockState,
+                    servicesRegistry,
+                    null,
+                    servicesSoftwareVersion,
+                    configuration,
+                    configuration,
+                    networkInfo,
+                    metrics,
+                    startupNetworks);
         });
 
         assertThat(exception.getMessage()).isEqualTo("Can only be used with MirrorNodeState instances");
@@ -188,8 +206,10 @@ class ServiceMigratorImplTest {
                     null,
                     servicesSoftwareVersion,
                     configuration,
+                    configuration,
                     networkInfo,
-                    metrics);
+                    metrics,
+                    startupNetworks);
         });
 
         assertThat(exception.getMessage()).isEqualTo("Can only be used with ServicesRegistryImpl instances");
@@ -212,8 +232,10 @@ class ServiceMigratorImplTest {
                     null,
                     servicesSoftwareVersion,
                     configuration,
+                    configuration,
                     networkInfo,
-                    metrics);
+                    metrics,
+                    startupNetworks);
         });
 
         assertThat(exception.getMessage()).isEqualTo("Can only be used with SchemaRegistryImpl instances");

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/ServicesRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/ServicesRegistryImplTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.service.file.impl.FileServiceImpl;
-import com.swirlds.state.spi.Service;
+import com.swirlds.state.lifecycle.Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/StartupNetworksImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/StartupNetworksImplTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state.components;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.hedera.node.internal.network.Network;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class StartupNetworksImplTest {
+
+    private StartupNetworksImpl startupNetworks;
+
+    @BeforeEach
+    void setUp() {
+        startupNetworks = new StartupNetworksImpl();
+    }
+
+    @Test
+    void testGenesisNetworkOrThrow() {
+        assertThat(startupNetworks.genesisNetworkOrThrow()).isEqualTo(Network.DEFAULT);
+    }
+
+    @Test
+    void testOverrideNetworkFor() {
+        assertThat(startupNetworks.overrideNetworkFor(0)).isEmpty();
+    }
+
+    @Test
+    void testSetOverrideRound() {
+        assertDoesNotThrow(() -> startupNetworks.setOverrideRound(0));
+    }
+
+    @Test
+    void testArchiveStartupNetworks() {
+        assertDoesNotThrow(() -> startupNetworks.archiveStartupNetworks());
+    }
+
+    @Test
+    void testMigrationNetworkOrThrow() {
+        assertThat(startupNetworks.migrationNetworkOrThrow()).isEqualTo(Network.DEFAULT);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/StartupNetworksImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/StartupNetworksImplTest.java
@@ -23,7 +23,7 @@ import com.hedera.node.internal.network.Network;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class StartupNetworksImplTest {
+class StartupNetworksImplTest {
 
     private StartupNetworksImpl startupNetworks;
 


### PR DESCRIPTION
**Description**:
Add StartupNetworks components and refactor code to be able to bump to hedera-app 0.57 after new changes in services

This PR modifies:
Add StartupNetwork bean introduced in 0.57
Add StartupNetworksImplTest add coverage
Modified current classes with package changes from upstream and newly intoduced methods in the interfaces for the state components

**Related issue(s)**:

Fixes #9928 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
