### PR TITLE
Expand throttling options for MN operators

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/throttle/ThrottleProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/throttle/ThrottleProperties.java
@@ -29,7 +29,7 @@ import org.springframework.validation.annotation.Validated;
 public class ThrottleProperties {
 
     @Getter
-    @Min(100)
+    @Min(1)
     private long requestsPerSecond = 500;
 
     @Getter


### PR DESCRIPTION
**Description**:

While configuring the throttling limits as a MN's operator, I want to be able to go down to 1 request per second, but at the moment the MN poses a fixed minimum limit of 100 RPS.

**Related issue(s)**:

N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
