### PR TITLE
Fix OpenAPI spec response schema for getTopicMessageByIdAndSequenceNumber 

### DIFF
--- a/hedera-mirror-rest/api/v1/openapi.yml
+++ b/hedera-mirror-rest/api/v1/openapi.yml
@@ -1078,8 +1078,8 @@ paths:
   /api/v1/topics/{topicId}/messages/{sequenceNumber}:
     get:
       summary: Get topic message by id and sequence number
-      description: Returns a single topic message the given topic id and sequence number.
-      operationId: getTopicMessageById
+      description: Returns a single topic message for the given topic id and sequence number.
+      operationId: getTopicMessageByIdAndSequenceNumber
       parameters:
         - $ref: "#/components/parameters/topicIdPathParam"
         - name: sequenceNumber
@@ -1097,7 +1097,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TopicMessagesResponse"
+                $ref: "#/components/schemas/TopicMessage"
         400:
           $ref: "#/components/responses/InvalidParameterError"
         404:


### PR DESCRIPTION
**Description**:

This PR fixes the OpenAPI spec response schema for `/api/v1/topics/{topicId}/messages/{sequenceNumber}`

**Related issue(s)**:

Fixes #9990

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
