### PR TITLE
Fix BytecodeUtilsTest against modularized

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -629,7 +629,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         final var contract = testWeb3jService.deploy(EthCall::deploy);
         final var serviceParameters = testWeb3jService.serviceParametersForTopLevelContractCreate(
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, senderAddress);
-        final var actualGas = 183552L;
+        final var actualGas = 175242L;
 
         // When
         final var result = contractExecutionService.processCall(serviceParameters);
@@ -647,7 +647,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         final var contract = testWeb3jService.deploy(EthCall::deploy);
         final var serviceParameters = testWeb3jService.serviceParametersForTopLevelContractCreate(
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, Address.ZERO);
-        final var actualGas = 183552L;
+        final var actualGas = 175242L;
 
         // When
         final var result = contractExecutionService.processCall(serviceParameters);
@@ -725,20 +725,6 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         assertGasUsedIsPositive(gasUsedBeforeExecution, ETH_CALL);
     }
 
-    @Test
-    void ercPrecompileCallForEstimateGas() {
-        // Given
-        final var token = tokenPersist();
-        final var contract = testWeb3jService.deploy(EthCall::deploy);
-        meterRegistry.clear();
-
-        // When
-        final var result = contract.send_getTokenName(toAddress(token.getId()).toHexString());
-
-        // Then
-        verifyEthCallAndEstimateGas(result, contract);
-    }
-
     @ParameterizedTest
     @EnumSource(
             value = CallType.class,
@@ -782,8 +768,8 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
     @MethodSource("ercPrecompileCallTypeArgumentsProvider")
     void ercPrecompileContractRevertReturnsExpectedGasToBucket(final CallType callType, final long gasLimit) {
         // Given
-        final var contract = testWeb3jService.deploy(EthCall::deploy);
-        final var functionCall = contract.call_getTokenName(Address.ZERO.toHexString());
+        final var contract = testWeb3jService.deploy(ERCTestContract::deploy);
+        final var functionCall = contract.call_nameNonStatic(Address.ZERO.toHexString());
 
         final var serviceParameters = getContractExecutionParameters(functionCall, contract, callType, gasLimit);
         final var expectedGasUsed = gasUsedAfterExecution(serviceParameters);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/BytecodeUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/utils/BytecodeUtilsTest.java
@@ -20,7 +20,7 @@ import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallTyp
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.hedera.mirror.web3.Web3IntegrationTest;
+import com.hedera.mirror.web3.service.AbstractContractCallServiceTest;
 import com.hedera.mirror.web3.service.ContractExecutionService;
 import com.hedera.mirror.web3.web3j.TestWeb3jService;
 import com.hedera.mirror.web3.web3j.TestWeb3jService.Web3jTestConfiguration;
@@ -43,7 +43,7 @@ import org.springframework.context.annotation.Import;
 
 @Import(Web3jTestConfiguration.class)
 @RequiredArgsConstructor
-class BytecodeUtilsTest extends Web3IntegrationTest {
+class BytecodeUtilsTest extends AbstractContractCallServiceTest {
 
     private final ContractExecutionService contractExecutionService;
     private final TestWeb3jService testWeb3jService;

--- a/hedera-mirror-web3/src/test/solidity/EthCall.sol
+++ b/hedera-mirror-web3/src/test/solidity/EthCall.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "./HederaTokenService.sol";
 import "./IHederaTokenService.sol";
 
@@ -35,16 +34,6 @@ contract EthCall is HederaTokenService {
     // External pure function that returns a storage field as a function result
     function returnStorageData() external pure returns (string memory) {
         return storageData;
-    }
-
-    // External view function that has an argument for a token address and using open zeppelin IERC20 interface as a wrapper, returns the token’s name
-    function getTokenName(address _tokenAddress) external view returns (string memory) {
-        return IERC20Metadata(_tokenAddress).name();
-    }
-
-    // External view function that has an argument for a token address and using open zeppelin IERC20 interface as a wrapper, returns the token’s symbol
-    function getTokenSymbol(address _tokenAddress) external view returns (string memory) {
-        return IERC20Metadata(_tokenAddress).symbol();
     }
 
     // External function that freezes a given token for the message sender


### PR DESCRIPTION
**Description**:
This PR fixes `BytecodeUtilsTest` which were failing when ran against modularized flag.

Made `BytecodeUtilsTest` extend `AbstractContractCallServiceTest` and now gets initial setup which makes most of the test except for one pass.

The one test that did not pass was -> `testExtractRuntimeBytecodeEthCall`. The reason was that the EthCall.binary was bigger than services max transaction size with a little bit.
This issue will be fixed in https://github.com/hashgraph/hedera-services/issues/17099

Workaround solution for the test is:
Deleted EthCall methods - `getTokenName` and `getTokenSymbol`.
We have the exacts same tests in `ContractCallServiceERCTokenReadOnlyFunctionsTest` so these 2 can be deleted.
Deleting those decreased the binary and now it passes services max txn size check.

Changes in this PR also fix a couple of tests using the EthCall contract in `ContracCallServiceTest`.

This PR modifies ... in order to support ...
`BytecodeUtilsTest` - extends `AbstractContractCallServiceTest`
`EthCall`.sol - delete `getTokenName` and `getTokenSymbol` to decrease contract binary

**Related issue(s)**:

Fixes #9992

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
