### PR TITLE
Add github actions step for executing web3 tests using transaction executor

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -94,7 +94,7 @@ jobs:
         run: ./gradlew :${{matrix.project}}:build --scan ${{ secrets.GRADLE_ARGS }}
 
       - name: Execute Gradle using transaction executor
-        if: ${{ matrix.project == 'web3'}}
+        if: ${{ matrix.project == 'web3' && matrix.schema == 'v1'}}
         continue-on-error: true
         env:
           MIRROR_NODE_SCHEMA: ${{ matrix.schema}}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,7 @@ permissions:
 env:
   LC_ALL: C.UTF-8
   CGO_ENABLED: 1
-  ENABLE_TRANSACTION_EXECUTOR_STEP: "false" #Enable when the full implementation of reusable services is completed
+  ENABLE_TRANSACTION_EXECUTOR_STEP: "true" #Enable when the full implementation of reusable services is completed
 
 jobs:
   build:
@@ -88,19 +88,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gcc libc-dev libc6-dev
 
-      - name: Execute Gradle
-        env:
-          MIRROR_NODE_SCHEMA: ${{ matrix.schema}}
-          SPRING_PROFILES_ACTIVE: ${{ matrix.schema}}
-        run: ./gradlew :${{matrix.project}}:build --scan ${{ secrets.GRADLE_ARGS }}
+#      - name: Execute Gradle
+#        env:
+#          MIRROR_NODE_SCHEMA: ${{ matrix.schema}}
+#          SPRING_PROFILES_ACTIVE: ${{ matrix.schema}}
+#        run: ./gradlew :${{matrix.project}}:build --scan ${{ secrets.GRADLE_ARGS }}
 
       - name: Execute Gradle using transaction executor
         if: ${{ matrix.project == 'web3' && env.ENABLE_TRANSACTION_EXECUTOR_STEP == 'true'}}
         env:
           MIRROR_NODE_SCHEMA: ${{ matrix.schema}}
           SPRING_PROFILES_ACTIVE: ${{ matrix.schema}}
-          HEDERA_MIRROR_WEB3_EVM_MODULARIZED_SERVICES: "true"
-        run: ./gradlew :${{ matrix.project }}:build --scan ${{ secrets.GRADLE_ARGS }}
+          HEDERA_MIRROR_WEB3_EVM_MODULARIZEDSERVICES: "true"
+        run: ./gradlew :${{ matrix.project }}:build --info --scan ${{ secrets.GRADLE_ARGS }}
 
       - name: Upload coverage report
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -93,6 +93,14 @@ jobs:
           SPRING_PROFILES_ACTIVE: ${{ matrix.schema}}
         run: ./gradlew :${{matrix.project}}:build --scan ${{ secrets.GRADLE_ARGS }}
 
+      - name: Execute Gradle using transaction executor
+        if: ${{ matrix.project == 'web3' }}
+        env:
+          MIRROR_NODE_SCHEMA: ${{ matrix.schema}}
+          SPRING_PROFILES_ACTIVE: ${{ matrix.schema}}
+          HEDERA_MIRROR_WEB3_EVM_MODULARIZED_SERVICES: "true"
+        run: ./gradlew :${{ matrix.project }}:build --scan ${{ secrets.GRADLE_ARGS }}
+
       - name: Upload coverage report
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,7 @@ permissions:
 env:
   LC_ALL: C.UTF-8
   CGO_ENABLED: 1
-  ENABLE_TRANSACTION_EXECUTOR_STEP: "true"
+  ENABLE_TRANSACTION_EXECUTOR_STEP: "false" #Enable when the full implementation of reusable services is completed
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,6 +21,7 @@ permissions:
 env:
   LC_ALL: C.UTF-8
   CGO_ENABLED: 1
+  ENABLE_TRANSACTION_EXECUTOR_STEP: "true"
 
 jobs:
   build:
@@ -94,7 +95,7 @@ jobs:
         run: ./gradlew :${{matrix.project}}:build --scan ${{ secrets.GRADLE_ARGS }}
 
       - name: Execute Gradle using transaction executor
-        if: ${{ matrix.project == 'web3' }}
+        if: ${{ matrix.project == 'web3' && env.ENABLE_TRANSACTION_EXECUTOR_STEP == 'true'}}
         env:
           MIRROR_NODE_SCHEMA: ${{ matrix.schema}}
           SPRING_PROFILES_ACTIVE: ${{ matrix.schema}}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,6 @@ permissions:
 env:
   LC_ALL: C.UTF-8
   CGO_ENABLED: 1
-  ENABLE_TRANSACTION_EXECUTOR_STEP: "true" #Enable when the full implementation of reusable services is completed
 
 jobs:
   build:
@@ -88,19 +87,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gcc libc-dev libc6-dev
 
-#      - name: Execute Gradle
-#        env:
-#          MIRROR_NODE_SCHEMA: ${{ matrix.schema}}
-#          SPRING_PROFILES_ACTIVE: ${{ matrix.schema}}
-#        run: ./gradlew :${{matrix.project}}:build --scan ${{ secrets.GRADLE_ARGS }}
+      - name: Execute Gradle
+        env:
+          MIRROR_NODE_SCHEMA: ${{ matrix.schema}}
+          SPRING_PROFILES_ACTIVE: ${{ matrix.schema}}
+        run: ./gradlew :${{matrix.project}}:build --scan ${{ secrets.GRADLE_ARGS }}
 
       - name: Execute Gradle using transaction executor
-        if: ${{ matrix.project == 'web3' && env.ENABLE_TRANSACTION_EXECUTOR_STEP == 'true'}}
+        if: ${{ matrix.project == 'web3'}}
+        continue-on-error: true
         env:
           MIRROR_NODE_SCHEMA: ${{ matrix.schema}}
           SPRING_PROFILES_ACTIVE: ${{ matrix.schema}}
           HEDERA_MIRROR_WEB3_EVM_MODULARIZEDSERVICES: "true"
-        run: ./gradlew :${{ matrix.project }}:build --info --scan ${{ secrets.GRADLE_ARGS }}
+        run: ./gradlew :${{ matrix.project }}:build --scan ${{ secrets.GRADLE_ARGS }}
 
       - name: Upload coverage report
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -116,10 +116,8 @@ public abstract class ContractCallService {
         try {
             HederaEvmTransactionProcessingResult result;
             if (!mirrorNodeEvmProperties.isModularizedServices()) {
-                log.info("WE ARE HERE - FLAG IS FALSE");
                 result = mirrorEvmTxProcessor.execute(params, estimatedGas);
             } else {
-                log.info("WE ARE HERE - FLAG IS TRUE");
                 result = transactionExecutionService.execute(params, estimatedGas);
             }
             if (!restoreGasToThrottleBucket) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -116,8 +116,10 @@ public abstract class ContractCallService {
         try {
             HederaEvmTransactionProcessingResult result;
             if (!mirrorNodeEvmProperties.isModularizedServices()) {
+                log.info("WE ARE HERE - FLAG IS FALSE");
                 result = mirrorEvmTxProcessor.execute(params, estimatedGas);
             } else {
+                log.info("WE ARE HERE - FLAG IS TRUE");
                 result = transactionExecutionService.execute(params, estimatedGas);
             }
             if (!restoreGasToThrottleBucket) {


### PR DESCRIPTION
**Description**:
This PR adds new github actions step that executes the web3 tests using the new implementation for transaction executor. 

**Related issue(s)**:

Fixes #9995 

**Notes for reviewer**:
This step will be currently disabled until the full implementation for the reusable services is completed

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
