### PR TITLE
Disable schedule acceptance tests in mainnet-staging

### DIFF
--- a/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
+++ b/clusters/mainnet-staging-na/mainnet-citus/helmrelease.yaml
@@ -119,7 +119,7 @@ spec:
             test:
               acceptance:
                 network: MAINNET
-      cucumberTags: "@critical"
+      cucumberTags: "@critical and not @schedulebase"
       enabled: true
     web3:
       env:


### PR DESCRIPTION
**Description**:

Disable schedule acceptance tests until mainnet is upgraded to 0.57 which supports long term scheduled transactions tests added in https://github.com/hashgraph/hedera-mirror-node/pull/9963.

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
