### PR TITLE
Fix `MAX_GAS_LIMIT_EXCEEDED` test failures in modularized web3

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
@@ -16,10 +16,14 @@
 
 package com.hedera.mirror.web3.exception;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
 import com.hedera.mirror.web3.evm.exception.EvmException;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.io.Serial;
 import java.nio.charset.StandardCharsets;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.bytes.Bytes;
 
 @SuppressWarnings("java:S110")
@@ -55,5 +59,24 @@ public class MirrorEvmTransactionException extends EvmException {
 
     public String getData() {
         return data;
+    }
+
+    @Override
+    public String toString() {
+        return "%s(message=%s, detail=%s, data=%s, dataDecoded=%s)"
+                .formatted(getClass().getSimpleName(), getMessage(), detail, data, decodeHex(data));
+    }
+
+    private String decodeHex(final String hex) {
+        try {
+            if (StringUtils.isBlank(hex)) {
+                return EMPTY;
+            }
+
+            var decoded = Hex.decodeHex(hex.replace("0x", EMPTY));
+            return new String(decoded, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return EMPTY;
+        }
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesIntegrationTest.java
@@ -36,7 +36,7 @@ class MirrorNodeEvmPropertiesIntegrationTest extends Web3IntegrationTest {
     private static final String CONTRACTS_CONFIG = "contracts";
     private static final String CHAIN_ID_KEY_CONFIG = CONTRACTS_CONFIG + DOT_SEPARATOR + CHAIN_ID;
     private static final Map<String, String> YAML_PROPERTIES =
-            Map.of("contracts.allowCreate2", "false", "contracts.maxGasPerSec", "10000000", CHAIN_ID_KEY_CONFIG, "297");
+            Map.of("contracts.allowCreate2", "false", CHAIN_ID_KEY_CONFIG, "297");
     private static final String MAX_GAS_REFUND_PERCENTAGE = "maxRefundPercentOfGasLimit";
     private static final String MAX_GAS_REFUND_PERCENTAGE_KEY_CONFIG =
             CONTRACTS_CONFIG + DOT_SEPARATOR + MAX_GAS_REFUND_PERCENTAGE;

--- a/hedera-mirror-web3/src/test/resources/config/application.yml
+++ b/hedera-mirror-web3/src/test/resources/config/application.yml
@@ -5,7 +5,6 @@ hedera:
         properties:
           contracts.allowCreate2: "false"
           contracts.chainId: "297"
-          contracts.maxGasPerSec: "10000000"
         evm_versions:
           0: 0.30.0
           50: 0.34.0


### PR DESCRIPTION
**Description**:

* Fix `MAX_GAS_LIMIT_EXCEEDED` pre-check failure in modularized web3 tests due to specifying 15M gas in request but overriding `maxGasPerSec=10M` in test config
* Improve error message in tests to include the decoded data (which usually includes the HAPI response code)

**Related issue(s)**:

**Notes for reviewer**:

Fixes 400+ tests:

Before
```
3341 tests completed, 755 failed, 6 skipped
```
After
```
3341 tests completed, 332 failed, 6 skipped
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
