### PR TITLE
Fix consensus time and transaction valid start time

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutionService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutionService.java
@@ -67,7 +67,6 @@ public class TransactionExecutionService {
     private static final AccountID TREASURY_ACCOUNT_ID =
             AccountID.newBuilder().accountNum(2).build();
     private static final Duration TRANSACTION_DURATION = new Duration(15);
-    private static final Timestamp TRANSACTION_START = new Timestamp(0, 0);
     private static final int INITCODE_SIZE_KB = 6 * 1024;
     private final State mirrorNodeState;
     private final MirrorNodeEvmProperties mirrorNodeEvmProperties;
@@ -95,7 +94,7 @@ public class TransactionExecutionService {
             } else {
                 // Upload the init bytecode
                 transactionBody = buildFileCreateTransactionBody(params, maxLifetime);
-                var uploadReceipt = executor.execute(transactionBody, Instant.EPOCH);
+                var uploadReceipt = executor.execute(transactionBody, Instant.now());
                 final var fileID = uploadReceipt
                         .getFirst()
                         .transactionRecord()
@@ -117,7 +116,7 @@ public class TransactionExecutionService {
             transactionBody = buildContractCallTransactionBody(params, estimatedGas);
         }
 
-        var receipt = executor.execute(transactionBody, Instant.EPOCH, getOperationTracers());
+        var receipt = executor.execute(transactionBody, Instant.now(), getOperationTracers());
         var transactionRecord = receipt.getFirst().transactionRecord();
         if (transactionRecord.receiptOrThrow().status() == ResponseCodeEnum.SUCCESS) {
             result = buildSuccessResult(isContractCreate, transactionRecord, params);
@@ -165,7 +164,7 @@ public class TransactionExecutionService {
     private TransactionBody.Builder defaultTransactionBodyBuilder(final CallServiceParameters params) {
         return TransactionBody.newBuilder()
                 .transactionID(TransactionID.newBuilder()
-                        .transactionValidStart(TRANSACTION_START)
+                        .transactionValidStart(new Timestamp(Instant.now().getEpochSecond(), 0))
                         .accountID(getSenderAccountID(params))
                         .build())
                 .nodeAccountID(TREASURY_ACCOUNT_ID) // We don't really need another account here.
@@ -246,7 +245,7 @@ public class TransactionExecutionService {
 
     private OperationTracer[] getOperationTracers() {
         return ContractCallContext.get().getOpcodeTracerOptions() != null
-                ? new OperationTracer[] {opcodeTracer}
+                ? new OperationTracer[]{opcodeTracer}
                 : EMPTY_OPERATION_TRACER_ARRAY;
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutionService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutionService.java
@@ -245,7 +245,7 @@ public class TransactionExecutionService {
 
     private OperationTracer[] getOperationTracers() {
         return ContractCallContext.get().getOpcodeTracerOptions() != null
-                ? new OperationTracer[]{opcodeTracer}
+                ? new OperationTracer[] {opcodeTracer}
                 : EMPTY_OPERATION_TRACER_ARRAY;
     }
 


### PR DESCRIPTION
**Description**:
A few tests like update token expiry are failing since currently in transaction executor we are passing the EPOCH instant. In a test like update token expiry info consensus time is 0 due to that, consequently the tests fails.
In this pr we are now passing the now instant as transaction valid start and  consensus time. 
This will resolve issue like the ones in update token expiry test.

This PR modifies 
TransactionExecutionService - now instead of EPOCH time we are passing Instant.now()

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
