### PR TITLE
Fix some `INSUFFICIENT_PAYER_BALANCE` errors

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceHistoricalTest.java
@@ -152,8 +152,9 @@ public abstract class AbstractContractCallServiceHistoricalTest extends Abstract
         // result
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(timestampRange.lowerEndpoint(), EntityId.of(2)))
-                        .balance(balance))
+                .customize(
+                        ab -> ab.id(new AccountBalance.Id(timestampRange.lowerEndpoint(), treasuryEntity.toEntityId()))
+                                .balance(balance))
                 .persist();
         domainBuilder
                 .accountBalance()
@@ -168,8 +169,9 @@ public abstract class AbstractContractCallServiceHistoricalTest extends Abstract
         // result
         domainBuilder
                 .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(timestampRange.lowerEndpoint(), EntityId.of(2)))
-                        .balance(balance))
+                .customize(
+                        ab -> ab.id(new AccountBalance.Id(timestampRange.lowerEndpoint(), treasuryEntity.toEntityId()))
+                                .balance(balance))
                 .persist();
         domainBuilder
                 .tokenBalance()

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -75,6 +76,8 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
 
     protected RecordFile genesisRecordFile;
 
+    protected Entity treasuryEntity;
+
     protected static final String TREASURY_ADDRESS = EvmTokenUtils.toAddress(2).toHexString();
 
     protected static final byte[] EXCHANGE_RATES_SET = ExchangeRateSet.newBuilder()
@@ -111,7 +114,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     protected void setup() {
         genesisRecordFile =
                 domainBuilder.recordFile().customize(f -> f.index(0L)).persist();
-        domainBuilder
+        treasuryEntity = domainBuilder
                 .entity()
                 .customize(e -> e.id(2L).num(2L).balance(5000000000000000000L))
                 .persist();
@@ -119,6 +122,12 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
         domainBuilder
                 .fileData()
                 .customize(f -> f.entityId(EntityId.of(112L)).fileData(EXCHANGE_RATES_SET))
+                .persist();
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new AccountBalance.Id(
+                                treasuryEntity.getCreatedTimestamp(), treasuryEntity.toEntityId()))
+                        .balance(treasuryEntity.getBalance()))
                 .persist();
         testWeb3jService.reset();
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceERCTokenHistoricalTest.java
@@ -28,7 +28,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.google.common.collect.Range;
-import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
@@ -673,22 +672,17 @@ class ContractCallServiceERCTokenHistoricalTest extends AbstractContractCallServ
         final var tokenEntityId = entityIdFromEvmAddress(tokenAddress);
         final var accountId = entityIdFromEvmAddress(senderAddress);
         final var tokenId = entityIdFromEvmAddress(tokenAddress);
-        // hardcoded treasury account id is mandatory
-        final long lowerTimestamp = historicalRange.lowerEndpoint();
-        domainBuilder
-                .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(lowerTimestamp, EntityId.of(2))))
-                .persist();
         domainBuilder
                 .tokenBalance()
-                .customize(tb -> tb.id(new TokenBalance.Id(lowerTimestamp, accountId, tokenId))
+                .customize(tb -> tb.id(new TokenBalance.Id(treasuryEntity.getCreatedTimestamp(), accountId, tokenId))
                         .balance(balance))
                 .persist();
         domainBuilder
                 .tokenBalance()
                 // Expected total supply is 12345
                 .customize(tb -> tb.balance(12345L - balance)
-                        .id(new TokenBalance.Id(lowerTimestamp, domainBuilder.entityId(), tokenEntityId)))
+                        .id(new TokenBalance.Id(
+                                treasuryEntity.getCreatedTimestamp(), domainBuilder.entityId(), tokenEntityId)))
                 .persist();
     }
 


### PR DESCRIPTION
**Description**:
After PR https://github.com/hashgraph/hedera-mirror-node/pull/10063 was merged, some of the test that were previously successful, now are failing with `INSUFFICIENT_PAYER_BALANCE` error. The reason for that was that before the PR, the tests were false positive. After the PR, the hidden errors are now uncovered. This PR moves the treasury account and balance creation in `AbstractContractCallServiceTest#setup` only. This PR is focused on the errors in `ContractCallServicePrecompileModificationTest`.

**Related issue(s)**: https://github.com/hashgraph/hedera-mirror-node/issues/9984
