### PR TITLE
Fix NodeUpdateTransaction always updating node zero (0.120)

### DIFF
--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeDeleteTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeDeleteTransactionHandler.java
@@ -51,9 +51,10 @@ class NodeDeleteTransactionHandler extends AbstractTransactionHandler {
     private void parseNode(RecordItem recordItem) {
         if (recordItem.isSuccessful()) {
             long consensusTimestamp = recordItem.getConsensusTimestamp();
+            var body = recordItem.getTransactionBody().getNodeDelete();
             entityListener.onNode(Node.builder()
                     .deleted(true)
-                    .nodeId(recordItem.getTransactionRecord().getReceipt().getNodeId())
+                    .nodeId(body.getNodeId())
                     .timestampRange(Range.atLeast(consensusTimestamp))
                     .build());
         }

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeUpdateTransactionHandler.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeUpdateTransactionHandler.java
@@ -64,8 +64,13 @@ class NodeUpdateTransactionHandler extends AbstractTransactionHandler {
                 node.setAdminKey(nodeUpdate.getAdminKey().toByteArray());
             }
 
+            // As a special case, nodes migrated state to mirror nodes via a NodeUpdate instead of a proper NodeCreate
+            if (recordItem.getTransactionRecord().getTransactionID().getNonce() > 0) {
+                node.setCreatedTimestamp(consensusTimestamp);
+            }
+
             node.setDeleted(false);
-            node.setNodeId(recordItem.getTransactionRecord().getReceipt().getNodeId());
+            node.setNodeId(nodeUpdate.getNodeId());
             node.setTimestampRange(Range.atLeast(consensusTimestamp));
 
             entityListener.onNode(node);

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/domain/RecordItemBuilder.java
@@ -689,7 +689,6 @@ public class RecordItemBuilder {
     }
 
     public Builder<NodeUpdateTransactionBody.Builder> nodeUpdate() {
-        var nodeId = id();
         var builder = NodeUpdateTransactionBody.newBuilder()
                 .setAccountId(accountId())
                 .setAdminKey(key())
@@ -697,15 +696,14 @@ public class RecordItemBuilder {
                 .setGossipCaCertificate(BytesValue.of(bytes(4)))
                 .addGossipEndpoint(gossipEndpoint())
                 .setGrpcCertificateHash(BytesValue.of(bytes(48)))
-                .setNodeId(nodeId)
+                .setNodeId(id())
                 .addServiceEndpoint(serviceEndpoint());
-        return new Builder<>(TransactionType.NODEUPDATE, builder).receipt(r -> r.setNodeId(nodeId));
+        return new Builder<>(TransactionType.NODEUPDATE, builder);
     }
 
     public Builder<NodeDeleteTransactionBody.Builder> nodeDelete() {
-        var nodeId = id();
-        var builder = NodeDeleteTransactionBody.newBuilder().setNodeId(nodeId);
-        return new Builder<>(TransactionType.NODEDELETE, builder).receipt(r -> r.setNodeId(nodeId));
+        var builder = NodeDeleteTransactionBody.newBuilder().setNodeId(id());
+        return new Builder<>(TransactionType.NODEDELETE, builder);
     }
 
     @SuppressWarnings("deprecation")

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/entity/sql/SqlEntityListenerTest.java
@@ -1749,9 +1749,7 @@ class SqlEntityListenerTest extends ImporterIntegrationTest {
         var node1 = domainBuilder.node().get();
         var node2 = domainBuilder
                 .node()
-                .customize(node -> node.adminKey(null))
-                .customize(node -> node.createdTimestamp(null))
-                .customize(node -> node.nodeId(node1.getNodeId()))
+                .customize(node -> node.adminKey(null).nodeId(node1.getNodeId()))
                 .get();
 
         // when
@@ -1774,10 +1772,8 @@ class SqlEntityListenerTest extends ImporterIntegrationTest {
         var node1 = domainBuilder.node().get();
         var node2 = domainBuilder
                 .node()
-                .customize(node -> node.adminKey(null))
-                .customize(node -> node.createdTimestamp(null))
-                .customize(node -> node.deleted(true))
-                .customize(node -> node.nodeId(node1.getNodeId()))
+                .customize(node ->
+                        node.adminKey(null).createdTimestamp(null).deleted(true).nodeId(node1.getNodeId()))
                 .get();
 
         // when

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeDeleteTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeDeleteTransactionHandlerTest.java
@@ -98,7 +98,7 @@ class NodeDeleteTransactionHandlerTest extends AbstractTransactionHandlerTest {
         assertThat(transaction.getTransactionRecordBytes()).containsExactly(transactionRecordBytes);
         verify(entityListener, times(1)).onNode(assertArg(t -> assertThat(t)
                 .isNotNull()
-                .returns(recordItem.getTransactionRecord().getReceipt().getNodeId(), Node::getNodeId)
+                .returns(recordItem.getTransactionBody().getNodeDelete().getNodeId(), Node::getNodeId)
                 .returns(true, Node::isDeleted)));
     }
 }

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeUpdateTransactionHandlerTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/parser/record/transactionhandler/NodeUpdateTransactionHandlerTest.java
@@ -26,6 +26,7 @@ import com.hedera.mirror.common.domain.entity.Node;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.NodeUpdateTransactionBody;
 import com.hederahashgraph.api.proto.java.TransactionBody;
+import com.hederahashgraph.api.proto.java.TransactionID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -101,8 +102,36 @@ class NodeUpdateTransactionHandlerTest extends AbstractTransactionHandlerTest {
                 recordItem.getTransactionBody().getNodeUpdate().getAdminKey().toByteArray();
         verify(entityListener, times(1)).onNode(assertArg(t -> assertThat(t)
                 .isNotNull()
-                .returns(recordItem.getTransactionRecord().getReceipt().getNodeId(), Node::getNodeId)
+                .returns(recordItem.getTransactionBody().getNodeUpdate().getNodeId(), Node::getNodeId)
                 .returns(adminKey, Node::getAdminKey)
+                .returns(null, Node::getCreatedTimestamp)
+                .returns(recordItem.getConsensusTimestamp(), Node::getTimestampLower)
+                .returns(false, Node::isDeleted)));
+    }
+
+    @Test
+    void nodeUpdateMigration() {
+        entityProperties.getPersist().setNodes(true);
+
+        // given
+        var transactionId = TransactionID.newBuilder().setNonce(1);
+        var recordItem = recordItemBuilder
+                .nodeUpdate()
+                .record(b -> b.setTransactionID(transactionId))
+                .build();
+        var transaction = domainBuilder.transaction().get();
+
+        // when
+        transactionHandler.updateTransaction(transaction, recordItem);
+
+        // then
+        var adminKey =
+                recordItem.getTransactionBody().getNodeUpdate().getAdminKey().toByteArray();
+        verify(entityListener, times(1)).onNode(assertArg(t -> assertThat(t)
+                .isNotNull()
+                .returns(recordItem.getTransactionBody().getNodeUpdate().getNodeId(), Node::getNodeId)
+                .returns(adminKey, Node::getAdminKey)
+                .returns(recordItem.getConsensusTimestamp(), Node::getCreatedTimestamp)
                 .returns(recordItem.getConsensusTimestamp(), Node::getTimestampLower)
                 .returns(false, Node::isDeleted)));
     }
@@ -133,7 +162,7 @@ class NodeUpdateTransactionHandlerTest extends AbstractTransactionHandlerTest {
 
         verify(entityListener, times(1)).onNode(assertArg(t -> assertThat(t)
                 .isNotNull()
-                .returns(recordItem.getTransactionRecord().getReceipt().getNodeId(), Node::getNodeId)
+                .returns(recordItem.getTransactionBody().getNodeUpdate().getNodeId(), Node::getNodeId)
                 .returns(null, Node::getAdminKey)
                 .returns(recordItem.getConsensusTimestamp(), Node::getTimestampLower)
                 .returns(false, Node::isDeleted)));


### PR DESCRIPTION
**Description**:

Cherry pick of #10134 to `release/0.120`.

* Change node update to populate `createdTimestamp` if it's missing and an inner transaction. This is because nodes erroneously sent us updates instead of creates when migrating state.
* Fix `NodeUpdateTransaction` updating the wrong node
* Fix `NodeDeleteTransaction` deleting the wrong node

**Related issue(s)**:

Fixes #10133

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
