### PR TITLE
Support block hash operation in modularized web3

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
@@ -152,8 +152,10 @@ public class ContractCallContext {
     }
 
     public boolean useHistorical() {
-        return (callServiceParameters != null && callServiceParameters.getBlock() != BlockType.LATEST)
-                || recordFile != null; // Remove recordFile comparison after mono code deletion
+        if (callServiceParameters != null) {
+            return callServiceParameters.getBlock() != BlockType.LATEST;
+        }
+        return recordFile != null; // Remove recordFile comparison after mono code deletion
     }
 
     public void incrementContractActionsCounter() {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
@@ -153,7 +153,7 @@ public class ContractCallContext {
 
     public boolean useHistorical() {
         return (callServiceParameters != null && callServiceParameters.getBlock() != BlockType.LATEST)
-                || recordFile != null; // TODO: Remove recordFile comparison after mono code deletion
+                || recordFile != null; // Remove recordFile comparison after mono code deletion
     }
 
     public void incrementContractActionsCounter() {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
@@ -26,7 +26,9 @@ import com.hedera.mirror.web3.evm.contracts.execution.traceability.OpcodeTracer;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.OpcodeTracerOptions;
 import com.hedera.mirror.web3.evm.store.CachingStateFrame;
 import com.hedera.mirror.web3.evm.store.StackedStateFrames;
+import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.state.FileReadableKVState;
+import com.hedera.mirror.web3.viewmodel.BlockType;
 import java.util.ArrayList;
 import java.util.EmptyStackException;
 import java.util.List;
@@ -57,6 +59,10 @@ public class ContractCallContext {
 
     @Setter
     private List<Opcode> opcodes = new ArrayList<>();
+
+    @Setter
+    private CallServiceParameters callServiceParameters;
+
     /**
      * Record file which stores the block timestamp and other historical block details used for filtering of historical
      * data.
@@ -101,7 +107,6 @@ public class ContractCallContext {
     }
 
     public void reset() {
-        recordFile = null;
         stack = stackBase;
         file = Optional.empty();
     }
@@ -147,7 +152,8 @@ public class ContractCallContext {
     }
 
     public boolean useHistorical() {
-        return recordFile != null;
+        return (callServiceParameters != null && callServiceParameters.getBlock() != BlockType.LATEST)
+                || recordFile != null; // TODO: Remove recordFile comparison after mono code deletion
     }
 
     public void incrementContractActionsCounter() {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoader.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/pricing/RatesAndFeesLoader.java
@@ -62,14 +62,7 @@ public class RatesAndFeesLoader {
 
     public static final EntityId EXCHANGE_RATE_ENTITY_ID = EntityId.of(0L, 0L, 112L);
     public static final EntityId FEE_SCHEDULE_ENTITY_ID = EntityId.of(0L, 0L, 111L);
-
-    static final ExchangeRateSet DEFAULT_EXCHANGE_RATE_SET = ExchangeRateSet.newBuilder()
-            .setCurrentRate(ExchangeRate.newBuilder()
-                    .setCentEquiv(12)
-                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(4102444800L))
-                    .setHbarEquiv(1))
-            .build();
-    static final CurrentAndNextFeeSchedule DEFAULT_FEE_SCHEDULE = CurrentAndNextFeeSchedule.newBuilder()
+    public static final CurrentAndNextFeeSchedule DEFAULT_FEE_SCHEDULE = CurrentAndNextFeeSchedule.newBuilder()
             .setCurrentFeeSchedule(FeeSchedule.newBuilder()
                     .setExpiryTime(TimestampSeconds.newBuilder().setSeconds(4102444800L))
                     .addTransactionFeeSchedule(TransactionFeeSchedule.newBuilder()
@@ -263,6 +256,12 @@ public class RatesAndFeesLoader {
                                     .setServicedata(FeeComponents.newBuilder()
                                             .setGas(852000)
                                             .build()))))
+            .build();
+    static final ExchangeRateSet DEFAULT_EXCHANGE_RATE_SET = ExchangeRateSet.newBuilder()
+            .setCurrentRate(ExchangeRate.newBuilder()
+                    .setCentEquiv(12)
+                    .setExpirationTime(TimestampSeconds.newBuilder().setSeconds(4102444800L))
+                    .setHbarEquiv(1))
             .build();
     private static final CurrentAndNextFeeSchedule EMPTY_FEE_SCHEDULE = CurrentAndNextFeeSchedule.getDefaultInstance();
     private static final ExchangeRateSet EMPTY_EXCHANGE_RATE_SET = ExchangeRateSet.getDefaultInstance();

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -198,7 +198,7 @@ public class MirrorNodeEvmProperties implements EvmProperties {
     private int feesTokenTransferUsageMultiplier = 380;
 
     @Getter
-    private boolean modularizedServices = true;
+    private boolean modularizedServices;
 
     public boolean shouldAutoRenewAccounts() {
         return autoRenewTargetTypes.contains(EntityType.ACCOUNT);

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -25,6 +25,7 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_5
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static com.swirlds.state.lifecycle.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
 
+import com.google.common.collect.ImmutableSortedMap;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.web3.common.ContractCallContext;
@@ -66,7 +67,8 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "hedera.mirror.web3.evm")
 public class MirrorNodeEvmProperties implements EvmProperties {
 
-    public static final TreeMap<Long, SemanticVersion> DEFAULT_EVM_VERSION_MAP = new TreeMap<>(Map.of(0L, EVM_VERSION));
+    private static final NavigableMap<Long, SemanticVersion> DEFAULT_EVM_VERSION_MAP =
+            ImmutableSortedMap.of(0L, EVM_VERSION);
 
     @Getter
     private boolean allowTreasuryToOwnNfts = true;
@@ -196,7 +198,7 @@ public class MirrorNodeEvmProperties implements EvmProperties {
     private int feesTokenTransferUsageMultiplier = 380;
 
     @Getter
-    private boolean modularizedServices;
+    private boolean modularizedServices = true;
 
     public boolean shouldAutoRenewAccounts() {
         return autoRenewTargetTypes.contains(EntityType.ACCOUNT);
@@ -333,7 +335,7 @@ public class MirrorNodeEvmProperties implements EvmProperties {
     }
 
     private Map<String, String> buildTransactionProperties() {
-        final Map<String, String> mirrorNodeProperties = new HashMap<>(properties);
+        var mirrorNodeProperties = new HashMap<>(properties);
         mirrorNodeProperties.put("contracts.evm.version", "v" + evmVersion.major() + "." + evmVersion.minor());
         mirrorNodeProperties.put(
                 "ledger.id", Bytes.wrap(getNetwork().getLedgerId()).toHexString());

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
@@ -19,13 +19,16 @@ package com.hedera.mirror.web3.exception;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 import com.hedera.mirror.web3.evm.exception.EvmException;
+import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.io.Serial;
 import java.nio.charset.StandardCharsets;
+import lombok.Getter;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.tuweni.bytes.Bytes;
 
+@Getter
 @SuppressWarnings("java:S110")
 public class MirrorEvmTransactionException extends EvmException {
 
@@ -34,31 +37,31 @@ public class MirrorEvmTransactionException extends EvmException {
 
     private final String detail;
     private final String data;
+    private final HederaEvmTransactionProcessingResult result;
 
     public MirrorEvmTransactionException(
             final ResponseCodeEnum responseCode, final String detail, final String hexData) {
-        super(responseCode.name());
-        this.detail = detail;
-        this.data = hexData;
+        this(responseCode.name(), detail, hexData, null);
     }
 
     public MirrorEvmTransactionException(final String message, final String detail, final String hexData) {
+        this(message, detail, hexData, null);
+    }
+
+    public MirrorEvmTransactionException(
+            final String message,
+            final String detail,
+            final String hexData,
+            HederaEvmTransactionProcessingResult result) {
         super(message);
         this.detail = detail;
         this.data = hexData;
+        this.result = result;
     }
 
     public Bytes messageBytes() {
         final var message = getMessage();
         return Bytes.of(message.getBytes(StandardCharsets.UTF_8));
-    }
-
-    public String getDetail() {
-        return detail;
-    }
-
-    public String getData() {
-        return data;
     }
 
     @Override

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/exception/MirrorEvmTransactionException.java
@@ -37,7 +37,7 @@ public class MirrorEvmTransactionException extends EvmException {
 
     private final String detail;
     private final String data;
-    private final HederaEvmTransactionProcessingResult result;
+    private final transient HederaEvmTransactionProcessingResult result;
 
     public MirrorEvmTransactionException(
             final ResponseCodeEnum responseCode, final String detail, final String hexData) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/RecordFileRepository.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/repository/RecordFileRepository.java
@@ -25,6 +25,7 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_RECO
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.CACHE_NAME_RECORD_FILE_LATEST_INDEX;
 
 import com.hedera.mirror.common.domain.transaction.RecordFile;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
@@ -65,4 +66,7 @@ public interface RecordFileRepository extends PagingAndSortingRepository<RecordF
             put = @CachePut(cacheNames = CACHE_NAME, cacheManager = CACHE_MANAGER_RECORD_FILE_INDEX))
     @Query("select r from RecordFile r where r.consensusEnd >= ?1 order by r.consensusEnd asc limit 1")
     Optional<RecordFile> findByTimestamp(long timestamp);
+
+    @Query(value = "select * from record_file where index >= ?1 and index <= ?2 order by index asc", nativeQuery = true)
+    List<RecordFile> findByIndexRange(long startIndex, long endIndex);
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractCallService.java
@@ -100,17 +100,19 @@ public abstract class ContractCallService {
      */
     protected HederaEvmTransactionProcessingResult callContract(CallServiceParameters params, ContractCallContext ctx)
             throws MirrorEvmTransactionException {
-
         ctx.setCallServiceParameters(params);
+
         if (mirrorNodeEvmProperties.isModularizedServices() || params.getBlock() != BlockType.LATEST) {
             ctx.setRecordFile(recordFileService
                     .findByBlockType(params.getBlock())
                     .orElseThrow(BlockNumberNotFoundException::new));
         }
+
         // initializes the stack frame with the current state or historical state (if the call is historical)
         if (!mirrorNodeEvmProperties.isModularizedServices()) {
             ctx.initializeStackFrames(store.getStackedStateFrames());
         }
+
         return doProcessCall(params, params.getGas(), true);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractExecutionService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractExecutionService.java
@@ -75,9 +75,6 @@ public class ContractExecutionService extends ContractCallService {
                     result = estimateGas(params, ctx);
                 } else {
                     final var ethCallTxnResult = callContract(params, ctx);
-
-                    validateResult(ethCallTxnResult, params.getCallType());
-
                     result = Objects.requireNonNullElse(ethCallTxnResult.getOutput(), Bytes.EMPTY);
                 }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractExecutionService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/ContractExecutionService.java
@@ -72,9 +72,7 @@ public class ContractExecutionService extends ContractCallService {
 
                 Bytes result;
                 if (params.isEstimate()) {
-                    // eth_estimateGas initialization - historical timestamp is Optional.empty()
-                    ctx.initializeStackFrames(store.getStackedStateFrames());
-                    result = estimateGas(params);
+                    result = estimateGas(params, ctx);
                 } else {
                     final var ethCallTxnResult = callContract(params, ctx);
 
@@ -103,8 +101,8 @@ public class ContractExecutionService extends ContractCallService {
      * 2. Finally, if the first step is successful, a binary search is initiated. The lower bound of the search is the
      * gas used in the first step, while the upper bound is the inputted gas parameter.
      */
-    private Bytes estimateGas(final ContractExecutionParameters params) {
-        final var processingResult = doProcessCall(params, params.getGas(), true);
+    private Bytes estimateGas(final ContractExecutionParameters params, final ContractCallContext context) {
+        final var processingResult = callContract(params, context);
         validateResult(processingResult, CallType.ETH_ESTIMATE_GAS);
 
         final var gasUsedByInitialCall = processingResult.getGasUsed();

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutorFactory.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutorFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.service;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.node.app.workflows.standalone.TransactionExecutor;
+import com.hedera.node.app.workflows.standalone.TransactionExecutors;
+import com.swirlds.state.State;
+import jakarta.inject.Named;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+
+@Named
+@RequiredArgsConstructor
+public class TransactionExecutorFactory {
+
+    private final State mirrorNodeState;
+    private final MirrorNodeEvmProperties mirrorNodeEvmProperties;
+    private final Map<SemanticVersion, TransactionExecutor> transactionExecutors = new ConcurrentHashMap<>();
+
+    // Reuse TransactionExecutor across requests for the same EVM version
+    public TransactionExecutor get() {
+        var version = mirrorNodeEvmProperties.getSemanticEvmVersion();
+        return transactionExecutors.computeIfAbsent(version, this::create);
+    }
+
+    private TransactionExecutor create(SemanticVersion evmVersion) {
+        var properties = new HashMap<>(mirrorNodeEvmProperties.getTransactionProperties());
+        properties.put("contracts.evm.version", "v" + evmVersion.major() + "." + evmVersion.minor());
+        return TransactionExecutors.TRANSACTION_EXECUTORS.newExecutor(mirrorNodeState, properties, null);
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/ServicesRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/ServicesRegistryImpl.java
@@ -16,20 +16,25 @@
 
 package com.hedera.mirror.web3.state.components;
 
+import com.hedera.mirror.web3.state.singleton.SingletonState;
 import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.app.state.merkle.SchemaApplications;
 import com.swirlds.state.lifecycle.Service;
 import jakarta.annotation.Nonnull;
 import jakarta.inject.Named;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import lombok.RequiredArgsConstructor;
 
 @Named
+@RequiredArgsConstructor
 public class ServicesRegistryImpl implements ServicesRegistry {
 
     private final SortedSet<Registration> entries = new TreeSet<>();
+    private final Collection<SingletonState<?>> singletons;
 
     @Nonnull
     @Override
@@ -39,7 +44,7 @@ public class ServicesRegistryImpl implements ServicesRegistry {
 
     @Override
     public void register(@Nonnull Service service) {
-        final var registry = new SchemaRegistryImpl(new SchemaApplications());
+        final var registry = new SchemaRegistryImpl(singletons, new SchemaApplications());
         service.registerSchemas(registry);
         entries.add(new ServicesRegistryImpl.Registration(service, registry));
     }
@@ -48,7 +53,7 @@ public class ServicesRegistryImpl implements ServicesRegistry {
     @Override
     public ServicesRegistry subRegistryFor(@Nonnull String... serviceNames) {
         final var selections = Set.of(serviceNames);
-        final var subRegistry = new ServicesRegistryImpl();
+        final var subRegistry = new ServicesRegistryImpl(singletons);
         subRegistry.entries.addAll(entries.stream()
                 .filter(registration -> selections.contains(registration.serviceName()))
                 .toList());

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/BlockInfoSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/BlockInfoSingleton.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.BLOCK_INFO_STATE_KEY;
+
+import com.hedera.hapi.node.state.blockrecords.BlockInfo;
+import com.hedera.mirror.common.domain.transaction.RecordFile;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.repository.RecordFileRepository;
+import com.hedera.mirror.web3.state.Utils;
+import com.hedera.node.config.data.BlockRecordStreamConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import jakarta.inject.Named;
+import java.nio.ByteBuffer;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.commons.codec.binary.Hex;
+
+@Named
+@RequiredArgsConstructor
+public class BlockInfoSingleton implements SingletonState<BlockInfo> {
+
+    private static final int HASH_SIZE = 48;
+
+    private final MirrorNodeEvmProperties properties;
+    private final RecordFileRepository recordFileRepository;
+
+    @Override
+    public String getKey() {
+        return BLOCK_INFO_STATE_KEY;
+    }
+
+    @Override
+    public BlockInfo get() {
+        var recordFile = ContractCallContext.get().getRecordFile();
+        var blockHashes = getBlockHashes(recordFile);
+        var startTimestamp = Utils.convertToTimestamp(recordFile.getConsensusStart());
+        var endTimestamp = Utils.convertToTimestamp(recordFile.getConsensusEnd());
+
+        return BlockInfo.newBuilder()
+                .blockHashes(Bytes.wrap(blockHashes))
+                .consTimeOfLastHandledTxn(endTimestamp)
+                .firstConsTimeOfCurrentBlock(endTimestamp)
+                .firstConsTimeOfLastBlock(startTimestamp)
+                .lastBlockNumber(recordFile.getIndex())
+                .migrationRecordsStreamed(true)
+                .build();
+    }
+
+    /**
+     * Loads the last 256 block hashes from the database into a single byte array. This is inefficient to do for every
+     * request when only a few requests may have a BLOCKHASH operation. This method is temporary until the EVM library
+     * supports custom implementations for operations that don't need to use the BlockInfo singleton.
+     */
+    @SneakyThrows
+    private byte[] getBlockHashes(RecordFile recordFile) {
+        if (recordFile.getIndex() == 0) {
+            return Hex.decodeHex(recordFile.getHash());
+        }
+
+        var config = properties.getVersionedConfiguration().getConfigData(BlockRecordStreamConfig.class);
+        int blockHashCount = config.numOfBlockHashesInState();
+        long endIndex = recordFile.getIndex() - 1; // Optimization: Don't reload the record file in context
+        long startIndex = Math.max(0L, endIndex - blockHashCount + 1);
+
+        var blocks = recordFileRepository.findByIndexRange(startIndex, endIndex);
+        blocks.add(recordFile);
+        var buffer = ByteBuffer.allocate(blocks.size() * HASH_SIZE);
+
+        for (var block : blocks) {
+            var hash = Hex.decodeHex(block.getHash());
+            buffer.put(hash);
+        }
+
+        return buffer.array();
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/BlockInfoSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/BlockInfoSingleton.java
@@ -76,7 +76,7 @@ public class BlockInfoSingleton implements SingletonState<BlockInfo> {
 
         var config = properties.getVersionedConfiguration().getConfigData(BlockRecordStreamConfig.class);
         int blockHashCount = config.numOfBlockHashesInState();
-        long endIndex = recordFile.getIndex() - 1; // Optimization: Don't reload the record file in context
+        long endIndex = recordFile.getIndex() - 1; // Optimization: Don't reload the record file from the context
         long startIndex = Math.max(0L, endIndex - blockHashCount + 1);
 
         var blocks = recordFileRepository.findByIndexRange(startIndex, endIndex);

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/DefaultSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/DefaultSingleton.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state.singleton;
+
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DefaultSingleton extends AtomicReference<Object> implements SingletonState<Object> {
+
+    private final String key;
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/RunningHashesSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/RunningHashesSingleton.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.RUNNING_HASHES_STATE_KEY;
+
+import com.hedera.hapi.node.state.blockrecords.RunningHashes;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import jakarta.inject.Named;
+import lombok.RequiredArgsConstructor;
+
+@Named
+@RequiredArgsConstructor
+public class RunningHashesSingleton implements SingletonState<RunningHashes> {
+
+    @Override
+    public String getKey() {
+        return RUNNING_HASHES_STATE_KEY;
+    }
+
+    @Override
+    public RunningHashes get() {
+        var recordFile = ContractCallContext.get().getRecordFile();
+        return RunningHashes.newBuilder()
+                .runningHash(Bytes.fromHex(recordFile.getHash()))
+                .build();
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/SingletonState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/SingletonState.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state.singleton;
+
+import java.util.function.Supplier;
+
+public interface SingletonState<T> extends Supplier<T> {
+
+    String getKey();
+
+    default void set(T value) {
+        // Do nothing since our singletons are either immutable static data or dynamically retrieved from the db.
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/common/ContractCallContextTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/common/ContractCallContextTest.java
@@ -18,7 +18,6 @@ package com.hedera.mirror.web3.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.evm.store.StackedStateFrames;
@@ -30,14 +29,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ContextExtension.class)
 class ContractCallContextTest {
 
-    private final StackedStateFrames stackedStateFrames;
-
-    private final DomainBuilder domainBuilder = new DomainBuilder();
-
-    public ContractCallContextTest() {
-        stackedStateFrames = new StackedStateFrames(List.of(
-                new BareDatabaseAccessor<Object, Character>() {}, new BareDatabaseAccessor<Object, String>() {}));
-    }
+    private final StackedStateFrames stackedStateFrames = new StackedStateFrames(
+            List.of(new BareDatabaseAccessor<Object, Character>() {}, new BareDatabaseAccessor<Object, String>() {}));
 
     @Test
     void testGet() {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/common/ContractCallContextTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/common/ContractCallContextTest.java
@@ -46,17 +46,6 @@ class ContractCallContextTest {
     }
 
     @Test
-    void testRecordFileIsClearedOnReset() {
-        var context = ContractCallContext.get();
-        final var recordFile = domainBuilder.recordFile().get();
-        context.setRecordFile(recordFile);
-        assertThat(context.getRecordFile()).isEqualTo(recordFile);
-
-        context.reset();
-        assertThat(context.getRecordFile()).isNull();
-    }
-
-    @Test
     void testReset() {
         var context = ContractCallContext.get();
         context.setRecordFile(RecordFile.builder().consensusEnd(123L).build());
@@ -65,7 +54,6 @@ class ContractCallContextTest {
         context.setStack(stackedStateFrames.top());
 
         context.reset();
-        assertThat(context.getRecordFile()).isNull();
         assertThat(context.getStack()).isEqualTo(context.getStackBase());
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/RecordFileRepositoryTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/repository/RecordFileRepositoryTest.java
@@ -48,16 +48,7 @@ class RecordFileRepositoryTest extends Web3IntegrationTest {
     }
 
     @Test
-    void findFileHashByIndex() {
-        final var file = domainBuilder.recordFile().persist();
-
-        assertThat(recordFileRepository.findByIndex(file.getIndex()))
-                .map(RecordFile::getHash)
-                .hasValue(file.getHash());
-    }
-
-    @Test
-    void findLatestFile() {
+    void findLatest() {
         domainBuilder.recordFile().persist();
         var latest = domainBuilder.recordFile().persist();
 
@@ -65,7 +56,7 @@ class RecordFileRepositoryTest extends Web3IntegrationTest {
     }
 
     @Test
-    void findRecordFileByIndex() {
+    void findByIndex() {
         domainBuilder.recordFile().persist();
         var latest = domainBuilder.recordFile().persist();
         long blockNumber = latest.getIndex();
@@ -76,13 +67,23 @@ class RecordFileRepositoryTest extends Web3IntegrationTest {
     }
 
     @Test
-    void findRecordFileByIndexNotExists() {
+    void findByIndexNotExists() {
         long nonExistentBlockNumber = 1L;
         assertThat(recordFileRepository.findByIndex(nonExistentBlockNumber)).isEmpty();
     }
 
     @Test
-    void findRecordFileByTimestamp() {
+    void findByIndexRange() {
+        domainBuilder.recordFile().persist();
+        var recordFile2 = domainBuilder.recordFile().persist();
+        var recordFile3 = domainBuilder.recordFile().persist();
+        domainBuilder.recordFile().persist();
+        assertThat(recordFileRepository.findByIndexRange(recordFile2.getIndex(), recordFile3.getIndex()))
+                .containsExactly(recordFile2, recordFile3);
+    }
+
+    @Test
+    void findByTimestamp() {
         var timestamp = domainBuilder.timestamp();
         var recordFile = domainBuilder
                 .recordFile()

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.web3.service;
 
+import static com.hedera.mirror.web3.evm.pricing.RatesAndFeesLoader.DEFAULT_FEE_SCHEDULE;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.ESTIMATE_GAS_ERROR_MESSAGE;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.TRANSACTION_GAS_LIMIT;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.isWithinExpectedGasRange;
@@ -127,6 +128,10 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                 .customize(ab -> ab.id(new AccountBalance.Id(
                                 treasuryEntity.getCreatedTimestamp(), treasuryEntity.toEntityId()))
                         .balance(treasuryEntity.getBalance()))
+                .persist();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.entityId(EntityId.of(111L)).fileData(DEFAULT_FEE_SCHEDULE.toByteArray()))
                 .persist();
         testWeb3jService.reset();
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -33,9 +33,9 @@ import com.hedera.mirror.common.domain.token.TokenFreezeStatusEnum;
 import com.hedera.mirror.common.domain.token.TokenKycStatusEnum;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.web3.Web3IntegrationTest;
-import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.evm.utils.EvmTokenUtils;
+import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.service.model.CallServiceParameters.CallType;
 import com.hedera.mirror.web3.service.model.ContractDebugParameters;
 import com.hedera.mirror.web3.service.model.ContractExecutionParameters;
@@ -90,8 +90,10 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     @Resource
     protected State state;
 
-    protected RecordFile genesisRecordFile;
+    @Resource
+    protected ContractExecutionService contractExecutionService;
 
+    protected RecordFile genesisRecordFile;
     protected Entity treasuryEntity;
 
     public static Key getKeyWithDelegatableContractId(final Contract contract) {
@@ -112,8 +114,11 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
 
     @BeforeEach
     protected void setup() {
-        genesisRecordFile =
-                domainBuilder.recordFile().customize(f -> f.index(0L)).persist();
+        // Change this to not be epoch once services fixes config updates for non-genesis flow
+        genesisRecordFile = domainBuilder
+                .recordFile()
+                .customize(f -> f.consensusEnd(0L).consensusStart(0L).index(0L))
+                .persist();
         treasuryEntity = domainBuilder
                 .entity()
                 .customize(e -> e.id(2L).num(2L).balance(5000000000000000000L))
@@ -141,17 +146,19 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
         testWeb3jService.reset();
     }
 
-    @SuppressWarnings("try")
     protected long gasUsedAfterExecution(final ContractExecutionParameters serviceParameters) {
-        return ContractCallContext.run(ctx -> {
-            ctx.initializeStackFrames(store.getStackedStateFrames());
-            long result = processor
-                    .execute(serviceParameters, serviceParameters.getGas())
-                    .getGasUsed();
+        try {
+            return contractExecutionService.callContract(serviceParameters).getGasUsed();
+        } catch (MirrorEvmTransactionException e) {
+            var result = e.getResult();
 
-            assertThat(store.getStackedStateFrames().height()).isEqualTo(1);
-            return result;
-        });
+            // Some tests expect to fail but still want to capture the gas used
+            if (result != null) {
+                return result.getGasUsed();
+            }
+
+            throw e;
+        }
     }
 
     protected void verifyEthCallAndEstimateGas(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallAddressThisTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallAddressThisTest.java
@@ -20,11 +20,10 @@ import static com.hedera.mirror.common.domain.entity.EntityType.CONTRACT;
 import static com.hedera.mirror.common.util.DomainUtils.toEvmAddress;
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdFromEvmAddress;
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_ESTIMATE_GAS;
+import static com.hedera.mirror.web3.utils.ContractCallTestUtil.ESTIMATE_GAS_ERROR_MESSAGE;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.isWithinExpectedGasRange;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.longValueOf;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -34,18 +33,13 @@ import com.hedera.mirror.web3.viewmodel.BlockType;
 import com.hedera.mirror.web3.viewmodel.ContractCallRequest;
 import com.hedera.mirror.web3.web3j.generated.TestAddressThis;
 import com.hedera.mirror.web3.web3j.generated.TestNestedAddressThis;
-import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionProcessingResult;
 import jakarta.annotation.Resource;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.SneakyThrows;
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
@@ -64,9 +58,6 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
     @Resource
     private ObjectMapper objectMapper;
 
-    @MockitoSpyBean
-    private ContractExecutionService contractExecutionService;
-
     @SneakyThrows
     private ResultActions contractCall(ContractCallRequest request) {
         return mockMvc.perform(post(CALL_URI)
@@ -81,8 +72,9 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
         final var serviceParameters = testWeb3jService.serviceParametersForTopLevelContractCreate(
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, Address.ZERO);
         final long actualGas = 57764L;
-        assertThat(isWithinExpectedGasRange(
-                        longValueOf.applyAsLong(contractCallService.processCall(serviceParameters)), actualGas))
+        long expectedGas = longValueOf.applyAsLong(contractCallService.processCall(serviceParameters));
+        assertThat(isWithinExpectedGasRange(expectedGas, actualGas))
+                .withFailMessage(ESTIMATE_GAS_ERROR_MESSAGE, expectedGas, actualGas)
                 .isTrue();
     }
 
@@ -100,22 +92,16 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
                 testWeb3jService.deployWithoutPersistWithValue(TestAddressThis::deploy, BigInteger.valueOf(1000));
         addressThisContractPersist(
                 testWeb3jService.getContractRuntime(), Address.fromHexString(contract.getContractAddress()));
-        final List<Bytes> capturedOutputs = new ArrayList<>();
-        doAnswer(invocation -> {
-                    HederaEvmTransactionProcessingResult result =
-                            (HederaEvmTransactionProcessingResult) invocation.callRealMethod();
-                    capturedOutputs.add(result.getOutput()); // Capture the result
-                    return result;
-                })
-                .when(contractExecutionService)
-                .callContract(any(), any());
 
         // When
-        final var result = contract.call_getAddressThis().send();
+        var callFunction = contract.call_getAddressThis();
+        final var result = callFunction.send();
+        var parameters = getContractExecutionParameters(callFunction, contract);
+        var output = contractExecutionService.callContract(parameters).getOutput();
 
         // Then
         final var successfulResponse = "0x" + StringUtils.leftPad(result.substring(2), 64, '0');
-        assertThat(successfulResponse).isEqualTo(capturedOutputs.getFirst().toHexString());
+        assertThat(successfulResponse).isEqualTo(output.toHexString());
     }
 
     @Test
@@ -161,8 +147,9 @@ class ContractCallAddressThisTest extends AbstractContractCallServiceTest {
         final var serviceParameters = testWeb3jService.serviceParametersForTopLevelContractCreate(
                 contract.getContractBinary(), ETH_ESTIMATE_GAS, Address.ZERO);
         final long actualGas = 95401L;
-        assertThat(isWithinExpectedGasRange(
-                        longValueOf.applyAsLong(contractCallService.processCall(serviceParameters)), actualGas))
+        long expectedGas = longValueOf.applyAsLong(contractCallService.processCall(serviceParameters));
+        assertThat(isWithinExpectedGasRange(expectedGas, actualGas))
+                .withFailMessage(ESTIMATE_GAS_ERROR_MESSAGE, expectedGas, actualGas)
                 .isTrue();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesTest.java
@@ -166,32 +166,34 @@ class ContractCallEvmCodesTest extends AbstractContractCallServiceTest {
     @Test
     void getBlockHashReturnsCorrectHash() throws Exception {
         testWeb3jService.setUseContractCallDeploy(true);
-        domainBuilder.recordFile().persist(); // Set a latest block - needed for the block hash operation
+        domainBuilder.recordFile().customize(r -> r.index(1L)).persist();
+        var latest = domainBuilder.recordFile().customize(r -> r.index(2L)).persist();
         final var contract = testWeb3jService.deploy(EvmCodes::deploy);
-        var result = contract.call_getBlockHash(BigInteger.valueOf(genesisRecordFile.getIndex()))
+        var result = contract.call_getBlockHash(BigInteger.valueOf(latest.getIndex()))
                 .send();
-        var expectedResult =
-                ByteString.fromHex(genesisRecordFile.getHash().substring(0, 64)).toByteArray();
+        var expectedResult = Hex.decode(latest.getHash().substring(0, 64));
         assertThat(result).isEqualTo(expectedResult);
     }
 
     @Test
     void getGenesisBlockHashReturnsCorrectBlock() throws Exception {
         testWeb3jService.setUseContractCallDeploy(true);
-        domainBuilder.recordFile().persist(); // Set a latest block - needed for the block hash operation
+        domainBuilder.recordFile().customize(r -> r.index(1L)).persist();
+        domainBuilder.recordFile().customize(r -> r.index(2L)).persist();
+
         final var contract = testWeb3jService.deploy(EvmCodes::deploy);
         var result = contract.call_getBlockHash(BigInteger.ZERO).send();
-        var expectedResult =
-                ByteString.fromHex(genesisRecordFile.getHash().substring(0, 64)).toByteArray();
+
+        var expectedResult = Hex.decode(genesisRecordFile.getHash().substring(0, 64));
         assertThat(result).isEqualTo(expectedResult);
     }
 
     @Test
     void getLatestBlockHashIsNotEmpty() throws Exception {
-        domainBuilder.recordFile().persist();
+        domainBuilder.recordFile().customize(r -> r.index(1L)).persist();
         final var contract = testWeb3jService.deploy(EvmCodes::deploy);
         var result = contract.call_getLatestBlockHash().send();
-        var expectedResult = ByteString.fromHex((EMPTY_BLOCK_HASH)).toByteArray();
+        var expectedResult = Hex.decode(EMPTY_BLOCK_HASH);
         assertThat(result).isNotEqualTo(expectedResult);
     }
 
@@ -200,7 +202,7 @@ class ContractCallEvmCodesTest extends AbstractContractCallServiceTest {
         final var contract = testWeb3jService.deploy(EvmCodes::deploy);
         var result =
                 contract.call_getBlockHash(BigInteger.valueOf(Long.MAX_VALUE)).send();
-        var expectedResult = ByteString.fromHex((EMPTY_BLOCK_HASH)).toByteArray();
+        var expectedResult = Hex.decode(EMPTY_BLOCK_HASH);
         assertThat(result).isEqualTo(expectedResult);
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallNativePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallNativePrecompileTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.web3.service;
 
+import static com.hedera.mirror.web3.evm.pricing.RatesAndFeesLoader.DEFAULT_FEE_SCHEDULE;
 import static com.hedera.mirror.web3.service.AbstractContractCallServiceTest.EXCHANGE_RATES_SET;
 import static com.hedera.mirror.web3.service.ContractExecutionService.GAS_USED_METRIC;
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType;
@@ -48,6 +49,10 @@ class ContractCallNativePrecompileTest extends Web3IntegrationTest {
         domainBuilder
                 .fileData()
                 .customize(f -> f.entityId(EntityId.of(112L)).fileData(EXCHANGE_RATES_SET))
+                .persist();
+        domainBuilder
+                .fileData()
+                .customize(f -> f.entityId(EntityId.of(111L)).fileData(DEFAULT_FEE_SCHEDULE.toByteArray()))
                 .persist();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -63,7 +63,6 @@ import com.hedera.services.store.models.Id;
 import com.hedera.services.utils.EntityIdUtils;
 import io.github.bucket4j.Bucket;
 import jakarta.annotation.PostConstruct;
-import jakarta.annotation.Resource;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -108,9 +107,6 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
 
     @Autowired
     private TransactionExecutionService transactionExecutionService;
-
-    @Resource
-    private ContractExecutionService contractExecutionService;
 
     private static Stream<BlockType> provideBlockTypes() {
         return Stream.of(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/TransactionExecutionServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/TransactionExecutionServiceTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.ResponseCodeEnum;
@@ -31,11 +30,11 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.node.transaction.TransactionReceipt;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.evm.contracts.execution.traceability.MirrorOperationTracer;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.OpcodeTracer;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.OpcodeTracerOptions;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
-import com.hedera.mirror.web3.service.TransactionExecutionService.ExecutorFactory;
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.service.model.CallServiceParameters.CallType;
 import com.hedera.mirror.web3.service.model.ContractExecutionParameters;
@@ -65,7 +64,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -76,16 +74,16 @@ class TransactionExecutionServiceTest {
     private State mirrorNodeState;
 
     @Mock
-    private MirrorNodeEvmProperties mirrorNodeEvmProperties;
+    private OpcodeTracer opcodeTracer;
 
     @Mock
-    private OpcodeTracer opcodeTracer;
+    private MirrorOperationTracer mirrorOperationTracer;
 
     @Mock
     private TransactionExecutor transactionExecutor;
 
     @Mock
-    private ContractCallContext contractCallContext;
+    private TransactionExecutorFactory transactionExecutorFactory;
 
     @Mock
     private MeterProvider<Counter> gasUsedCounter;
@@ -100,8 +98,13 @@ class TransactionExecutionServiceTest {
 
     @BeforeEach
     void setUp() {
-        transactionExecutionService =
-                new TransactionExecutionService(mirrorNodeState, mirrorNodeEvmProperties, opcodeTracer);
+        transactionExecutionService = new TransactionExecutionService(
+                mirrorNodeState,
+                new MirrorNodeEvmProperties(),
+                opcodeTracer,
+                mirrorOperationTracer,
+                transactionExecutorFactory);
+        when(transactionExecutorFactory.get()).thenReturn(transactionExecutor);
     }
 
     @ParameterizedTest
@@ -113,29 +116,20 @@ class TransactionExecutionServiceTest {
             })
     void testExecuteContractCallSuccess(String senderAddressHex) {
         // Given
-        try (MockedStatic<ExecutorFactory> executorFactoryMock = mockStatic(ExecutorFactory.class);
-                MockedStatic<ContractCallContext> contractCallContextMock = mockStatic(ContractCallContext.class)) {
-
-            // Set up mock behaviors for ExecutorFactory
-            executorFactoryMock
-                    .when(() -> ExecutorFactory.newExecutor(any(), any(), any()))
-                    .thenReturn(transactionExecutor);
-
-            // Set up mock behaviors for ContractCallContext
-            contractCallContextMock.when(ContractCallContext::get).thenReturn(contractCallContext);
-            when(contractCallContext.getOpcodeTracerOptions()).thenReturn(new OpcodeTracerOptions());
+        ContractCallContext.run(context -> {
+            context.setOpcodeTracerOptions(new OpcodeTracerOptions());
 
             // Mock the SingleTransactionRecord and TransactionRecord
-            SingleTransactionRecord singleTransactionRecord = mock(SingleTransactionRecord.class);
-            TransactionRecord transactionRecord = mock(TransactionRecord.class);
-            TransactionReceipt transactionReceipt = mock(TransactionReceipt.class);
+            var singleTransactionRecord = mock(SingleTransactionRecord.class);
+            var transactionRecord = mock(TransactionRecord.class);
+            var transactionReceipt = mock(TransactionReceipt.class);
 
             // Simulate SUCCESS status in the receipt
             when(transactionReceipt.status()).thenReturn(ResponseCodeEnum.SUCCESS);
             when(transactionRecord.receiptOrThrow()).thenReturn(transactionReceipt);
             when(singleTransactionRecord.transactionRecord()).thenReturn(transactionRecord);
 
-            ContractFunctionResult contractFunctionResult = mock(ContractFunctionResult.class);
+            var contractFunctionResult = mock(ContractFunctionResult.class);
             when(contractFunctionResult.gasUsed()).thenReturn(DEFAULT_GAS);
             when(contractFunctionResult.contractCallResult()).thenReturn(Bytes.EMPTY);
 
@@ -156,8 +150,7 @@ class TransactionExecutionServiceTest {
                             any(TransactionBody.class), any(Instant.class), any(OperationTracer[].class)))
                     .thenReturn(List.of(singleTransactionRecord));
 
-            CallServiceParameters callServiceParameters =
-                    buildServiceParams(false, org.apache.tuweni.bytes.Bytes.EMPTY, senderAddress);
+            var callServiceParameters = buildServiceParams(false, org.apache.tuweni.bytes.Bytes.EMPTY, senderAddress);
 
             // When
             var result = transactionExecutionService.execute(callServiceParameters, DEFAULT_GAS, gasUsedCounter);
@@ -166,7 +159,8 @@ class TransactionExecutionServiceTest {
             assertThat(result).isNotNull();
             assertThat(result.getGasUsed()).isEqualTo(DEFAULT_GAS);
             assertThat(result.getRevertReason()).isNotPresent();
-        }
+            return null;
+        });
     }
 
     @ParameterizedTest
@@ -175,30 +169,21 @@ class TransactionExecutionServiceTest {
         "INVALID_TOKEN_ID,CONTRACT_REVERT_EXECUTED,''",
         "0x,INVALID_TOKEN_ID,''"
     })
+    @SuppressWarnings("unused")
     void testExecuteContractCallFailureWithErrorMessage(
             final String errorMessage, final ResponseCodeEnum responseCode, final String detail) {
         // Given
-        try (MockedStatic<ExecutorFactory> executorFactoryMock = mockStatic(ExecutorFactory.class);
-                MockedStatic<ContractCallContext> contractCallContextMock = mockStatic(ContractCallContext.class)) {
-
-            // Set up mock behaviors for ExecutorFactory
-            executorFactoryMock
-                    .when(() -> ExecutorFactory.newExecutor(any(), any(), any()))
-                    .thenReturn(transactionExecutor);
-
-            // Set up mock behaviors for ContractCallContext
-            contractCallContextMock.when(ContractCallContext::get).thenReturn(contractCallContext);
-
+        ContractCallContext.run(context -> {
             // Mock the SingleTransactionRecord and TransactionRecord
-            SingleTransactionRecord singleTransactionRecord = mock(SingleTransactionRecord.class);
-            TransactionRecord transactionRecord = mock(TransactionRecord.class);
-            TransactionReceipt transactionReceipt = mock(TransactionReceipt.class);
+            var singleTransactionRecord = mock(SingleTransactionRecord.class);
+            var transactionRecord = mock(TransactionRecord.class);
+            var transactionReceipt = mock(TransactionReceipt.class);
 
             when(transactionReceipt.status()).thenReturn(responseCode);
             when(transactionRecord.receiptOrThrow()).thenReturn(transactionReceipt);
             when(singleTransactionRecord.transactionRecord()).thenReturn(transactionRecord);
 
-            ContractFunctionResult contractFunctionResult = mock(ContractFunctionResult.class);
+            var contractFunctionResult = mock(ContractFunctionResult.class);
             when(transactionRecord.contractCallResult()).thenReturn(contractFunctionResult);
             when(contractFunctionResult.errorMessage()).thenReturn(errorMessage);
             when(gasUsedCounter.withTags(anyString(), anyString(), anyString(), anyString()))
@@ -209,8 +194,7 @@ class TransactionExecutionServiceTest {
                             any(TransactionBody.class), any(Instant.class), any(OperationTracer[].class)))
                     .thenReturn(List.of(singleTransactionRecord));
 
-            CallServiceParameters callServiceParameters =
-                    buildServiceParams(false, org.apache.tuweni.bytes.Bytes.EMPTY, Address.ZERO);
+            var callServiceParameters = buildServiceParams(false, org.apache.tuweni.bytes.Bytes.EMPTY, Address.ZERO);
 
             // Then
             assertThatThrownBy(() ->
@@ -218,27 +202,19 @@ class TransactionExecutionServiceTest {
                     .isInstanceOf(MirrorEvmTransactionException.class)
                     .hasMessageContaining(responseCode.name())
                     .hasFieldOrPropertyWithValue("detail", detail);
-        }
+            return null;
+        });
     }
 
+    @SuppressWarnings("unused")
     @Test
     void testExecuteContractCallFailureOnPreChecks() {
         // Given
-        try (MockedStatic<ExecutorFactory> executorFactoryMock = mockStatic(ExecutorFactory.class);
-                MockedStatic<ContractCallContext> contractCallContextMock = mockStatic(ContractCallContext.class)) {
-
-            // Set up mock behaviors for ExecutorFactory
-            executorFactoryMock
-                    .when(() -> ExecutorFactory.newExecutor(any(), any(), any()))
-                    .thenReturn(transactionExecutor);
-
-            // Set up mock behaviors for ContractCallContext
-            contractCallContextMock.when(ContractCallContext::get).thenReturn(contractCallContext);
-
+        ContractCallContext.run(context -> {
             // Mock the SingleTransactionRecord and TransactionRecord
-            SingleTransactionRecord singleTransactionRecord = mock(SingleTransactionRecord.class);
-            TransactionRecord transactionRecord = mock(TransactionRecord.class);
-            TransactionReceipt transactionReceipt = mock(TransactionReceipt.class);
+            var singleTransactionRecord = mock(SingleTransactionRecord.class);
+            var transactionRecord = mock(TransactionRecord.class);
+            var transactionReceipt = mock(TransactionReceipt.class);
 
             when(transactionRecord.receiptOrThrow()).thenReturn(transactionReceipt);
             when(transactionReceipt.status()).thenReturn(ResponseCodeEnum.INVALID_ACCOUNT_ID);
@@ -249,15 +225,15 @@ class TransactionExecutionServiceTest {
                             any(TransactionBody.class), any(Instant.class), any(OperationTracer[].class)))
                     .thenReturn(List.of(singleTransactionRecord));
 
-            CallServiceParameters callServiceParameters =
-                    buildServiceParams(false, org.apache.tuweni.bytes.Bytes.EMPTY, Address.ZERO);
+            var callServiceParameters = buildServiceParams(false, org.apache.tuweni.bytes.Bytes.EMPTY, Address.ZERO);
 
             // Then
             assertThatThrownBy(() ->
                             transactionExecutionService.execute(callServiceParameters, DEFAULT_GAS, gasUsedCounter))
                     .isInstanceOf(MirrorEvmTransactionException.class)
                     .hasMessageContaining(ResponseCodeEnum.INVALID_ACCOUNT_ID.name());
-        }
+            return null;
+        });
     }
 
     // NestedCalls.BINARY
@@ -265,28 +241,19 @@ class TransactionExecutionServiceTest {
     @MethodSource("provideCallData")
     void testExecuteContractCreateSuccess(org.apache.tuweni.bytes.Bytes callData) {
         // Given
-        try (MockedStatic<ExecutorFactory> executorFactoryMock = mockStatic(ExecutorFactory.class);
-                MockedStatic<ContractCallContext> contractCallContextMock = mockStatic(ContractCallContext.class)) {
-
-            // Set up mock behaviors for ExecutorFactory
-            executorFactoryMock
-                    .when(() -> ExecutorFactory.newExecutor(any(), any(), any()))
-                    .thenReturn(transactionExecutor);
-
-            // Set up mock behaviors for ContractCallContext
-            contractCallContextMock.when(ContractCallContext::get).thenReturn(contractCallContext);
-            when(contractCallContext.getOpcodeTracerOptions()).thenReturn(new OpcodeTracerOptions());
+        ContractCallContext.run(context -> {
+            context.setOpcodeTracerOptions(new OpcodeTracerOptions());
 
             // Mock the SingleTransactionRecord and TransactionRecord
-            SingleTransactionRecord singleTransactionRecord = mock(SingleTransactionRecord.class);
-            TransactionRecord transactionRecord = mock(TransactionRecord.class);
-            TransactionReceipt transactionReceipt = mock(TransactionReceipt.class);
+            var singleTransactionRecord = mock(SingleTransactionRecord.class);
+            var transactionRecord = mock(TransactionRecord.class);
+            var transactionReceipt = mock(TransactionReceipt.class);
 
             when(transactionReceipt.status()).thenReturn(ResponseCodeEnum.SUCCESS);
             when(transactionRecord.receiptOrThrow()).thenReturn(transactionReceipt);
             when(singleTransactionRecord.transactionRecord()).thenReturn(transactionRecord);
 
-            ContractFunctionResult contractFunctionResult = mock(ContractFunctionResult.class);
+            var contractFunctionResult = mock(ContractFunctionResult.class);
             when(contractFunctionResult.gasUsed()).thenReturn(DEFAULT_GAS);
             when(contractFunctionResult.contractCallResult()).thenReturn(Bytes.EMPTY);
 
@@ -298,7 +265,7 @@ class TransactionExecutionServiceTest {
                             any(TransactionBody.class), any(Instant.class), any(OperationTracer[].class)))
                     .thenReturn(List.of(singleTransactionRecord));
 
-            CallServiceParameters callServiceParameters = buildServiceParams(true, callData, Address.ZERO);
+            var callServiceParameters = buildServiceParams(true, callData, Address.ZERO);
 
             // When
             var result = transactionExecutionService.execute(callServiceParameters, DEFAULT_GAS, gasUsedCounter);
@@ -307,7 +274,8 @@ class TransactionExecutionServiceTest {
             assertThat(result).isNotNull();
             assertThat(result.getGasUsed()).isEqualTo(DEFAULT_GAS);
             assertThat(result.getRevertReason()).isNotPresent();
-        }
+            return null;
+        });
     }
 
     private CallServiceParameters buildServiceParams(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/MirrorNodeStateIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/MirrorNodeStateIntegrationTest.java
@@ -20,6 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.mirror.web3.Web3IntegrationTest;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.state.singleton.BlockInfoSingleton;
+import com.hedera.mirror.web3.state.singleton.DefaultSingleton;
+import com.hedera.mirror.web3.state.singleton.RunningHashesSingleton;
 import com.hedera.node.app.fees.FeeService;
 import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.records.BlockRecordService;
@@ -88,8 +91,8 @@ public class MirrorNodeStateIntegrationTest extends Web3IntegrationTest {
 
         // BlockRecordService
         Map<String, Class<?>> blockRecordServiceDataSources = Map.of(
-                "BLOCKS", AtomicReference.class,
-                "RUNNING_HASHES", AtomicReference.class);
+                "BLOCKS", BlockInfoSingleton.class,
+                "RUNNING_HASHES", RunningHashesSingleton.class);
         verifyServiceDataSources(states, BlockRecordService.NAME, blockRecordServiceDataSources);
 
         // FileService
@@ -98,12 +101,12 @@ public class MirrorNodeStateIntegrationTest extends Web3IntegrationTest {
 
         // CongestionThrottleService
         Map<String, Class<?>> congestionThrottleServiceDataSources = Map.of(
-                "THROTTLE_USAGE_SNAPSHOTS", AtomicReference.class,
-                "CONGESTION_LEVEL_STARTS", AtomicReference.class);
+                "THROTTLE_USAGE_SNAPSHOTS", DefaultSingleton.class,
+                "CONGESTION_LEVEL_STARTS", DefaultSingleton.class);
         verifyServiceDataSources(states, CongestionThrottleService.NAME, congestionThrottleServiceDataSources);
 
         // FeeService
-        Map<String, Class<?>> feeServiceDataSources = Map.of("MIDNIGHT_RATES", AtomicReference.class);
+        Map<String, Class<?>> feeServiceDataSources = Map.of("MIDNIGHT_RATES", DefaultSingleton.class);
         verifyServiceDataSources(states, FeeService.NAME, feeServiceDataSources);
 
         // ContractService
@@ -117,7 +120,7 @@ public class MirrorNodeStateIntegrationTest extends Web3IntegrationTest {
         verifyServiceDataSources(states, RecordCacheService.NAME, recordCacheServiceDataSources);
 
         // EntityIdService
-        Map<String, Class<?>> entityIdServiceDataSources = Map.of("ENTITY_ID", AtomicReference.class);
+        Map<String, Class<?>> entityIdServiceDataSources = Map.of("ENTITY_ID", DefaultSingleton.class);
         verifyServiceDataSources(states, EntityIdService.NAME, entityIdServiceDataSources);
 
         // TokenService

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
@@ -41,6 +41,7 @@ import com.swirlds.state.lifecycle.info.NetworkInfo;
 import com.swirlds.state.spi.ReadableStates;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.atomic.AtomicLong;
@@ -80,15 +81,13 @@ class SchemaRegistryImplTest {
     @Mock
     private Codec<String> mockCodec;
 
-    private Configuration appConfig;
-    private Configuration platformConfig;
+    private Configuration config;
     private SchemaRegistryImpl schemaRegistry;
 
     @BeforeEach
     void initialize() {
-        schemaRegistry = new SchemaRegistryImpl(schemaApplications);
-        appConfig = new ConfigProviderImpl().getConfiguration();
-        platformConfig = new ConfigProviderImpl().getConfiguration();
+        schemaRegistry = new SchemaRegistryImpl(List.of(), schemaApplications);
+        config = new ConfigProviderImpl().getConfiguration();
     }
 
     @Test
@@ -118,8 +117,8 @@ class SchemaRegistryImplTest {
                 mirrorNodeState,
                 previousVersion,
                 networkInfo,
-                appConfig,
-                platformConfig,
+                config,
+                config,
                 new HashMap<>(),
                 new AtomicLong(),
                 startupNetworks);
@@ -140,8 +139,8 @@ class SchemaRegistryImplTest {
                 mirrorNodeState,
                 previousVersion,
                 networkInfo,
-                appConfig,
-                platformConfig,
+                config,
+                config,
                 new HashMap<>(),
                 new AtomicLong(),
                 startupNetworks);
@@ -165,7 +164,7 @@ class SchemaRegistryImplTest {
 
         StateDefinition stateDefinition = new StateDefinition("STATE", mockCodec, mockCodec, 123, true, false, false);
 
-        when(schema.statesToCreate(appConfig))
+        when(schema.statesToCreate(config))
                 .thenReturn(Set.of(stateDefinitionSingleton, stateDefinitionQueue, stateDefinition));
 
         schemaRegistry.register(schema);
@@ -174,8 +173,8 @@ class SchemaRegistryImplTest {
                 mirrorNodeState,
                 previousVersion,
                 networkInfo,
-                appConfig,
-                platformConfig,
+                config,
+                config,
                 new HashMap<>(),
                 new AtomicLong(),
                 startupNetworks);
@@ -199,8 +198,8 @@ class SchemaRegistryImplTest {
                 mirrorNodeState,
                 previousVersion,
                 networkInfo,
-                appConfig,
-                platformConfig,
+                config,
+                config,
                 new HashMap<>(),
                 new AtomicLong(),
                 startupNetworks);
@@ -215,8 +214,8 @@ class SchemaRegistryImplTest {
                 previousVersion,
                 readableStates,
                 writableStates,
-                appConfig,
-                platformConfig,
+                config,
+                config,
                 networkInfo,
                 new AtomicLong(1),
                 EMPTY_MAP,
@@ -229,8 +228,8 @@ class SchemaRegistryImplTest {
             assertThat(c.previousVersion()).isEqualTo(previousVersion);
             assertThat(c.previousStates()).isEqualTo(readableStates);
             assertThat(c.newStates()).isEqualTo(writableStates);
-            assertThat(c.appConfig()).isEqualTo(appConfig);
-            assertThat(c.platformConfig()).isEqualTo(platformConfig);
+            assertThat(c.appConfig()).isEqualTo(config);
+            assertThat(c.platformConfig()).isEqualTo(config);
             assertThat(c.genesisNetworkInfo()).isEqualTo(networkInfo);
             assertThat(c.newEntityNum()).isEqualTo(1);
             assertThat(c.sharedValues()).isEqualTo(EMPTY_MAP);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/ServicesRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/ServicesRegistryImplTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.service.file.impl.FileServiceImpl;
 import com.swirlds.state.lifecycle.Service;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,7 @@ class ServicesRegistryImplTest {
 
     @BeforeEach
     void setUp() {
-        servicesRegistry = new ServicesRegistryImpl();
+        servicesRegistry = new ServicesRegistryImpl(List.of());
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/BlockInfoSingletonTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/BlockInfoSingletonTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static com.hedera.mirror.web3.state.Utils.convertToTimestamp;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.node.state.blockrecords.BlockInfo;
+import com.hedera.mirror.common.domain.DomainBuilder;
+import com.hedera.mirror.common.domain.transaction.RecordFile;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.repository.RecordFileRepository;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BlockInfoSingletonTest {
+
+    private final DomainBuilder domainBuilder = new DomainBuilder();
+    private final MirrorNodeEvmProperties properties = new MirrorNodeEvmProperties();
+
+    private BlockInfoSingleton blockInfoSingleton;
+
+    @Mock
+    private RecordFileRepository recordFileRepository;
+
+    @BeforeEach
+    void setup() {
+        properties.setProperties(Map.of("hedera.recordStream.numOfBlockHashesInState", "2"));
+        blockInfoSingleton = new BlockInfoSingleton(properties, recordFileRepository);
+    }
+
+    @ValueSource(longs = {0, 1, 2})
+    @ParameterizedTest
+    void get(long startIndex) {
+        ContractCallContext.run(context -> {
+            var recordFile1 = recordFile(startIndex);
+            var recordFile2 = recordFile(startIndex + 1L);
+            var recordFile3 = recordFile(startIndex + 2L);
+            var recordFiles = new ArrayList<>(List.of(recordFile1, recordFile2));
+
+            when(recordFileRepository.findByIndexRange(startIndex, startIndex + 1))
+                    .thenReturn(recordFiles);
+            context.setRecordFile(recordFile3);
+
+            assertThat(blockInfoSingleton.get())
+                    .isEqualTo(BlockInfo.newBuilder()
+                            .blockHashes(Bytes.fromHex(
+                                    recordFile1.getHash() + recordFile2.getHash() + recordFile3.getHash()))
+                            .consTimeOfLastHandledTxn(convertToTimestamp(recordFile3.getConsensusEnd()))
+                            .firstConsTimeOfCurrentBlock(convertToTimestamp(recordFile3.getConsensusEnd()))
+                            .firstConsTimeOfLastBlock(convertToTimestamp(recordFile3.getConsensusStart()))
+                            .lastBlockNumber(recordFile3.getIndex())
+                            .migrationRecordsStreamed(true)
+                            .build());
+            return null;
+        });
+    }
+
+    @Test
+    void getGenesis() {
+        ContractCallContext.run(context -> {
+            var recordFile = recordFile(0L);
+            context.setRecordFile(recordFile);
+
+            assertThat(blockInfoSingleton.get())
+                    .isEqualTo(BlockInfo.newBuilder()
+                            .blockHashes(Bytes.fromHex(recordFile.getHash()))
+                            .consTimeOfLastHandledTxn(convertToTimestamp(recordFile.getConsensusEnd()))
+                            .firstConsTimeOfCurrentBlock(convertToTimestamp(recordFile.getConsensusEnd()))
+                            .firstConsTimeOfLastBlock(convertToTimestamp(recordFile.getConsensusStart()))
+                            .lastBlockNumber(recordFile.getIndex())
+                            .migrationRecordsStreamed(true)
+                            .build());
+            return null;
+        });
+    }
+
+    @Test
+    void key() {
+        assertThat(blockInfoSingleton.getKey()).isEqualTo("BLOCKS");
+    }
+
+    @Test
+    void set() {
+        ContractCallContext.run(context -> {
+            var recordFile = recordFile(0L);
+            context.setRecordFile(recordFile);
+            blockInfoSingleton.set(BlockInfo.DEFAULT);
+            assertThat(blockInfoSingleton.get()).isNotEqualTo(BlockInfo.DEFAULT);
+            return null;
+        });
+    }
+
+    private RecordFile recordFile(long index) {
+        return domainBuilder.recordFile().customize(r -> r.index(index)).get();
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/RunningHashesSingletonTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/RunningHashesSingletonTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.state.singleton;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.node.state.blockrecords.RunningHashes;
+import com.hedera.mirror.common.domain.DomainBuilder;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import org.junit.jupiter.api.Test;
+
+class RunningHashesSingletonTest {
+
+    private final DomainBuilder domainBuilder = new DomainBuilder();
+    private final RunningHashesSingleton runningHashesSingleton = new RunningHashesSingleton();
+
+    @Test
+    void get() {
+        ContractCallContext.run(context -> {
+            var recordFile = domainBuilder.recordFile().get();
+            context.setRecordFile(recordFile);
+            assertThat(runningHashesSingleton.get())
+                    .isEqualTo(RunningHashes.newBuilder()
+                            .runningHash(Bytes.fromHex(recordFile.getHash()))
+                            .build());
+            return null;
+        });
+    }
+
+    @Test
+    void key() {
+        assertThat(runningHashesSingleton.getKey()).isEqualTo("RUNNING_HASHES");
+    }
+
+    @Test
+    void set() {
+        ContractCallContext.run(context -> {
+            var recordFile = domainBuilder.recordFile().get();
+            context.setRecordFile(recordFile);
+            runningHashesSingleton.set(RunningHashes.DEFAULT);
+            assertThat(runningHashesSingleton.get()).isNotEqualTo(RunningHashes.DEFAULT);
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
**Description**:

* Add a `BlockInfo` singleton to return the last 256 block hashes
* Add a `RunningHashes` singleton to return the running hash
* Add `MirrorOperationTracer` to modularized execution
* Change modularized code to not initialize stacked state frame
* Change to always load requested block in modularized code for use in `BlockInfo` later
* Change to initialize `VersionedConfiguration` once and use it everywhere
* Change to reuse stateless `TransactionExecutor` between requests
* Disable `contracts.sidecars` to avoid generating unnecessary sidecar data
* Fix EVM version being cached for the first request
* Fix some tests by always inserting exchange rate

**Related issue(s)**:

Fixes #9983
Fixes #10149
Part of #10079

**Notes for reviewer**:

Before
```
3342 tests completed, 397 failed, 6 skipped
```

After
```
3350 tests completed, 302 failed, 6 skipped
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
