### PR TITLE
Fix hbar and token transfer tests

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.hedera.mirror.common.domain.balance.AccountBalance;
+import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -258,6 +259,30 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                         .freezeStatus(TokenFreezeStatusEnum.UNFROZEN)
                         .kycStatus(TokenKycStatusEnum.GRANTED)
                         .associated(true))
+                .persist();
+    }
+
+    protected void persistAccountBalance(Entity account, long balance, long timestamp) {
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new AccountBalance.Id(timestamp, account.toEntityId()))
+                        .balance(balance))
+                .persist();
+    }
+
+    protected void persistAccountBalance(Entity account, long balance) {
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new AccountBalance.Id(account.getCreatedTimestamp(), account.toEntityId()))
+                        .balance(balance))
+                .persist();
+    }
+
+    protected void persistTokenBalance(Entity account, Entity token, long timestamp) {
+        domainBuilder
+                .tokenBalance()
+                .customize(ab -> ab.id(new TokenBalance.Id(timestamp, account.toEntityId(), token.toEntityId()))
+                        .balance(100))
                 .persist();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
@@ -1193,7 +1193,6 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         long timestampForBalances = payer.getCreatedTimestamp();
         persistAccountBalance(payer, payer.getBalance());
         persistAccountBalance(sender, sender.getBalance(), timestampForBalances);
-        treasuryEntity = domainBuilder.entity().customize(e -> e.id(2L).num(2L)).get();
         persistAccountBalance(treasuryEntity, treasuryEntity.getBalance(), timestampForBalances);
 
         // When
@@ -1228,7 +1227,6 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         persistTokenBalance(sender, tokenEntity, timestampForBalances);
 
         persistTokenBalance(receiver, tokenEntity, timestampForBalances);
-        treasuryEntity = domainBuilder.entity().customize(e -> e.id(2L).num(2L)).get();
         persistAccountBalance(treasuryEntity, treasuryEntity.getBalance(), timestampForBalances);
 
         tokenAccountPersist(tokenEntity, sender);
@@ -1271,7 +1269,6 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
 
         persistTokenBalance(receiver, tokenEntity, timestampForBalances);
 
-        treasuryEntity = domainBuilder.entity().customize(e -> e.id(2L).num(2L)).get();
         persistAccountBalance(treasuryEntity, treasuryEntity.getBalance(), timestampForBalances);
 
         tokenAccountPersist(tokenEntity, sender);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
@@ -29,6 +29,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import com.hedera.mirror.common.domain.balance.AccountBalance;
+import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -1190,6 +1192,12 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         final var receiver = accountEntityWithEvmAddressPersist();
         final var payer = accountEntityWithEvmAddressPersist();
 
+        long timestampForBalances = payer.getCreatedTimestamp();
+        persistAccountBalance(payer, payer.getBalance());
+        persistAccountBalance(sender, sender.getBalance(), timestampForBalances);
+        treasuryEntity = domainBuilder.entity().customize(e -> e.id(2L).num(2L)).get();
+        persistAccountBalance(treasuryEntity, treasuryEntity.getBalance(), timestampForBalances);
+
         // When
         testWeb3jService.setSender(getAliasFromEntity(payer));
         final var transferList = new TransferList(List.of(
@@ -1214,10 +1222,20 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         final var receiver = accountEntityWithEvmAddressPersist();
         final var payer = accountEntityWithEvmAddressPersist();
 
-        tokenAccountPersist(tokenEntity, payer);
+        long timestampForBalances = payer.getCreatedTimestamp();
+        persistAccountBalance(payer, payer.getBalance());
+        persistTokenBalance(payer, tokenEntity, timestampForBalances);
+
+        persistAccountBalance(sender, sender.getBalance(), timestampForBalances);
+        persistTokenBalance(sender, tokenEntity, timestampForBalances);
+
+        persistTokenBalance(receiver, tokenEntity, timestampForBalances);
+        treasuryEntity = domainBuilder.entity().customize(e -> e.id(2L).num(2L)).get();
+        persistAccountBalance(treasuryEntity, treasuryEntity.getBalance(), timestampForBalances);
+
         tokenAccountPersist(tokenEntity, sender);
         tokenAccountPersist(tokenEntity, receiver);
-
+        tokenAccountPersist(tokenEntity, payer);
         // When
         testWeb3jService.setSender(getAliasFromEntity(payer));
         final var tokenTransferList = new TokenTransferList(
@@ -1246,9 +1264,21 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         final var receiver = accountEntityWithEvmAddressPersist();
         final var payer = accountEntityWithEvmAddressPersist();
 
-        tokenAccountPersist(tokenEntity, payer);
+        long timestampForBalances = payer.getCreatedTimestamp();
+        persistAccountBalance(payer, payer.getBalance());
+        persistTokenBalance(payer, tokenEntity, timestampForBalances);
+
+        persistAccountBalance(sender, sender.getBalance(), timestampForBalances);
+        persistTokenBalance(sender, tokenEntity, timestampForBalances);
+
+        persistTokenBalance(receiver, tokenEntity, timestampForBalances);
+
+        treasuryEntity = domainBuilder.entity().customize(e -> e.id(2L).num(2L)).get();
+        persistAccountBalance(treasuryEntity, treasuryEntity.getBalance(), timestampForBalances);
+
         tokenAccountPersist(tokenEntity, sender);
         tokenAccountPersist(tokenEntity, receiver);
+        tokenAccountPersist(tokenEntity, payer);
 
         // When
         testWeb3jService.setSender(getAliasFromEntity(payer));
@@ -1541,5 +1571,29 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                         BigInteger.valueOf(entity.getEffectiveExpiration()),
                         EntityIdUtils.asHexedEvmAddress(new Id(0, 0, entityRenewAccountId)),
                         BigInteger.valueOf(entity.getEffectiveExpiration())));
+    }
+
+    private void persistAccountBalance(Entity account, long balance, long timestamp) {
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new AccountBalance.Id(timestamp, account.toEntityId()))
+                        .balance(balance))
+                .persist();
+    }
+
+    private void persistAccountBalance(Entity account, long balance) {
+        domainBuilder
+                .accountBalance()
+                .customize(ab -> ab.id(new AccountBalance.Id(account.getCreatedTimestamp(), account.toEntityId()))
+                        .balance(balance))
+                .persist();
+    }
+
+    private void persistTokenBalance(Entity account, Entity token, long timestamp) {
+        domainBuilder
+                .tokenBalance()
+                .customize(ab -> ab.id(new TokenBalance.Id(timestamp, account.toEntityId(), token.toEntityId()))
+                        .balance(100))
+                .persist();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
@@ -29,8 +29,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import com.hedera.mirror.common.domain.balance.AccountBalance;
-import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
@@ -1571,29 +1569,5 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                         BigInteger.valueOf(entity.getEffectiveExpiration()),
                         EntityIdUtils.asHexedEvmAddress(new Id(0, 0, entityRenewAccountId)),
                         BigInteger.valueOf(entity.getEffectiveExpiration())));
-    }
-
-    private void persistAccountBalance(Entity account, long balance, long timestamp) {
-        domainBuilder
-                .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(timestamp, account.toEntityId()))
-                        .balance(balance))
-                .persist();
-    }
-
-    private void persistAccountBalance(Entity account, long balance) {
-        domainBuilder
-                .accountBalance()
-                .customize(ab -> ab.id(new AccountBalance.Id(account.getCreatedTimestamp(), account.toEntityId()))
-                        .balance(balance))
-                .persist();
-    }
-
-    private void persistTokenBalance(Entity account, Entity token, long timestamp) {
-        domainBuilder
-                .tokenBalance()
-                .customize(ab -> ab.id(new TokenBalance.Id(timestamp, account.toEntityId(), token.toEntityId()))
-                        .balance(100))
-                .persist();
     }
 }


### PR DESCRIPTION
**Description**:
This Pr fixes `cryptoTransferHbars`, `cryptoTransferToken` and `cryptoTransferHbarsAndToken` test in ContractCallServicePrecompileModificationTest.
Those test were failing in the opcode assertion calls.
In the opcode flow we are always having a timestamp in the request.

So even if the timestamp is pretty similar to the latest case token balance and account balance are calculated with the historical queries. This PR adds the token and account balance setup for opcode flow.

Having the blueprint of the token and account balance, now we can fix other opcode test failure which are failing with insufficient payer or token balance.

This PR modifies ... in order to support ...
`ContractCallServicePrecompileModificationTest` - add token and account balance setup for transfer tests

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
3342 tests completed, 295 failed, 6 skipped

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
