### PR TITLE
Fix the failing tests in `InternalCallsTest`

### DIFF
--- a/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/converter/StringToLongConverter.java
+++ b/hedera-mirror-rest-java/src/main/java/com/hedera/mirror/restjava/converter/StringToLongConverter.java
@@ -31,7 +31,6 @@ public class StringToLongConverter implements Converter<String, Long> {
             return null;
         }
 
-
         var parts = source.split("\\.");
         if (parts.length == 3) {
             return EntityId.of(source).getId();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/InternalCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/InternalCallsTest.java
@@ -75,10 +75,8 @@ public class InternalCallsTest extends AbstractContractCallServiceTest {
         if (!mirrorNodeEvmProperties.isModularizedServices()) {
             assertThat(result).isEqualTo(Boolean.TRUE);
         } else {
-            assertThat(result)
-                    .isEqualTo(
-                            Boolean.FALSE); // In the mod code, there is a check if the address is an alias and in this
-            // case it is not.
+            // In the mod code, there is a check if the address is an alias and in this case it is not.
+            assertThat(result).isEqualTo(Boolean.FALSE);
         }
         assertGasLimit(TRANSACTION_GAS_LIMIT);
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/InternalCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/InternalCallsTest.java
@@ -21,8 +21,11 @@ import static com.hedera.mirror.web3.service.ContractCallService.GAS_LIMIT_METRI
 import static com.hedera.mirror.web3.service.model.CallServiceParameters.CallType.ETH_CALL;
 import static com.hedera.mirror.web3.utils.ContractCallTestUtil.TRANSACTION_GAS_LIMIT;
 import static com.hedera.mirror.web3.validation.HexValidator.HEX_PREFIX;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import com.hedera.mirror.web3.exception.MirrorEvmTransactionException;
 import com.hedera.mirror.web3.web3j.generated.InternalCaller;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -69,7 +72,14 @@ public class InternalCallsTest extends AbstractContractCallServiceTest {
         meterRegistry.clear();
         final var result = contract.call_sendTo(NON_EXISTING_ADDRESS).send();
 
-        assertThat(result).isEqualTo(Boolean.TRUE);
+        if (!mirrorNodeEvmProperties.isModularizedServices()) {
+            assertThat(result).isEqualTo(Boolean.TRUE);
+        } else {
+            assertThat(result)
+                    .isEqualTo(
+                            Boolean.FALSE); // In the mod code, there is a check if the address is an alias and in this
+            // case it is not.
+        }
         assertGasLimit(TRANSACTION_GAS_LIMIT);
     }
 
@@ -77,9 +87,16 @@ public class InternalCallsTest extends AbstractContractCallServiceTest {
     void transferToNonExistingAccount() throws Exception {
         final var contract = testWeb3jService.deploy(InternalCaller::deploy);
         meterRegistry.clear();
-        contract.send_transferTo(NON_EXISTING_ADDRESS).send();
-
-        assertThat(testWeb3jService.getTransactionResult()).isEqualTo(HEX_PREFIX);
+        final var functionCall = contract.send_transferTo(NON_EXISTING_ADDRESS);
+        if (!mirrorNodeEvmProperties.isModularizedServices()) {
+            functionCall.send();
+            assertThat(testWeb3jService.getTransactionResult()).isEqualTo(HEX_PREFIX);
+        } else {
+            // In the mod code, there is a check if the address is an alias and in this case it is not.
+            assertThatThrownBy(functionCall::send)
+                    .isInstanceOf(MirrorEvmTransactionException.class)
+                    .hasMessage(CONTRACT_REVERT_EXECUTED.name());
+        }
         assertGasLimit(TRANSACTION_GAS_LIMIT);
     }
 


### PR DESCRIPTION
**Description**:
Adapt the failing tests in `InternalCallsTest`. There is a difference in the behaviour in the mono code and the modularized code, so depending on the `modularizedServices` flag the test assertions are different.

Fixes #10089 
