### PR TITLE
Reduce pgbouncer server lifetime to reduce memory footprint 

### DIFF
--- a/charts/hedera-mirror/values.yaml
+++ b/charts/hedera-mirror/values.yaml
@@ -320,6 +320,7 @@ stackgres:
         max_client_conn: "1600"
         max_prepared_statements: "512"
         pool_mode: transaction
+        server_lifetime: "1200"
       users:
         mirror_node:
           pool_mode: session
@@ -373,6 +374,7 @@ stackgres:
         max_client_conn: "2000"
         max_prepared_statements: "512"
         pool_mode: transaction
+        server_lifetime: "1200"
       users:
         mirror_node:
           pool_mode: session


### PR DESCRIPTION
**Description**:

This PR reduces pgbouncer server_lifetime from default of 60 minutes to 20 minutes.

**Related issue(s)**:

Fixes #10154 

**Notes for reviewer**:

Tested in staging with traffic replay, peak memory consumption is much less than with 60 minutes server lifetime.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
