### PR TITLE
Remove automatic publishing of builds data

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,6 +56,7 @@ fun shortenProjectName(project: ProjectDescriptor) {
 
 develocity {
     buildScan {
+        publishing.onlyIf { false }
         termsOfUseUrl = "https://gradle.com/terms-of-service"
         termsOfUseAgree = "yes"
         tag("CI")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,7 +56,7 @@ fun shortenProjectName(project: ProjectDescriptor) {
 
 develocity {
     buildScan {
-        publishing.onlyIf { false }
+        publishing.onlyIf { System.getenv().containsKey("CI") }
         termsOfUseUrl = "https://gradle.com/terms-of-service"
         termsOfUseAgree = "yes"
         tag("CI")


### PR DESCRIPTION
**Description:**

To be more privacy-friendly by default, this PR removes the automatic publishing of build data to Gradle servers. The report is still published automatically when the build is run in a CI environment.

If developers want to publish build scans, they can use the `--scan` option:

```sh
./gradlew clean build --scan
````

or set the `publishing.onlyIf` parameter to `true` to always publish the report like this:

```
develocity {
    buildScan {
        publishing.onlyIf { true }
        termsOfUseUrl = "https://gradle.com/terms-of-service"
        termsOfUseAgree = "yes
        tag("CI")
    }
}
```

In this case, developers can use `--no-scan` to avoid selectively publishing the report:

```sh
./gradlew clean build --no-scan
````

**Related issue(s)**:

N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
