### PR TITLE
Update deprecated parameter in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xms1024m -Xmx4096m -XX:+UseParallelGC -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 org.gradle.parallel=true
-systemProp.gradle.enterprise.testretry.enabled=false
+systemProp.develocity.testretry.enabled=false
 # Kotlin Settings
 kotlin.code.style=official
 kotlin.incremental=true


### PR DESCRIPTION
**Description**:

This PR modifies the gradle.properties file in order to replace the deprecated `systemProp.gradle.enterprise.testretry.enabled` parameter with the new `systemProp.develocity.testretry.enabled`.

This fixes the following warning at the end of the build process:

```sh
WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin:
- The deprecated "gradle.enterprise.testretry.enabled" system property has been replaced by "develocity.testretry.enabled"
```

**Related issue(s)**:

N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
