### PR TITLE
Fix flaky importer tests

### DIFF
--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -51,7 +51,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     // Disable serial and this-escape warnings due to errors in generated code
     options.compilerArgs.addAll(
         listOf("-parameters", "-Werror", "-Xlint:all", "-Xlint:-this-escape,-preview")
@@ -65,7 +65,7 @@ tasks.compileJava { options.compilerArgs.add("-Xlint:-serial") }
 
 tasks.javadoc { options.encoding = "UTF-8" }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     finalizedBy(tasks.jacocoTestReport)
     jvmArgs = listOf("-XX:+EnableDynamicAgentLoading") // Allow byte buddy for Mockito
     maxHeapSize = "4096m"

--- a/buildSrc/src/main/kotlin/openapi-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/openapi-conventions.gradle.kts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import org.gradle.api.tasks.compile.JavaCompile
-import org.gradle.kotlin.dsl.withType
-
 plugins {
     id("java-conventions")
     id("org.openapi.generator")
@@ -58,6 +55,6 @@ openApiGenerate {
     typeMappings = mapOf("Timestamp" to "String", "string+binary" to "String")
 }
 
-tasks.withType<JavaCompile> { dependsOn("openApiGenerate") }
+tasks.withType<JavaCompile>().configureEach { dependsOn("openApiGenerate") }
 
 java.sourceSets["main"].java { srcDir(openApiGenerate.outputDir) }

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/RedisTestConfiguration.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/config/RedisTestConfiguration.java
@@ -17,19 +17,20 @@
 package com.hedera.mirror.common.config;
 
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
-@Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(RedisAutoConfiguration.class)
+@Configuration
 public class RedisTestConfiguration {
     @Bean
-    @Lazy
     @ServiceConnection("redis")
     GenericContainer<?> redis() {
         var logger = LoggerFactory.getLogger("RedisContainer");

--- a/hedera-mirror-graphql/build.gradle.kts
+++ b/hedera-mirror-graphql/build.gradle.kts
@@ -88,7 +88,7 @@ generatePojoConf {
     )
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     dependsOn(tasks.generatePojo)
     if (name == "compileJava") {
         options.compilerArgs.addAll(

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ConfigurableJavaMigration.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/migration/ConfigurableJavaMigration.java
@@ -22,13 +22,18 @@ import org.flywaydb.core.api.configuration.Configuration;
 
 abstract class ConfigurableJavaMigration extends AbstractJavaMigration {
 
+    private static final String ASYNC = "async";
     private static final MigrationProperties DEFAULT_MIGRATION_PROPERTIES = new MigrationProperties();
 
     protected final MigrationProperties migrationProperties;
 
     protected ConfigurableJavaMigration(Map<String, MigrationProperties> migrationPropertiesMap) {
         String propertiesKey = StringUtils.uncapitalize(getClass().getSimpleName());
-        migrationProperties = migrationPropertiesMap.getOrDefault(propertiesKey, DEFAULT_MIGRATION_PROPERTIES);
+        var defaultProperties = DEFAULT_MIGRATION_PROPERTIES;
+        if (this instanceof AsyncJavaMigration<?>) {
+            defaultProperties = migrationPropertiesMap.getOrDefault(ASYNC, DEFAULT_MIGRATION_PROPERTIES);
+        }
+        migrationProperties = migrationPropertiesMap.getOrDefault(propertiesKey, defaultProperties);
     }
 
     @Override

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AsyncJavaMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AsyncJavaMigrationTest.java
@@ -137,10 +137,10 @@ class AsyncJavaMigrationTest extends ImporterIntegrationTest {
                 .addValue("checksum", migrationHistory.getChecksum());
         var sql =
                 """
-                        insert into flyway_schema_history (installed_rank, description, type, script, checksum,
-                        installed_by, execution_time, success) values (:installedRank, :description, 'JDBC', :script,
-                        :checksum, 20, 100, true)
-                        """;
+                insert into flyway_schema_history (installed_rank, description, type, script, checksum,
+                installed_by, execution_time, success) values (:installedRank, :description, 'JDBC', :script,
+                :checksum, 20, 100, true)
+                """;
         namedParameterJdbcTemplate.update(sql, paramSource);
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AsyncJavaMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/AsyncJavaMigrationTest.java
@@ -24,6 +24,7 @@ import com.hedera.mirror.importer.EnabledIfV1;
 import com.hedera.mirror.importer.ImporterIntegrationTest;
 import com.hedera.mirror.importer.db.DBProperties;
 import jakarta.annotation.Nonnull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -53,12 +54,22 @@ class AsyncJavaMigrationTest extends ImporterIntegrationTest {
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private final TransactionOperations transactionOperations;
     private final String script = TestAsyncJavaMigration.class.getName();
+    private final Collection<AsyncJavaMigration<?>> asyncMigrations;
 
     @AfterEach
     @BeforeEach
     void cleanup() {
         namedParameterJdbcTemplate.update(
                 "delete from flyway_schema_history where script = :script", Map.of("script", script));
+    }
+
+    @Test
+    void disabledInConfig() {
+        asyncMigrations.forEach(migration -> {
+            assertThat(migration.migrationProperties.isEnabled())
+                    .as("%s is not disabled", migration.getClass().getSimpleName())
+                    .isFalse();
+        });
     }
 
     @ParameterizedTest
@@ -126,10 +137,10 @@ class AsyncJavaMigrationTest extends ImporterIntegrationTest {
                 .addValue("checksum", migrationHistory.getChecksum());
         var sql =
                 """
-                insert into flyway_schema_history (installed_rank, description, type, script, checksum,
-                installed_by, execution_time, success) values (:installedRank, :description, 'JDBC', :script,
-                :checksum, 20, 100, true)
-                """;
+                        insert into flyway_schema_history (installed_rank, description, type, script, checksum,
+                        installed_by, execution_time, success) values (:installedRank, :description, 'JDBC', :script,
+                        :checksum, 20, 100, true)
+                        """;
         namedParameterJdbcTemplate.update(sql, paramSource);
     }
 

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigrationTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/migration/BackfillAndDeduplicateBalanceMigrationTest.java
@@ -41,6 +41,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
@@ -84,11 +85,17 @@ class BackfillAndDeduplicateBalanceMigrationTest
 
     private final TokenBalanceRepository tokenBalanceRepository;
 
+    @BeforeEach
+    void setup() {
+        migration.migrationProperties.setEnabled(true);
+    }
+
     @AfterEach
     void teardown() {
         addBalanceDeduplicateFunctions();
         jdbcTemplate.execute(REVERT_DDL);
-        getMigrationProperties().getParams().clear();
+        migration.migrationProperties.setEnabled(false);
+        migration.migrationProperties.getParams().clear();
     }
 
     @Test
@@ -456,7 +463,7 @@ class BackfillAndDeduplicateBalanceMigrationTest
     @Test
     void minFrequency() {
         // given min frequency is set to 6 minutes
-        getMigrationProperties().getParams().put("minFrequency", "6m");
+        migration.migrationProperties.getParams().put("minFrequency", "6m");
 
         var treasury = EntityId.of(TREASURY);
         var account = EntityId.of(domainBuilder.id() + TREASURY);
@@ -605,10 +612,6 @@ class BackfillAndDeduplicateBalanceMigrationTest
                     ps.setLong(3, tokenBalance.getId().getConsensusTimestamp());
                     ps.setLong(4, tokenBalance.getId().getTokenId().getId());
                 });
-    }
-
-    private MigrationProperties getMigrationProperties() {
-        return importerProperties.getMigration().get("backfillAndDeduplicateBalanceMigration");
     }
 
     @SneakyThrows

--- a/hedera-mirror-importer/src/test/resources/config/application.yml
+++ b/hedera-mirror-importer/src/test/resources/config/application.yml
@@ -5,10 +5,8 @@ hedera:
         bucketName: test
       importHistoricalAccountInfo: false
       migration:
-        backfillAndDeduplicateBalanceMigration:
-          enabled: false # disable the migration so during test it doesn't drop the balance tables
-        fixCryptoAllowanceAmountMigration:
-          enabled: false # disable the migration so during test it doesn't drop the crypto_allowance_migration table
+        async:
+          enabled: false
         DUMMYMIGRATION:
           checksum: 5
       network: TESTNET

--- a/hedera-mirror-web3/build.gradle.kts
+++ b/hedera-mirror-web3/build.gradle.kts
@@ -131,7 +131,7 @@ val extractOpenZeppelin =
 
 tasks.bootRun { jvmArgs = listOf("--enable-preview") }
 
-tasks.withType<JavaCompile> { options.compilerArgs.add("--enable-preview") }
+tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("--enable-preview") }
 
 tasks.test { jvmArgs = listOf("--enable-preview") }
 


### PR DESCRIPTION
**Description**:

* Change Gradle `tasks.withType` to use [configuration avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:how_do_i_defer_configuration)
* Disable async migrations by default in tests to avoid concurrent context issues

**Related issue(s)**:

Fixes #10202

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
