### PR TITLE
HIP-1056: Update topic message running hash version to be nullable

### DIFF
--- a/docs/design/block-streams.md
+++ b/docs/design/block-streams.md
@@ -58,6 +58,7 @@ Update the handling of the topic message `runningHashVersion`:
 - Update `ConsensusSubmitMessageTransactionHandler` to account for block streams no longer sending the runningHashVersion value:
   - If the TransactionReceipt runningHashVersion is 3 (the current value) set the runningHashVersion to null.
   - If the TransactionReceipt runningHashVersion is not 3 set the runningHashVersion to that value.
+- The `ConsensusSubmitMessageTransformer`, when transforming a block item to a record item, will set the topic message receipt runningHashVersion to 3.
 
 ### Interfaces and Classes
 

--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/topic/TopicMessage.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/topic/TopicMessage.java
@@ -61,7 +61,7 @@ public class TopicMessage implements Comparable<TopicMessage>, Persistable<Long>
     @ToString.Exclude
     private byte[] runningHash;
 
-    private int runningHashVersion;
+    private Integer runningHashVersion;
 
     private long sequenceNumber;
 

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/topic/TopicMessageTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/domain/topic/TopicMessageTest.java
@@ -23,13 +23,15 @@ import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionID;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class TopicMessageTest {
 
     // Test serialization to JSON to verify contract with PostgreSQL listen/notify
-    @Test
-    void toJson() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void toJson(boolean nullVersion) throws Exception {
         TopicMessage topicMessage = new TopicMessage();
         topicMessage.setChunkNum(1);
         topicMessage.setChunkTotal(2);
@@ -37,7 +39,7 @@ class TopicMessageTest {
         topicMessage.setMessage(new byte[] {1, 2, 3});
         topicMessage.setPayerAccountId(EntityId.of("0.1.1000"));
         topicMessage.setRunningHash(new byte[] {4, 5, 6});
-        topicMessage.setRunningHashVersion(2);
+        topicMessage.setRunningHashVersion(nullVersion ? null : 2);
         topicMessage.setSequenceNumber(1L);
         topicMessage.setTopicId(EntityId.of("0.0.1001"));
         topicMessage.setValidStartTimestamp(1594401416000000000L);
@@ -50,6 +52,7 @@ class TopicMessageTest {
                 .setScheduled(true)
                 .build();
         topicMessage.setInitialTransactionId(transactionID.toByteArray());
+        var expectedVersion = nullVersion ? "\"running_hash_version\":null," : "\"running_hash_version\":2,";
 
         String json = OBJECT_MAPPER.writeValueAsString(topicMessage);
         assertThat(json)
@@ -61,7 +64,7 @@ class TopicMessageTest {
                         + "\"message\":\"AQID\","
                         + "\"payer_account_id\":4294968296,"
                         + "\"running_hash\":\"BAUG\","
-                        + "\"running_hash_version\":2,"
+                        + expectedVersion
                         + "\"sequence_number\":1,"
                         + "\"topic_id\":1001,"
                         + "\"valid_start_timestamp\":1594401416000000000}");

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
@@ -29,6 +29,7 @@ import com.hedera.mirror.grpc.util.ProtoUtil;
 import com.hederahashgraph.api.proto.java.ConsensusMessageChunkInfo;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionID;
+import java.util.Objects;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import net.devh.boot.grpc.server.service.GrpcService;
@@ -89,14 +90,12 @@ public class ConsensusController extends ReactorConsensusServiceGrpc.ConsensusSe
 
     // Consider caching this conversion for multiple subscribers to the same topic if the need arises.
     private ConsensusTopicResponse toResponse(TopicMessage t) {
-        int runningHashVersion =
-                t.getRunningHashVersion() == null ? DEFAULT_RUNNING_HASH_VERSION : t.getRunningHashVersion();
-
         var consensusTopicResponseBuilder = ConsensusTopicResponse.newBuilder()
                 .setConsensusTimestamp(ProtoUtil.toTimestamp(t.getConsensusTimestamp()))
                 .setMessage(ProtoUtil.toByteString(t.getMessage()))
                 .setRunningHash(ProtoUtil.toByteString(t.getRunningHash()))
-                .setRunningHashVersion(runningHashVersion)
+                .setRunningHashVersion(
+                        Objects.requireNonNullElse(t.getRunningHashVersion(), DEFAULT_RUNNING_HASH_VERSION))
                 .setSequenceNumber(t.getSequenceNumber());
 
         if (t.getChunkNum() != null) {

--- a/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
+++ b/hedera-mirror-grpc/src/main/java/com/hedera/mirror/grpc/controller/ConsensusController.java
@@ -46,6 +46,9 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class ConsensusController extends ReactorConsensusServiceGrpc.ConsensusServiceImplBase {
 
+    // Blockstreams no longer contain runningHashVersion, default to the latest version
+    static final int DEFAULT_RUNNING_HASH_VERSION = 3;
+
     private final TopicMessageService topicMessageService;
 
     @Override
@@ -86,11 +89,14 @@ public class ConsensusController extends ReactorConsensusServiceGrpc.ConsensusSe
 
     // Consider caching this conversion for multiple subscribers to the same topic if the need arises.
     private ConsensusTopicResponse toResponse(TopicMessage t) {
+        int runningHashVersion =
+                t.getRunningHashVersion() == null ? DEFAULT_RUNNING_HASH_VERSION : t.getRunningHashVersion();
+
         var consensusTopicResponseBuilder = ConsensusTopicResponse.newBuilder()
                 .setConsensusTimestamp(ProtoUtil.toTimestamp(t.getConsensusTimestamp()))
                 .setMessage(ProtoUtil.toByteString(t.getMessage()))
                 .setRunningHash(ProtoUtil.toByteString(t.getRunningHash()))
-                .setRunningHashVersion(t.getRunningHashVersion())
+                .setRunningHashVersion(runningHashVersion)
                 .setSequenceNumber(t.getSequenceNumber());
 
         if (t.getChunkNum() != null) {

--- a/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.103.0__update_topic_message.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v1/V1.103.0__update_topic_message.sql
@@ -1,0 +1,2 @@
+alter table if exists topic_message
+  alter column running_hash_version drop not null;

--- a/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.8.0__update_topic_message.sql
+++ b/hedera-mirror-importer/src/main/resources/db/migration/v2/V2.8.0__update_topic_message.sql
@@ -1,0 +1,2 @@
+alter table if exists topic_message
+  alter column running_hash_version drop not null;

--- a/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/RestSpecTest.java
+++ b/hedera-mirror-rest-java/src/test/java/com/hedera/mirror/restjava/spec/RestSpecTest.java
@@ -64,7 +64,7 @@ import org.testcontainers.containers.GenericContainer;
         properties = {"spring.main.allow-bean-definition-overriding=true"})
 public class RestSpecTest extends RestJavaIntegrationTest {
     private static final Pattern INCLUDED_SPEC_DIRS = Pattern.compile(
-            "^(accounts|accounts/\\{id}/allowances.*|accounts/\\{id}/rewards.*|blocks.*|contracts|network/exchangerate.*|network/fees.*|network/stake.*|topics/\\{id}/messages)$");
+            "^(accounts|accounts/\\{id}/allowances.*|accounts/\\{id}/rewards.*|blocks.*|contracts|network/exchangerate.*|network/fees.*|network/stake.*)$");
     private static final String RESPONSE_HEADER_FILE = "responseHeaders.json";
     private static final int JS_REST_API_CONTAINER_PORT = 5551;
     private static final Path REST_BASE_PATH = Path.of("..", "hedera-mirror-rest", "__tests__", "specs");

--- a/hedera-mirror-rest/__tests__/specs/topics/{id}/messages/all-params.json
+++ b/hedera-mirror-rest/__tests__/specs/topics/{id}/messages/all-params.json
@@ -31,6 +31,7 @@
       },
       {
         "consensus_timestamp": "1236567890000000005",
+        "running_hash_version": null,
         "sequence_number": 5,
         "topic_id": 7
       },
@@ -71,7 +72,7 @@
         "message": "bWVzc2FnZQ==",
         "payer_account_id": "0.0.3",
         "running_hash": "cnVubmluZ19oYXNo",
-        "running_hash_version": 2,
+        "running_hash_version": 3,
         "sequence_number": 5,
         "topic_id": "0.0.7"
       }

--- a/hedera-mirror-rest/__tests__/viewmodel/topicMessageViewModel.test.js
+++ b/hedera-mirror-rest/__tests__/viewmodel/topicMessageViewModel.test.js
@@ -80,6 +80,16 @@ describe('topicMessageViewModel tests', () => {
   });
 });
 
+test('Default running hash version', () => {
+  const row = buildDefaultTopicMessageRow();
+  row.runningHashVersion = null;
+  const actual = new TopicMessageViewModel(row, '');
+
+  const expected = buildDefaultTopicMessageViewModel();
+  expected.running_hash_version = TopicMessageViewModel.DEFAULT_RUNNING_HASH_VERSION;
+  expect(actual).toEqual(expected);
+});
+
 const buildDefaultTopicMessageRow = () => {
   return {
     consensusTimestamp: '1234567890000000001',

--- a/hedera-mirror-rest/viewmodel/topicMessageViewModel.js
+++ b/hedera-mirror-rest/viewmodel/topicMessageViewModel.js
@@ -36,16 +36,12 @@ class TopicMessageViewModel {
    * @param {String} messageEncoding the encoding to display the message in
    */
   constructor(topicMessage, messageEncoding) {
-    const runningHashVersion = _.isNil(topicMessage.runningHashVersion)
-      ? TopicMessageViewModel.DEFAULT_RUNNING_HASH_VERSION
-      : topicMessage.runningHashVersion;
-
     this.chunk_info = _.isNil(topicMessage.chunkNum) ? null : new ChunkInfoViewModel(topicMessage);
     this.consensus_timestamp = nsToSecNs(topicMessage.consensusTimestamp);
     this.message = encodeBinary(topicMessage.message, messageEncoding);
     this.payer_account_id = EntityId.parse(topicMessage.payerAccountId).toString();
     this.running_hash = encodeBase64(topicMessage.runningHash);
-    this.running_hash_version = runningHashVersion;
+    this.running_hash_version = topicMessage.runningHashVersion ?? TopicMessageViewModel.DEFAULT_RUNNING_HASH_VERSION;
     this.sequence_number = topicMessage.sequenceNumber;
     this.topic_id = EntityId.parse(topicMessage.topicId).toString();
   }

--- a/hedera-mirror-rest/viewmodel/topicMessageViewModel.js
+++ b/hedera-mirror-rest/viewmodel/topicMessageViewModel.js
@@ -26,6 +26,9 @@ import {encodeBase64, encodeBinary, nsToSecNs} from '../utils';
  * Topic message view model
  */
 class TopicMessageViewModel {
+  // Blockstreams no longer contain runningHashVersion, default to the latest version
+  static DEFAULT_RUNNING_HASH_VERSION = 3;
+
   /**
    * Constructs topicMessage view model
    *
@@ -33,12 +36,16 @@ class TopicMessageViewModel {
    * @param {String} messageEncoding the encoding to display the message in
    */
   constructor(topicMessage, messageEncoding) {
+    const runningHashVersion = _.isNil(topicMessage.runningHashVersion)
+      ? TopicMessageViewModel.DEFAULT_RUNNING_HASH_VERSION
+      : topicMessage.runningHashVersion;
+
     this.chunk_info = _.isNil(topicMessage.chunkNum) ? null : new ChunkInfoViewModel(topicMessage);
     this.consensus_timestamp = nsToSecNs(topicMessage.consensusTimestamp);
     this.message = encodeBinary(topicMessage.message, messageEncoding);
     this.payer_account_id = EntityId.parse(topicMessage.payerAccountId).toString();
     this.running_hash = encodeBase64(topicMessage.runningHash);
-    this.running_hash_version = topicMessage.runningHashVersion;
+    this.running_hash_version = runningHashVersion;
     this.sequence_number = topicMessage.sequenceNumber;
     this.topic_id = EntityId.parse(topicMessage.topicId).toString();
   }


### PR DESCRIPTION
**Description**:

- Adds a migration to make topic_message.running_hash_version nullable.
- REST and GRPC APIs, when fetching a null value, will return the current default running hash version value. 

**Related issue(s)**:

Fixes #9933 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
