### PR TITLE
Fix `ContractCallEvmCodesTest`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
         api("com.graphql-java-generator:graphql-java-client-runtime:2.8")
         api("com.graphql-java:graphql-java-extended-scalars:22.0")
         api("com.graphql-java:graphql-java-extended-validation:22.0")
-        api("com.hedera.hashgraph:app:0.58.3")
+        api("com.hedera.hashgraph:app:0.58.4")
         api("com.hedera.evm:hedera-evm:0.54.2")
         api("com.hedera.hashgraph:hedera-protobuf-java-api:0.57.3")
         api("com.hedera.hashgraph:sdk:2.46.0")

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ModularizedOperation.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ModularizedOperation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.evm.config;
+
+import org.hyperledger.besu.evm.operation.Operation;
+
+/**
+ * This interface identifies classes that are applicable to the modularized EVM library. The code may still be
+ * applicable to the mono code base as well. This can be deleted once modularization is complete.
+ */
+public interface ModularizedOperation extends Operation {}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/operations/MirrorBlockHashOperation.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/operations/MirrorBlockHashOperation.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.evm.contracts.operations;
+
+import com.hedera.mirror.common.domain.transaction.RecordFile;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.evm.config.ModularizedOperation;
+import com.hedera.mirror.web3.repository.RecordFileRepository;
+import jakarta.inject.Named;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.evm.EVM;
+import org.hyperledger.besu.evm.frame.BlockValues;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.hyperledger.besu.evm.operation.BlockHashOperation;
+
+/**
+ * Custom version of the Besu's BlockHashOperation class. The difference is that in the mirror node we have the block
+ * hash values of all the blocks so the restriction for the latest 256 blocks is removed. The latest block value can be
+ * returned as well.
+ */
+@Named
+class MirrorBlockHashOperation extends BlockHashOperation implements ModularizedOperation {
+
+    private final RecordFileRepository recordFileRepository;
+
+    /**
+     * Instantiates a new Block hash operation.
+     *
+     * @param gasCalculator the gas calculator
+     */
+    MirrorBlockHashOperation(GasCalculator gasCalculator, RecordFileRepository recordFileRepository) {
+        super(gasCalculator);
+        this.recordFileRepository = recordFileRepository;
+    }
+
+    @Override
+    public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
+        final Bytes blockArg = frame.popStackItem().trimLeadingZeros();
+
+        // Short-circuit if value is unreasonably large
+        if (blockArg.size() > 8) {
+            frame.pushStackItem(UInt256.ZERO);
+            return successResponse;
+        }
+
+        final long soughtBlock = blockArg.toLong();
+        final BlockValues blockValues = frame.getBlockValues();
+        final long currentBlockNumber = blockValues.getNumber();
+
+        if (currentBlockNumber <= 0 || soughtBlock > currentBlockNumber) {
+            frame.pushStackItem(Bytes32.ZERO);
+        } else if (currentBlockNumber == soughtBlock) {
+            final var latestBlock = ContractCallContext.get().getRecordFile();
+            final var blockHash = getBlockHash(latestBlock);
+            frame.pushStackItem(blockHash);
+        } else {
+            final Hash blockHash = getBlockHash(soughtBlock);
+            frame.pushStackItem(blockHash);
+        }
+
+        return successResponse;
+    }
+
+    private Hash getBlockHash(long blockNumber) {
+        final var recordFile = recordFileRepository.findByIndex(blockNumber);
+        return recordFile.map(this::getBlockHash).orElse(Hash.ZERO);
+    }
+
+    private Hash getBlockHash(RecordFile recordFile) {
+        return Hash.fromHexString(StringUtils.substring(recordFile.getHash(), 0, 64));
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -336,7 +336,6 @@ public class MirrorNodeEvmProperties implements EvmProperties {
         props.put("contracts.evm.version", "v" + evmVersion.major() + "." + evmVersion.minor());
         props.put("contracts.maxRefundPercentOfGasLimit", String.valueOf(maxGasRefundPercentage()));
         props.put("contracts.sidecars", "");
-        props.put("executor.maxSignedTxnSize", "262144");
         props.put("ledger.id", Bytes.wrap(getNetwork().getLedgerId()).toHexString());
         props.putAll(properties); // Allow user defined properties to override the defaults
         return Collections.unmodifiableMap(props);

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -176,16 +176,12 @@ public class MirrorNodeEvmProperties implements EvmProperties {
     @NotNull
     private HederaNetwork network = HederaNetwork.TESTNET;
 
+    // Contains the user defined properties to pass to the consensus node library
     @Getter
     @NotNull
-    private Map<String, String> properties = Map.of(
-            "contracts.chainId",
-            chainIdBytes32().toBigInteger().toString(),
-            "contracts.maxRefundPercentOfGasLimit",
-            String.valueOf(maxGasRefundPercentage()),
-            "contracts.sidecars",
-            "");
+    private Map<String, String> properties = new HashMap<>();
 
+    // Contains the default properties merged with the user defined properties to pass to the consensus node library
     @Getter(lazy = true)
     private final Map<String, String> transactionProperties = buildTransactionProperties();
 
@@ -335,11 +331,15 @@ public class MirrorNodeEvmProperties implements EvmProperties {
     }
 
     private Map<String, String> buildTransactionProperties() {
-        var mirrorNodeProperties = new HashMap<>(properties);
-        mirrorNodeProperties.put("contracts.evm.version", "v" + evmVersion.major() + "." + evmVersion.minor());
-        mirrorNodeProperties.put(
-                "ledger.id", Bytes.wrap(getNetwork().getLedgerId()).toHexString());
-        return Collections.unmodifiableMap(mirrorNodeProperties);
+        var props = new HashMap<String, String>();
+        props.put("contracts.chainId", chainIdBytes32().toBigInteger().toString());
+        props.put("contracts.evm.version", "v" + evmVersion.major() + "." + evmVersion.minor());
+        props.put("contracts.maxRefundPercentOfGasLimit", String.valueOf(maxGasRefundPercentage()));
+        props.put("contracts.sidecars", "");
+        props.put("executor.maxSignedTxnSize", "262144");
+        props.put("ledger.id", Bytes.wrap(getNetwork().getLedgerId()).toHexString());
+        props.putAll(properties); // Allow user defined properties to override the defaults
+        return Collections.unmodifiableMap(props);
     }
 
     @Getter

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/SystemFileLoader.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/SystemFileLoader.java
@@ -22,7 +22,6 @@ import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.node.app.service.file.impl.schemas.V0490FileSchema;
 import com.hedera.node.config.data.EntitiesConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.state.lifecycle.info.NetworkInfo;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Named;
@@ -38,7 +37,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SystemFileLoader {
 
-    private final NetworkInfo networkInfo;
     private final MirrorNodeEvmProperties properties;
     private final V0490FileSchema fileSchema = new V0490FileSchema();
 
@@ -53,8 +51,8 @@ public class SystemFileLoader {
         var configuration = properties.getVersionedConfiguration();
 
         var files = List.of(
-                load(101, fileSchema.genesisAddressBook(networkInfo)),
-                load(102, fileSchema.genesisNodeDetails(networkInfo)),
+                load(101, Bytes.EMPTY), // Requires a node store but these aren't used by contracts so omit
+                load(102, Bytes.EMPTY),
                 load(111, fileSchema.genesisFeeSchedules(configuration)),
                 load(112, fileSchema.genesisExchangeRates(configuration)),
                 load(121, fileSchema.genesisNetworkProperties(configuration)),

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/BlockInfoSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/BlockInfoSingleton.java
@@ -19,27 +19,15 @@ package com.hedera.mirror.web3.state.singleton;
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.BLOCK_INFO_STATE_KEY;
 
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
-import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.web3.common.ContractCallContext;
-import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
-import com.hedera.mirror.web3.repository.RecordFileRepository;
 import com.hedera.mirror.web3.state.Utils;
-import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import jakarta.inject.Named;
-import java.nio.ByteBuffer;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import org.apache.commons.codec.binary.Hex;
 
 @Named
 @RequiredArgsConstructor
 public class BlockInfoSingleton implements SingletonState<BlockInfo> {
-
-    private static final int HASH_SIZE = 48;
-
-    private final MirrorNodeEvmProperties properties;
-    private final RecordFileRepository recordFileRepository;
 
     @Override
     public String getKey() {
@@ -49,45 +37,16 @@ public class BlockInfoSingleton implements SingletonState<BlockInfo> {
     @Override
     public BlockInfo get() {
         var recordFile = ContractCallContext.get().getRecordFile();
-        var blockHashes = getBlockHashes(recordFile);
         var startTimestamp = Utils.convertToTimestamp(recordFile.getConsensusStart());
         var endTimestamp = Utils.convertToTimestamp(recordFile.getConsensusEnd());
 
         return BlockInfo.newBuilder()
-                .blockHashes(Bytes.wrap(blockHashes))
+                .blockHashes(Bytes.EMPTY)
                 .consTimeOfLastHandledTxn(endTimestamp)
                 .firstConsTimeOfCurrentBlock(endTimestamp)
                 .firstConsTimeOfLastBlock(startTimestamp)
-                .lastBlockNumber(recordFile.getIndex())
+                .lastBlockNumber(recordFile.getIndex() - 1) // Library internally increments last by one for current
                 .migrationRecordsStreamed(true)
                 .build();
-    }
-
-    /**
-     * Loads the last 256 block hashes from the database into a single byte array. This is inefficient to do for every
-     * request when only a few requests may have a BLOCKHASH operation. This method is temporary until the EVM library
-     * supports custom implementations for operations that don't need to use the BlockInfo singleton.
-     */
-    @SneakyThrows
-    private byte[] getBlockHashes(RecordFile recordFile) {
-        if (recordFile.getIndex() == 0) {
-            return Hex.decodeHex(recordFile.getHash());
-        }
-
-        var config = properties.getVersionedConfiguration().getConfigData(BlockRecordStreamConfig.class);
-        int blockHashCount = config.numOfBlockHashesInState();
-        long endIndex = recordFile.getIndex() - 1; // Optimization: Don't reload the record file from the context
-        long startIndex = Math.max(0L, endIndex - blockHashCount + 1);
-
-        var blocks = recordFileRepository.findByIndexRange(startIndex, endIndex);
-        blocks.add(recordFile);
-        var buffer = ByteBuffer.allocate(blocks.size() * HASH_SIZE);
-
-        for (var block : blocks) {
-            var hash = Hex.decodeHex(block.getHash());
-            buffer.put(hash);
-        }
-
-        return buffer.array();
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/RunningHashesSingleton.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/singleton/RunningHashesSingleton.java
@@ -22,10 +22,8 @@ import com.hedera.hapi.node.state.blockrecords.RunningHashes;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import jakarta.inject.Named;
-import lombok.RequiredArgsConstructor;
 
 @Named
-@RequiredArgsConstructor
 public class RunningHashesSingleton implements SingletonState<RunningHashes> {
 
     @Override
@@ -37,7 +35,10 @@ public class RunningHashesSingleton implements SingletonState<RunningHashes> {
     public RunningHashes get() {
         var recordFile = ContractCallContext.get().getRecordFile();
         return RunningHashes.newBuilder()
-                .runningHash(Bytes.fromHex(recordFile.getHash()))
+                .runningHash(Bytes.EMPTY)
+                .nMinus1RunningHash(Bytes.EMPTY)
+                .nMinus2RunningHash(Bytes.EMPTY)
+                .nMinus3RunningHash(Bytes.fromHex(recordFile.getHash())) // Used by prevrandao
                 .build();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/operations/MirrorBlockHashOperationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/operations/MirrorBlockHashOperationTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.mirror.web3.evm.contracts.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.hedera.mirror.common.domain.DomainBuilder;
+import com.hedera.mirror.web3.ContextExtension;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.repository.RecordFileRepository;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.evm.fluent.SimpleBlockValues;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({ContextExtension.class, MockitoExtension.class})
+class MirrorBlockHashOperationTest {
+
+    private final DomainBuilder domainBuilder = new DomainBuilder();
+
+    @Mock
+    private MessageFrame messageFrame;
+
+    @Mock
+    private GasCalculator gasCalculator;
+
+    @Mock
+    private RecordFileRepository recordFileRepository;
+
+    @InjectMocks
+    private MirrorBlockHashOperation operation;
+
+    @Test
+    void invalid() {
+        // Given
+        given(messageFrame.popStackItem()).willReturn(Bytes.of(1, 1, 1, 1, 1, 1, 1, 1, 1));
+
+        // When
+        var result = operation.executeFixedCostOperation(messageFrame, null);
+
+        // Then
+        assertThat(result)
+                .isNotNull()
+                .extracting(OperationResult::getHaltReason)
+                .isNull();
+        verify(messageFrame).pushStackItem(UInt256.ZERO);
+    }
+
+    @Test
+    void negative() {
+        // Given
+        var blockValues = new SimpleBlockValues();
+        blockValues.setNumber(-1L);
+        given(messageFrame.popStackItem()).willReturn(Bytes.ofUnsignedLong(1L));
+        given(messageFrame.getBlockValues()).willReturn(blockValues);
+
+        // When
+        var result = operation.executeFixedCostOperation(messageFrame, null);
+
+        // Then
+        assertThat(result)
+                .isNotNull()
+                .extracting(OperationResult::getHaltReason)
+                .isNull();
+        verify(messageFrame).pushStackItem(UInt256.ZERO);
+    }
+
+    @Test
+    void future() {
+        // Given
+        var blockValues = new SimpleBlockValues();
+        blockValues.setNumber(1L);
+        given(messageFrame.popStackItem()).willReturn(Bytes.ofUnsignedLong(blockValues.getNumber() + 1));
+        given(messageFrame.getBlockValues()).willReturn(blockValues);
+
+        // When
+        var result = operation.executeFixedCostOperation(messageFrame, null);
+
+        // Then
+        assertThat(result)
+                .isNotNull()
+                .extracting(OperationResult::getHaltReason)
+                .isNull();
+        verify(messageFrame).pushStackItem(UInt256.ZERO);
+    }
+
+    @Test
+    void current() {
+        // Given
+        var recordFile = domainBuilder.recordFile().get();
+        ContractCallContext.get().setRecordFile(recordFile);
+        var blockValues = new SimpleBlockValues();
+        blockValues.setNumber(recordFile.getIndex());
+        given(messageFrame.popStackItem()).willReturn(Bytes.ofUnsignedLong(recordFile.getIndex()));
+        given(messageFrame.getBlockValues()).willReturn(blockValues);
+
+        // When
+        var result = operation.executeFixedCostOperation(messageFrame, null);
+
+        // Then
+        assertThat(result)
+                .isNotNull()
+                .extracting(OperationResult::getHaltReason)
+                .isNull();
+        verify(messageFrame)
+                .pushStackItem(Hash.fromHexString(recordFile.getHash().substring(0, 64)));
+    }
+
+    @Test
+    void past() {
+        // Given
+        var recordFile = domainBuilder.recordFile().get();
+        var blockValues = new SimpleBlockValues();
+        blockValues.setNumber(recordFile.getIndex() + 1);
+        given(messageFrame.popStackItem()).willReturn(Bytes.ofUnsignedLong(recordFile.getIndex()));
+        given(messageFrame.getBlockValues()).willReturn(blockValues);
+        given(recordFileRepository.findByIndex(recordFile.getIndex())).willReturn(Optional.of(recordFile));
+
+        // When
+        var result = operation.executeFixedCostOperation(messageFrame, null);
+
+        // Then
+        assertThat(result)
+                .isNotNull()
+                .extracting(OperationResult::getHaltReason)
+                .isNull();
+        verify(messageFrame)
+                .pushStackItem(Hash.fromHexString(recordFile.getHash().substring(0, 64)));
+    }
+
+    @Test
+    void notFound() {
+        // Given
+        var blockValues = new SimpleBlockValues();
+        blockValues.setNumber(1);
+        given(messageFrame.popStackItem()).willReturn(Bytes.ofUnsignedLong(0));
+        given(messageFrame.getBlockValues()).willReturn(blockValues);
+        given(recordFileRepository.findByIndex(0)).willReturn(Optional.empty());
+
+        // When
+        var result = operation.executeFixedCostOperation(messageFrame, null);
+
+        // Then
+        assertThat(result)
+                .isNotNull()
+                .extracting(OperationResult::getHaltReason)
+                .isNull();
+        verify(messageFrame).pushStackItem(Hash.ZERO);
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesIntegrationTest.java
@@ -32,10 +32,7 @@ import org.junit.jupiter.api.Test;
 class MirrorNodeEvmPropertiesIntegrationTest extends Web3IntegrationTest {
 
     private static final String DOT_SEPARATOR = ".";
-    private static final String CHAIN_ID = "chainId";
     private static final String CONTRACTS_CONFIG = "contracts";
-    private static final String CHAIN_ID_KEY_CONFIG = CONTRACTS_CONFIG + DOT_SEPARATOR + CHAIN_ID;
-    private static final Map<String, String> YAML_PROPERTIES = Map.of(CHAIN_ID_KEY_CONFIG, "297");
     private static final String MAX_GAS_REFUND_PERCENTAGE = "maxRefundPercentOfGasLimit";
     private static final String MAX_GAS_REFUND_PERCENTAGE_KEY_CONFIG =
             CONTRACTS_CONFIG + DOT_SEPARATOR + MAX_GAS_REFUND_PERCENTAGE;
@@ -62,9 +59,7 @@ class MirrorNodeEvmPropertiesIntegrationTest extends Web3IntegrationTest {
         assertThat(modularizedProperties)
                 .isNotEmpty()
                 // override from yaml
-                .doesNotContainEntry(CHAIN_ID_KEY_CONFIG, "296")
-                .containsEntry(MAX_GAS_REFUND_PERCENTAGE_KEY_CONFIG, "100")
-                .containsAllEntriesOf(YAML_PROPERTIES);
+                .containsEntry(MAX_GAS_REFUND_PERCENTAGE_KEY_CONFIG, "100");
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -103,11 +103,8 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
 
     @BeforeEach
     protected void setup() {
-        // Change this to not be epoch once services fixes config updates for non-genesis flow
-        genesisRecordFile = domainBuilder
-                .recordFile()
-                .customize(f -> f.consensusEnd(0L).consensusStart(0L).index(0L))
-                .persist();
+        genesisRecordFile =
+                domainBuilder.recordFile().customize(f -> f.index(0L)).persist();
         treasuryEntity = domainBuilder
                 .entity()
                 .customize(e -> e.id(2L).num(2L).balance(5000000000000000000L))
@@ -221,7 +218,8 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     }
 
     /**
-     *  Persists entity of type token in the entity db table. Entity table contains properties common for all entities on the network (tokens, accounts, smart contracts, topics)
+     * Persists entity of type token in the entity db table. Entity table contains properties common for all entities on
+     * the network (tokens, accounts, smart contracts, topics)
      */
     protected Entity tokenEntityPersist() {
         return domainBuilder.entity().customize(e -> e.type(EntityType.TOKEN)).persist();
@@ -229,7 +227,8 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
 
     /**
      * Persists fungible token in the token db table.
-     * @param tokenEntity The entity from the entity db table related to the token
+     *
+     * @param tokenEntity     The entity from the entity db table related to the token
      * @param treasuryAccount The account holding the initial token supply
      */
     protected Token fungibleTokenPersist(Entity tokenEntity, Entity treasuryAccount) {
@@ -243,6 +242,7 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
 
     /**
      * Persists non-fungible token in the token db table.
+     *
      * @param tokenEntity The entity from the entity db table related to the token
      */
     protected Token nonFungibleTokenPersist(Entity tokenEntity) {
@@ -262,11 +262,14 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     }
 
     /**
-     * The method creates token allowance, which defines the amount of tokens that the owner allows another account (spender) to use on its behalf.
+     * The method creates token allowance, which defines the amount of tokens that the owner allows another account
+     * (spender) to use on its behalf.
+     *
      * @param amountGranted - initial amount of tokens that the spender is allowed to use on owner's behalf
-     * @param tokenEntity - the token entity the allowance is created for
-     * @param owner - the owner of the token amount that the allowance is created for
-     * @param spenderId - the spender id (another user's id or contract id) that is allowed to spend amountGranted of tokenEntity on owner's behalf
+     * @param tokenEntity   - the token entity the allowance is created for
+     * @param owner         - the owner of the token amount that the allowance is created for
+     * @param spenderId     - the spender id (another user's id or contract id) that is allowed to spend amountGranted
+     *                      of tokenEntity on owner's behalf
      * @return TokenAllowance object that is persisted to the database
      */
     protected TokenAllowance tokenAllowancePersist(
@@ -282,12 +285,13 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     }
 
     /**
-     * This method creates nft allowance for all instances of a specific token type (approvedForAll).
-     * The allowance allows the spender to transfer NFTs on the owner's behalf.
-     * @param token the NFT token for which the allowance is created
-     * @param owner the account owning the NFT
+     * This method creates nft allowance for all instances of a specific token type (approvedForAll). The allowance
+     * allows the spender to transfer NFTs on the owner's behalf.
+     *
+     * @param token   the NFT token for which the allowance is created
+     * @param owner   the account owning the NFT
      * @param spender the account allowed to transfer the NFT on owner's behalf
-     * @param payer the account paying for the allowance creation
+     * @param payer   the account paying for the allowance creation
      * @return NftAllowance object that is persisted to the database
      */
     protected NftAllowance nftAllowancePersist(Token token, Entity owner, Entity spender, Entity payer) {
@@ -332,12 +336,13 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
     }
 
     /**
-     * Creates a non-fungible token instance with a specific serial number(a record in the nft table is persisted).
-     * The instance is tied to a specific token in the token db table.
-     * @param token the token entity that the nft instance is linked to by tokenId
+     * Creates a non-fungible token instance with a specific serial number(a record in the nft table is persisted). The
+     * instance is tied to a specific token in the token db table.
+     *
+     * @param token           the token entity that the nft instance is linked to by tokenId
      * @param nftSerialNumber the unique serial number of the nft instance
-     * @param ownerId the id of the account currently holding the nft
-     * @param spenderId id of the approved spender of the nft
+     * @param ownerId         the id of the account currently holding the nft
+     * @param spenderId       id of the approved spender of the nft
      */
     protected Nft nonFungibleTokenInstancePersist(
             final Token token, Long nftSerialNumber, final EntityId ownerId, final EntityId spenderId) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallNativePrecompileTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallNativePrecompileTest.java
@@ -41,11 +41,7 @@ class ContractCallNativePrecompileTest extends Web3IntegrationTest {
 
     @BeforeEach
     void setup() {
-        // Change this to not be epoch once services fixes config updates for non-genesis flow
-        domainBuilder
-                .recordFile()
-                .customize(f -> f.consensusEnd(0L).consensusStart(0L).index(0L))
-                .persist();
+        domainBuilder.recordFile().customize(f -> f.index(0L)).persist();
         domainBuilder.entity().customize(e -> e.id(98L).num(98L)).persist();
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/SystemFileLoaderTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/SystemFileLoaderTest.java
@@ -28,8 +28,6 @@ import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.hapi.node.transaction.ThrottleDefinitions;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
-import com.hedera.mirror.web3.state.components.NetworkInfoImpl;
-import com.swirlds.state.lifecycle.info.NetworkInfo;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -37,8 +35,7 @@ import org.junit.jupiter.api.Test;
 
 class SystemFileLoaderTest {
 
-    private final NetworkInfo networkInfo = new NetworkInfoImpl();
-    private final SystemFileLoader systemFileLoader = new SystemFileLoader(networkInfo, new MirrorNodeEvmProperties());
+    private final SystemFileLoader systemFileLoader = new SystemFileLoader(new MirrorNodeEvmProperties());
 
     @Test
     void loadNonSystemFile() {
@@ -52,9 +49,7 @@ class SystemFileLoaderTest {
         var file = systemFileLoader.load(fileId);
         assertFile(file, fileId);
         var nodeAddressBook = NodeAddressBook.PROTOBUF.parse(file.contents());
-        assertThat(nodeAddressBook).isNotNull().isNotEqualTo(NodeAddressBook.DEFAULT);
-        assertThat(nodeAddressBook.nodeAddress())
-                .hasSize(networkInfo.addressBook().size());
+        assertThat(nodeAddressBook).isNotNull().isEqualTo(NodeAddressBook.DEFAULT);
     }
 
     @Test
@@ -63,9 +58,7 @@ class SystemFileLoaderTest {
         var file = systemFileLoader.load(fileId);
         assertFile(file, fileId);
         var nodeAddressBook = NodeAddressBook.PROTOBUF.parse(file.contents());
-        assertThat(nodeAddressBook).isNotNull().isNotEqualTo(NodeAddressBook.DEFAULT);
-        assertThat(nodeAddressBook.nodeAddress())
-                .hasSize(networkInfo.addressBook().size());
+        assertThat(nodeAddressBook).isNotNull().isEqualTo(NodeAddressBook.DEFAULT);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/BlockInfoSingletonTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/BlockInfoSingletonTest.java
@@ -18,87 +18,35 @@ package com.hedera.mirror.web3.state.singleton;
 
 import static com.hedera.mirror.web3.state.Utils.convertToTimestamp;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
 import com.hedera.mirror.common.domain.DomainBuilder;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
+import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.common.ContractCallContext;
-import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
-import com.hedera.mirror.web3.repository.RecordFileRepository;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(ContextExtension.class)
 class BlockInfoSingletonTest {
 
+    private final BlockInfoSingleton blockInfoSingleton = new BlockInfoSingleton();
     private final DomainBuilder domainBuilder = new DomainBuilder();
-    private final MirrorNodeEvmProperties properties = new MirrorNodeEvmProperties();
-
-    private BlockInfoSingleton blockInfoSingleton;
-
-    @Mock
-    private RecordFileRepository recordFileRepository;
-
-    @BeforeEach
-    void setup() {
-        properties.setProperties(Map.of("hedera.recordStream.numOfBlockHashesInState", "2"));
-        blockInfoSingleton = new BlockInfoSingleton(properties, recordFileRepository);
-    }
-
-    @ValueSource(longs = {0, 1, 2})
-    @ParameterizedTest
-    void get(long startIndex) {
-        ContractCallContext.run(context -> {
-            var recordFile1 = recordFile(startIndex);
-            var recordFile2 = recordFile(startIndex + 1L);
-            var recordFile3 = recordFile(startIndex + 2L);
-            var recordFiles = new ArrayList<>(List.of(recordFile1, recordFile2));
-
-            when(recordFileRepository.findByIndexRange(startIndex, startIndex + 1))
-                    .thenReturn(recordFiles);
-            context.setRecordFile(recordFile3);
-
-            assertThat(blockInfoSingleton.get())
-                    .isEqualTo(BlockInfo.newBuilder()
-                            .blockHashes(Bytes.fromHex(
-                                    recordFile1.getHash() + recordFile2.getHash() + recordFile3.getHash()))
-                            .consTimeOfLastHandledTxn(convertToTimestamp(recordFile3.getConsensusEnd()))
-                            .firstConsTimeOfCurrentBlock(convertToTimestamp(recordFile3.getConsensusEnd()))
-                            .firstConsTimeOfLastBlock(convertToTimestamp(recordFile3.getConsensusStart()))
-                            .lastBlockNumber(recordFile3.getIndex())
-                            .migrationRecordsStreamed(true)
-                            .build());
-            return null;
-        });
-    }
+    private final RecordFile recordFile = domainBuilder.recordFile().get();
 
     @Test
-    void getGenesis() {
-        ContractCallContext.run(context -> {
-            var recordFile = recordFile(0L);
-            context.setRecordFile(recordFile);
-
-            assertThat(blockInfoSingleton.get())
-                    .isEqualTo(BlockInfo.newBuilder()
-                            .blockHashes(Bytes.fromHex(recordFile.getHash()))
-                            .consTimeOfLastHandledTxn(convertToTimestamp(recordFile.getConsensusEnd()))
-                            .firstConsTimeOfCurrentBlock(convertToTimestamp(recordFile.getConsensusEnd()))
-                            .firstConsTimeOfLastBlock(convertToTimestamp(recordFile.getConsensusStart()))
-                            .lastBlockNumber(recordFile.getIndex())
-                            .migrationRecordsStreamed(true)
-                            .build());
-            return null;
-        });
+    void get() {
+        ContractCallContext.get().setRecordFile(recordFile);
+        assertThat(blockInfoSingleton.get())
+                .isEqualTo(BlockInfo.newBuilder()
+                        .blockHashes(Bytes.EMPTY)
+                        .consTimeOfLastHandledTxn(convertToTimestamp(recordFile.getConsensusEnd()))
+                        .firstConsTimeOfCurrentBlock(convertToTimestamp(recordFile.getConsensusEnd()))
+                        .firstConsTimeOfLastBlock(convertToTimestamp(recordFile.getConsensusStart()))
+                        .lastBlockNumber(recordFile.getIndex() - 1)
+                        .migrationRecordsStreamed(true)
+                        .build());
     }
 
     @Test
@@ -108,16 +56,8 @@ class BlockInfoSingletonTest {
 
     @Test
     void set() {
-        ContractCallContext.run(context -> {
-            var recordFile = recordFile(0L);
-            context.setRecordFile(recordFile);
-            blockInfoSingleton.set(BlockInfo.DEFAULT);
-            assertThat(blockInfoSingleton.get()).isNotEqualTo(BlockInfo.DEFAULT);
-            return null;
-        });
-    }
-
-    private RecordFile recordFile(long index) {
-        return domainBuilder.recordFile().customize(r -> r.index(index)).get();
+        ContractCallContext.get().setRecordFile(recordFile);
+        blockInfoSingleton.set(BlockInfo.DEFAULT);
+        assertThat(blockInfoSingleton.get()).isNotEqualTo(BlockInfo.DEFAULT);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/RunningHashesSingletonTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/singleton/RunningHashesSingletonTest.java
@@ -35,9 +35,10 @@ class RunningHashesSingletonTest {
             var recordFile = domainBuilder.recordFile().get();
             context.setRecordFile(recordFile);
             assertThat(runningHashesSingleton.get())
-                    .isEqualTo(RunningHashes.newBuilder()
-                            .runningHash(Bytes.fromHex(recordFile.getHash()))
-                            .build());
+                    .returns(Bytes.EMPTY, RunningHashes::runningHash)
+                    .returns(Bytes.EMPTY, RunningHashes::nMinus1RunningHash)
+                    .returns(Bytes.EMPTY, RunningHashes::nMinus2RunningHash)
+                    .returns(Bytes.fromHex(recordFile.getHash()), RunningHashes::nMinus3RunningHash);
             return null;
         });
     }

--- a/hedera-mirror-web3/src/test/resources/config/application.yml
+++ b/hedera-mirror-web3/src/test/resources/config/application.yml
@@ -3,7 +3,6 @@ hedera:
     web3:
       evm:
         properties:
-          contracts.chainId: "297"
           contracts.maxRefundPercentOfGasLimit: "100"
         evm_versions:
           0: 0.30.0


### PR DESCRIPTION
**Description**:

* Bump Hedera app library from 0.58.3 to 0.58.4
* Add a custom `MirrorBlockHashOperation` to fix latest block and not require loading last 256 block hashes
* Add a `ModularizedOperation` interface and inject all implementations into the `TransactionExecutor`
* Change executor properties to allow user defined properties to override defaults
* Change tests to not use epoch for genesis block after upstream config override fix
* Fix `CHAINID` opcode by lazily setting `contracts.chainId` in `buildTransactionProperties` so that it can be changed later by a custom network being set from config
* Fix `PREVRANDAO` opcode by populating `RunningHashes.nMinus3RunningHash` for entropy

**Related issue(s)**:

Fixes #10079

**Notes for reviewer**:

Before
`3359 tests completed, 265 failed, 6 skipped`

After
`3362 tests completed, 258 failed, 6 skipped`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
