### PR TITLE
Remove file upload on contract create and use `maxSignedTxnSize` property

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
@@ -16,9 +16,6 @@
 
 package com.hedera.mirror.web3.common;
 
-import com.hedera.hapi.node.contract.ContractCreateTransactionBody;
-import com.hedera.hapi.node.file.FileCreateTransactionBody;
-import com.hedera.hapi.node.state.file.File;
 import com.hedera.mirror.common.domain.contract.ContractAction;
 import com.hedera.mirror.common.domain.transaction.RecordFile;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.Opcode;
@@ -27,7 +24,6 @@ import com.hedera.mirror.web3.evm.contracts.execution.traceability.OpcodeTracerO
 import com.hedera.mirror.web3.evm.store.CachingStateFrame;
 import com.hedera.mirror.web3.evm.store.StackedStateFrames;
 import com.hedera.mirror.web3.service.model.CallServiceParameters;
-import com.hedera.mirror.web3.state.keyvalue.FileReadableKVState;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import java.util.ArrayList;
 import java.util.EmptyStackException;
@@ -82,20 +78,6 @@ public class ContractCallContext {
     @Setter
     private Optional<Long> timestamp = Optional.empty();
 
-    /**
-     * The TransactionExecutor from the modularized services integration deploys contracts in 2 steps:
-     * <p>
-     * 1. The initcode is uploaded and saved as a file using a {@link FileCreateTransactionBody}. 2. The returned file
-     * id from step 1 is then passed to a {@link ContractCreateTransactionBody}. Each step performs a separate
-     * transaction. For step 2 even if we pass the correct file id, since the mirror node data is readonly, the
-     * {@link FileReadableKVState} is not able to populate the contract's bytecode from the DB since it was never
-     * explicitly persisted in the DB.
-     * <p>
-     * This is the function of the field "file" to hold temporary the bytecode and the fileId during contract deploy.
-     */
-    @Setter
-    private Optional<File> file = Optional.empty();
-
     private ContractCallContext() {}
 
     public static ContractCallContext get() {
@@ -108,7 +90,6 @@ public class ContractCallContext {
 
     public void reset() {
         stack = stackBase;
-        file = Optional.empty();
     }
 
     public int getStackHeight() {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -22,6 +22,7 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_3
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_38;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_46;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_50;
+import static com.hedera.mirror.web3.state.Utils.MAX_SIGNED_TXN_SIZE;
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static com.swirlds.state.lifecycle.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
 
@@ -184,7 +185,9 @@ public class MirrorNodeEvmProperties implements EvmProperties {
             "contracts.maxRefundPercentOfGasLimit",
             String.valueOf(maxGasRefundPercentage()),
             "contracts.sidecars",
-            "");
+            "",
+            "executor.maxSignedTxnSize",
+            String.valueOf(MAX_SIGNED_TXN_SIZE));
 
     @Getter(lazy = true)
     private final Map<String, String> transactionProperties = buildTransactionProperties();

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -22,7 +22,6 @@ import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_3
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_38;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_46;
 import static com.hedera.mirror.web3.evm.config.EvmConfiguration.EVM_VERSION_0_50;
-import static com.hedera.mirror.web3.state.Utils.MAX_SIGNED_TXN_SIZE;
 import static com.swirlds.common.utility.CommonUtils.unhex;
 import static com.swirlds.state.lifecycle.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
 
@@ -185,9 +184,7 @@ public class MirrorNodeEvmProperties implements EvmProperties {
             "contracts.maxRefundPercentOfGasLimit",
             String.valueOf(maxGasRefundPercentage()),
             "contracts.sidecars",
-            "",
-            "executor.maxSignedTxnSize",
-            String.valueOf(MAX_SIGNED_TXN_SIZE));
+            "");
 
     @Getter(lazy = true)
     private final Map<String, String> transactionProperties = buildTransactionProperties();
@@ -342,6 +339,12 @@ public class MirrorNodeEvmProperties implements EvmProperties {
         mirrorNodeProperties.put("contracts.evm.version", "v" + evmVersion.major() + "." + evmVersion.minor());
         mirrorNodeProperties.put(
                 "ledger.id", Bytes.wrap(getNetwork().getLedgerId()).toHexString());
+        // The configured data in the request is currently 128 KB. In services, we have a property for the
+        // max signed transaction size. We put 1 KB more here to have a buffer because the transaction has other
+        // fields (apart from the data) that will increase the transaction size.
+        mirrorNodeProperties.put(
+                "executor.maxSignedTxnSize",
+                String.valueOf(maxDataSize.toBytes() + DataSize.ofKilobytes(1).toBytes()));
         return Collections.unmodifiableMap(mirrorNodeProperties);
     }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
 import org.hyperledger.besu.datatypes.Address;
-import org.springframework.util.unit.DataSize;
 
 @CustomLog
 @UtilityClass
@@ -35,10 +34,6 @@ public class Utils {
     public static final int EVM_ADDRESS_LEN = 20;
     /* A placeholder to store the 12-byte of zeros prefix that marks an EVM address as a "mirror" address. */
     private static final byte[] MIRROR_PREFIX = new byte[12];
-    // The configured data in the request is currently 128 KB. In services, we have a property for the
-    // max signed transaction size. We put 1 KB more here to have a buffer because the transaction has other
-    // fields (apart from the data) that will increase the transaction size.
-    public static final long MAX_SIGNED_TXN_SIZE = DataSize.ofKilobytes(129).toBytes();
 
     public static Key parseKey(final byte[] keyBytes) {
         try {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/Utils.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import lombok.CustomLog;
 import lombok.experimental.UtilityClass;
 import org.hyperledger.besu.datatypes.Address;
+import org.springframework.util.unit.DataSize;
 
 @CustomLog
 @UtilityClass
@@ -34,6 +35,10 @@ public class Utils {
     public static final int EVM_ADDRESS_LEN = 20;
     /* A placeholder to store the 12-byte of zeros prefix that marks an EVM address as a "mirror" address. */
     private static final byte[] MIRROR_PREFIX = new byte[12];
+    // The configured data in the request is currently 128 KB. In services, we have a property for the
+    // max signed transaction size. We put 1 KB more here to have a buffer because the transaction has other
+    // fields (apart from the data) that will increase the transaction size.
+    public static final long MAX_SIGNED_TXN_SIZE = DataSize.ofKilobytes(129).toBytes();
 
     public static Key parseKey(final byte[] keyBytes) {
         try {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/FileReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/FileReadableKVState.java
@@ -64,12 +64,6 @@ public class FileReadableKVState extends AbstractReadableKVState<FileID, File> {
         final var timestamp = ContractCallContext.get().getTimestamp();
         final var fileEntityId = toEntityId(key);
         final var fileId = fileEntityId.getId();
-        final var contextFile = ContractCallContext.get().getFile();
-
-        // If we are in a contract create case, the fileID and the init bytecode are in the ContractCallContext.
-        if (contextFile.isPresent() && contextFile.get().fileId().equals(key)) {
-            return contextFile.get();
-        }
 
         return timestamp
                 .map(t -> fileDataRepository.getFileAtTimestamp(fileId, t))

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesIntegrationTest.java
@@ -71,8 +71,6 @@ class MirrorNodeEvmPropertiesIntegrationTest extends Web3IntegrationTest {
     @Test
     void verifyUpstreamPropertiesExist() {
         Set<String> propertyKeys = properties.getProperties().keySet();
-        // maxSignedTxnSize property does not have a config file, so it is verified here.
-        assertThat(propertyKeys).contains(TransactionExecutors.MAX_SIGNED_TXN_SIZE_PROPERTY);
         propertyKeys.stream()
                 .filter(configKey -> !configKey.equals(TransactionExecutors.MAX_SIGNED_TXN_SIZE_PROPERTY))
                 .forEach(configKey ->

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesIntegrationTest.java
@@ -35,7 +35,6 @@ class MirrorNodeEvmPropertiesIntegrationTest extends Web3IntegrationTest {
     private static final String DOT_SEPARATOR = ".";
     private static final String CHAIN_ID = "chainId";
     private static final String CONTRACTS_CONFIG = "contracts";
-    private static final String EXECUTOR_CONFIG = "executor";
     private static final String CHAIN_ID_KEY_CONFIG = CONTRACTS_CONFIG + DOT_SEPARATOR + CHAIN_ID;
     private static final Map<String, String> YAML_PROPERTIES = Map.of(CHAIN_ID_KEY_CONFIG, "297");
     private static final String MAX_GAS_REFUND_PERCENTAGE = "maxRefundPercentOfGasLimit";
@@ -73,8 +72,7 @@ class MirrorNodeEvmPropertiesIntegrationTest extends Web3IntegrationTest {
     void verifyUpstreamPropertiesExist() {
         Set<String> propertyKeys = properties.getProperties().keySet();
         // maxSignedTxnSize property does not have a config file, so it is verified here.
-        assertThat(propertyKeys.contains(TransactionExecutors.MAX_SIGNED_TXN_SIZE_PROPERTY))
-                .isTrue();
+        assertThat(propertyKeys).contains(TransactionExecutors.MAX_SIGNED_TXN_SIZE_PROPERTY);
         propertyKeys.stream()
                 .filter(configKey -> !configKey.equals(TransactionExecutors.MAX_SIGNED_TXN_SIZE_PROPERTY))
                 .forEach(configKey ->

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesIntegrationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmPropertiesIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.mirror.web3.Web3IntegrationTest;
+import com.hedera.node.app.workflows.standalone.TransactionExecutors;
 import com.hedera.node.config.data.ContractsConfig;
 import com.swirlds.config.api.ConfigData;
 import java.lang.reflect.Field;
@@ -34,6 +35,7 @@ class MirrorNodeEvmPropertiesIntegrationTest extends Web3IntegrationTest {
     private static final String DOT_SEPARATOR = ".";
     private static final String CHAIN_ID = "chainId";
     private static final String CONTRACTS_CONFIG = "contracts";
+    private static final String EXECUTOR_CONFIG = "executor";
     private static final String CHAIN_ID_KEY_CONFIG = CONTRACTS_CONFIG + DOT_SEPARATOR + CHAIN_ID;
     private static final Map<String, String> YAML_PROPERTIES = Map.of(CHAIN_ID_KEY_CONFIG, "297");
     private static final String MAX_GAS_REFUND_PERCENTAGE = "maxRefundPercentOfGasLimit";
@@ -70,8 +72,13 @@ class MirrorNodeEvmPropertiesIntegrationTest extends Web3IntegrationTest {
     @Test
     void verifyUpstreamPropertiesExist() {
         Set<String> propertyKeys = properties.getProperties().keySet();
-        propertyKeys.forEach(
-                configKey -> assertThat(getContractsConfigKey(configKey)).isEqualTo(configKey));
+        // maxSignedTxnSize property does not have a config file, so it is verified here.
+        assertThat(propertyKeys.contains(TransactionExecutors.MAX_SIGNED_TXN_SIZE_PROPERTY))
+                .isTrue();
+        propertyKeys.stream()
+                .filter(configKey -> !configKey.equals(TransactionExecutors.MAX_SIGNED_TXN_SIZE_PROPERTY))
+                .forEach(configKey ->
+                        assertThat(getContractsConfigKey(configKey)).isEqualTo(configKey));
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -723,7 +723,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
     }
 
     @Test
-    void contractCreationWork() throws Exception {
+    void contractCreationWorks() throws Exception {
         // Given
         final var contract = testWeb3jService.deploy(EthCall::deploy);
         meterRegistry.clear();
@@ -736,6 +736,22 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         // concatenation of the string "state" twice, resulting in this value
         assertThat(result).isEqualTo("statestate");
         assertGasLimit(ETH_CALL, TRANSACTION_GAS_LIMIT);
+    }
+
+    @Test
+    void contractCreationWorksWithIncreasedMaxSignedTxnSize() {
+        // Given
+        testWeb3jService.setUseContractCallDeploy(true);
+
+        // When
+        // The size of the EthCall contract is bigger than 6 KB which is the default max size of init bytecode
+        // than can be deployed directly without uploading the contract as a file and then making a separate
+        // contract create transaction with a file ID. So, if this deploy works, we have verified that the
+        // property for increased maxSignedTxnSize works correctly.
+        var result = testWeb3jService.deploy(EthCall::deploy);
+
+        // Then
+        assertThat(result.getContractBinary()).isEqualTo(EthCall.BINARY);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/FileReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/FileReadableKVStateTest.java
@@ -21,8 +21,6 @@ import static com.hedera.services.utils.EntityIdUtils.toFileId;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.FileID;
@@ -195,30 +193,6 @@ class FileReadableKVStateTest {
         File result = fileReadableKVState.readFromDataSource(FILE_ID);
 
         assertThat(result).isEqualTo(FILE);
-    }
-
-    @Test
-    void readFromDataSourceWhenThereIsContext() {
-        when(ContractCallContext.get().getFile()).thenReturn(Optional.of(FILE));
-
-        File result = fileReadableKVState.readFromDataSource(FILE_ID);
-
-        assertThat(result)
-                .isEqualTo(
-                        File.newBuilder().fileId(FILE_ID).contents(initBytecode).build());
-        verify(fileDataRepository, times(0)).findById(anyLong());
-        verify(fileDataRepository, times(0)).getFileAtTimestamp(anyLong(), anyLong());
-    }
-
-    @Test
-    void readFromDataSourceWhenThereIsContextButDoesNotMatchTheKey() {
-        when(ContractCallContext.get().getFile()).thenReturn(Optional.of(FILE));
-
-        File result = fileReadableKVState.readFromDataSource(
-                FileID.newBuilder().fileNum(321L).build());
-
-        assertThat(result).isNull();
-        verify(fileDataRepository, times(1)).getFileAtTimestamp(anyLong(), anyLong());
     }
 
     @Test


### PR DESCRIPTION
**Description**:
After the hedera app dependency bump to 0.58.x we now have available the `maxSignedTxnSize` property. This allows us to set it to a value higher than 6KB that was the default one before. The configured callData size in the requests is currently 128 KB. The size of the call data + the additional transaction fields and signing increase the overall transaction size a little (about 50-200 bytes depending on the request), so value of `maxSignedTxnSize` is now set to 129KB to ensure that there is enough buffer and that the transaction will not be rejected in hedera app.

Setting this property allows us to:
1. Remove the checks in `TransactionExecutionService` for transaction size.
2. Remove the file upload logic for contract create when the transaction is bigger that 6KB.
3. Remove the `file` field in the `ContractCallContext` that saved the content of the uploaded file between the separate transaction executions (file uplaod & contract create).
4. Clean the `FileReadableKVState` from using the `file` field from the `ContractCallContext`.

This makes the overall code a lot cleaner and easier to understand.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/10031