### PR TITLE
Fix `ContractCallEvmCodesHistoricalTest`

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/config/ServicesConfiguration.java
@@ -129,7 +129,6 @@ import java.util.stream.Collectors;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -771,7 +770,7 @@ public class ServicesConfiguration {
     HederaExtCodeHashOperationV038 hederaExtCodeHashOperationV038(
             final GasCalculator gasCalculator,
             final Predicate<Address> strictSystemAccountDetector,
-            @Qualifier("addressValidator") BiPredicate<Address, MessageFrame> addressValidator,
+            final BiPredicate<Address, MessageFrame> addressValidator,
             final MirrorNodeEvmProperties mirrorNodeEvmProperties) {
         return new HederaExtCodeHashOperationV038(
                 gasCalculator, addressValidator, strictSystemAccountDetector, mirrorNodeEvmProperties);
@@ -779,9 +778,8 @@ public class ServicesConfiguration {
 
     @Bean
     HederaExtCodeHashOperation hederaExtCodeHashOperation(
-            final GasCalculator gasCalculator,
-            @Qualifier("preV38AddressValidator") BiPredicate<Address, MessageFrame> preV38AddressValidator) {
-        return new HederaExtCodeHashOperation(gasCalculator, preV38AddressValidator);
+            final GasCalculator gasCalculator, final BiPredicate<Address, MessageFrame> addressValidator) {
+        return new HederaExtCodeHashOperation(gasCalculator, addressValidator);
     }
 
     @Bean
@@ -791,11 +789,6 @@ public class ServicesConfiguration {
                 .collect(Collectors.toSet());
         return (address, frame) ->
                 precompiles.contains(address) || frame.getWorldUpdater().get(address) != null;
-    }
-
-    @Bean
-    BiPredicate<Address, MessageFrame> preV38AddressValidator() {
-        return (address, frame) -> frame.getWorldUpdater().get(address) != null;
     }
 
     @Bean

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/properties/MirrorNodeEvmProperties.java
@@ -336,6 +336,7 @@ public class MirrorNodeEvmProperties implements EvmProperties {
         props.put("contracts.evm.version", "v" + evmVersion.major() + "." + evmVersion.minor());
         props.put("contracts.maxRefundPercentOfGasLimit", String.valueOf(maxGasRefundPercentage()));
         props.put("contracts.sidecars", "");
+        props.put("contracts.throttle.throttleByGas", "false");
         // The configured data in the request is currently 128 KB. In services, we have a property for the
         // max signed transaction size. We put 1 KB more here to have a buffer because the transaction has other
         // fields (apart from the data) that will increase the transaction size.

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallEvmCodesHistoricalTest.java
@@ -53,11 +53,7 @@ public class ContractCallEvmCodesHistoricalTest extends AbstractContractCallServ
 
     @ParameterizedTest
     @CsvSource({
-        // function getCodeHash with parameter hedera system accounts or accounts that do not exist
-        // expected to revert with INVALID_SOLIDITY_ADDRESS
-        "0000000000000000000000000000000000000000000000000000000000000167",
-        "0000000000000000000000000000000000000000000000000000000000000168",
-        "0000000000000000000000000000000000000000000000000000000000000169",
+        // function getCodeHash with accounts that do not exist expected to revert with INVALID_SOLIDITY_ADDRESS
         "00000000000000000000000000000000000000000000000000000000000005ee",
         "00000000000000000000000000000000000000000000000000000000000005e4",
     })

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/web3j/TestWeb3jService.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/web3j/TestWeb3jService.java
@@ -270,7 +270,7 @@ public class TestWeb3jService implements Web3jService {
 
     @Override
     public void close() throws IOException {
-        throw new UnsupportedOperationException("Close");
+        reset();
     }
 
     protected ContractExecutionParameters serviceParametersForExecutionSingle(


### PR DESCRIPTION
**Description**:

* Change mono code to not revert with `INVALID_SOLIDITY_ADDRESS` for precompiles to match consensus node pre v0.38 behavior
* Disable throttling by library to avoid `CONSENSUS_GAS_EXHAUSTED` errors
* Fix `ContractCallEvmCodesHistoricalTest`
* Fix throwing `UnsupportedOperationException` during test shutdown

**Related issue(s)**:

Fixes #10078

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
