### PR TITLE
Fix the ERC historical tests

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
@@ -125,9 +125,7 @@ public class ContractCallContext {
      */
     public void initializeStackFrames(final StackedStateFrames stackedStateFrames) {
         if (stackedStateFrames != null) {
-            final var stateTimestamp = timestamp.isPresent()
-                    ? timestamp
-                    : Optional.ofNullable(recordFile).map(RecordFile::getConsensusEnd);
+            final var stateTimestamp = getTimestampOrDefaultFromRecordFile();
             stackBase = stack = stackedStateFrames.getInitializedStackBase(stateTimestamp);
         }
     }
@@ -141,5 +139,21 @@ public class ContractCallContext {
 
     public void incrementContractActionsCounter() {
         this.contractActionIndexOfCurrentFrame++;
+    }
+
+    /**
+     * Returns the set timestamp or the consensus end timestamp from the set record file only if we are in a historical context. If not - an empty optional is returned.
+     * */
+    public Optional<Long> getTimestamp() {
+        if (useHistorical()) {
+            return getTimestampOrDefaultFromRecordFile();
+        }
+        return Optional.empty();
+    }
+
+    private Optional<Long> getTimestampOrDefaultFromRecordFile() {
+        return timestamp.isPresent()
+                ? timestamp
+                : Optional.ofNullable(recordFile).map(RecordFile::getConsensusEnd);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceHistoricalTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceHistoricalTest.java
@@ -80,6 +80,8 @@ public abstract class AbstractContractCallServiceHistoricalTest extends Abstract
         return domainBuilder
                 .entity()
                 .customize(e -> e.type(EntityType.ACCOUNT)
+                        .evmAddress(null)
+                        .alias(null)
                         .deleted(false)
                         .balance(1_000_000_000_000L)
                         .timestampRange(timestampRange)

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -119,7 +119,6 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                                 treasuryEntity.getCreatedTimestamp(), treasuryEntity.toEntityId()))
                         .balance(treasuryEntity.getBalance()))
                 .persist();
-        testWeb3jService.reset();
     }
 
     @AfterEach


### PR DESCRIPTION
**Description**:
This PR fixes the setup for the ERC historical tests. Also, the timestamp from the context is now fetched differently:
- If there is timestamp set directly -> return this timestamp.
- If there isn't -> return the timestamp from the consensus end timestamp of the set record file in the context.
The above points are valid only if we are in a historical context. Otherwise -> return empty optional.

Note: Changing the timestamp fetch logic now enables us to read historical records correctly. However, there is a cache mechanism in `ReadableKVStateBase` and when multiple test suites are run it gets polluted and some tests sometimes fail and pass when run separately. This is a known issue but the change from this PR seems to make it appear more frequently. This is not a regression.

Fixes #10083 