### PR TITLE
Fix `INSUFFICIENT_GAS` issue in ContractCallServiceTests

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
@@ -51,17 +51,10 @@ public class BinaryGasEstimator {
             contractCallContext.reset();
 
             long mid = (hi + lo) / 2;
-            HederaEvmTransactionProcessingResult transactionResult = null;
-
-            try {
-                transactionResult = call.apply(mid);
-            } catch (Exception ignore) {
-            }
+            HederaEvmTransactionProcessingResult transactionResult = call.apply(mid);
             iterationsMade++;
 
-            boolean err = transactionResult == null
-                    || !transactionResult.isSuccessful()
-                    || transactionResult.getGasUsed() < 0;
+            boolean err = !transactionResult.isSuccessful() || transactionResult.getGasUsed() < 0;
             long gasUsed = err ? prevGasLimit : transactionResult.getGasUsed();
             totalGasUsed += gasUsed;
             if (err || gasUsed == 0) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
@@ -51,10 +51,17 @@ public class BinaryGasEstimator {
             contractCallContext.reset();
 
             long mid = (hi + lo) / 2;
-            HederaEvmTransactionProcessingResult transactionResult = call.apply(mid);
+            HederaEvmTransactionProcessingResult transactionResult = null;
+
+            try {
+                transactionResult = call.apply(mid);
+            } catch (Exception ignore) {
+            }
             iterationsMade++;
 
-            boolean err = !transactionResult.isSuccessful() || transactionResult.getGasUsed() < 0;
+            boolean err = transactionResult == null
+                    || !transactionResult.isSuccessful()
+                    || transactionResult.getGasUsed() < 0;
             long gasUsed = err ? prevGasLimit : transactionResult.getGasUsed();
             totalGasUsed += gasUsed;
             if (err || gasUsed == 0) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -129,7 +129,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
     }
 
     private static Stream<Arguments> ercPrecompileCallTypeArgumentsProvider() {
-        List<Long> gasLimits = List.of(15_000_000L, 30_000L);
+        List<Long> gasLimits = List.of(15_000_000L, 34_000L);
         List<Integer> gasUnits = List.of(1, 2);
 
         return Arrays.stream(CallType.values())


### PR DESCRIPTION
**Description**:
This PR fixes 7 tests that were failing with INSUFFICIENT_GAS in ContractCallServiceTests by Increasing the gasLimit value in the method source for some of the tests from 30_000 to 34_000

**Related issue(s)**:
Related to  #10087 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
