### PR TITLE
Handle exception throwing in binary gas estimator when performing estimate gas

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
@@ -51,17 +51,10 @@ public class BinaryGasEstimator {
             contractCallContext.reset();
 
             long mid = (hi + lo) / 2;
-            HederaEvmTransactionProcessingResult transactionResult = null;
-
-            try {
-                transactionResult = call.apply(mid);
-            } catch (Exception ignore) {
-            }
+            HederaEvmTransactionProcessingResult transactionResult = call.apply(mid);
             iterationsMade++;
 
-            boolean err = transactionResult == null
-                    || !transactionResult.isSuccessful()
-                    || transactionResult.getGasUsed() < 0;
+            boolean err = !transactionResult.isSuccessful() || transactionResult.getGasUsed() < 0;
             long gasUsed = err ? prevGasLimit : transactionResult.getGasUsed();
             totalGasUsed += gasUsed;
             if (err || gasUsed == 0) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
@@ -80,7 +80,7 @@ public class BinaryGasEstimator {
         return hi;
     }
 
-    // This method is needed because within the modularized services if the contract call fails an exceptio is thrown
+    // This method is needed because within the modularized services if the contract call fails an exception is thrown
     // instead of transaction result with 'failed' status which will result in a failing test. This way we handle the
     // exception and return estimated gas
     private HederaEvmTransactionProcessingResult safeCall(

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
@@ -22,8 +22,10 @@ import com.hedera.node.app.service.evm.contracts.execution.HederaEvmTransactionP
 import jakarta.inject.Named;
 import java.util.function.LongFunction;
 import java.util.function.ObjIntConsumer;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
+@CustomLog
 @RequiredArgsConstructor
 @Named
 public class BinaryGasEstimator {
@@ -51,10 +53,16 @@ public class BinaryGasEstimator {
             contractCallContext.reset();
 
             long mid = (hi + lo) / 2;
-            HederaEvmTransactionProcessingResult transactionResult = call.apply(mid);
+
+            // If modularizedServices is true - we call the safeCall function that handles if an exception is thrown
+            HederaEvmTransactionProcessingResult transactionResult =
+                    properties.isModularizedServices() ? safeCall(mid, call) : call.apply(mid);
+
             iterationsMade++;
 
-            boolean err = !transactionResult.isSuccessful() || transactionResult.getGasUsed() < 0;
+            boolean err = transactionResult == null
+                    || !transactionResult.isSuccessful()
+                    || transactionResult.getGasUsed() < 0;
             long gasUsed = err ? prevGasLimit : transactionResult.getGasUsed();
             totalGasUsed += gasUsed;
             if (err || gasUsed == 0) {
@@ -70,5 +78,18 @@ public class BinaryGasEstimator {
 
         metricUpdater.accept(totalGasUsed, iterationsMade);
         return hi;
+    }
+
+    // This method is needed because within the modularized services if the contract call fails an exceptio is thrown
+    // instead of transaction result with 'failed' status which will result in a failing test. This way we handle the
+    // exception and return estimated gas
+    private HederaEvmTransactionProcessingResult safeCall(
+            long mid, LongFunction<HederaEvmTransactionProcessingResult> call) {
+        try {
+            return call.apply(mid);
+        } catch (Exception ignored) {
+            log.info("Exception while calling contract for gas estimation");
+            return null;
+        }
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/utils/BinaryGasEstimator.java
@@ -51,10 +51,17 @@ public class BinaryGasEstimator {
             contractCallContext.reset();
 
             long mid = (hi + lo) / 2;
-            HederaEvmTransactionProcessingResult transactionResult = call.apply(mid);
+            HederaEvmTransactionProcessingResult transactionResult = null;
+
+            try {
+                transactionResult = call.apply(mid);
+            } catch (Exception ignore) {
+            }
             iterationsMade++;
 
-            boolean err = !transactionResult.isSuccessful() || transactionResult.getGasUsed() < 0;
+            boolean err = transactionResult == null
+                    || !transactionResult.isSuccessful()
+                    || transactionResult.getGasUsed() < 0;
             long gasUsed = err ? prevGasLimit : transactionResult.getGasUsed();
             totalGasUsed += gasUsed;
             if (err || gasUsed == 0) {

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -129,7 +129,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
     }
 
     private static Stream<Arguments> ercPrecompileCallTypeArgumentsProvider() {
-        List<Long> gasLimits = List.of(15_000_000L, 30_000L);
+        List<Long> gasLimits = List.of(15_000_000L, 34_000L);
         List<Integer> gasUnits = List.of(1, 2);
 
         return Arrays.stream(CallType.values())

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -470,6 +470,41 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         assertGasLimit(ETH_ESTIMATE_GAS, TRANSACTION_GAS_LIMIT);
     }
 
+    // This test will be removed in the future. Needed only for test coverage right now.
+    @Test
+    void estimateGasForBalanceCallToContractModularizedServices() throws Exception {
+        // Given
+        final var modularizedServicesFlag = mirrorNodeEvmProperties.isModularizedServices();
+        final var backupProperties = mirrorNodeEvmProperties.getProperties();
+
+        try {
+            mirrorNodeEvmProperties.setModularizedServices(true);
+            Method postConstructMethod = Arrays.stream(MirrorNodeState.class.getDeclaredMethods())
+                    .filter(method -> method.isAnnotationPresent(PostConstruct.class))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("@PostConstruct method not found"));
+
+            postConstructMethod.setAccessible(true); // Make the method accessible
+            postConstructMethod.invoke(state);
+
+            final Map<String, String> propertiesMap = new HashMap<>();
+            propertiesMap.put("contracts.maxRefundPercentOfGasLimit", "100");
+            propertiesMap.put("contracts.maxGasPerSec", "15000000");
+            mirrorNodeEvmProperties.setProperties(propertiesMap);
+            final var contract = testWeb3jService.deploy(EthCall::deploy);
+            meterRegistry.clear();
+
+            // When
+            final var functionCall = contract.send_getAccountBalance(contract.getContractAddress());
+
+            // Then
+            verifyEthCallAndEstimateGas(functionCall, contract);
+        } finally {
+            mirrorNodeEvmProperties.setModularizedServices(modularizedServicesFlag);
+            mirrorNodeEvmProperties.setProperties(backupProperties);
+        }
+    }
+
     @Test
     void testRevertDetailMessage() {
         // Given


### PR DESCRIPTION
**Description**:
This PR adds an exception handling during estimate gas using transaction executor. Using the modularized services when performing a contract call in binary gas estimator with the mid value and if the call fails it throws an exception instead of result with status failed. That results in a failing in the test. 

- Added a method that performs a safe contract call with try-catch mechanism
- Added additional check for 'err' if the contract result is null
- added logic to differentiate between the two flows for modularizedServices

This PR also fixes 1 test in contractCallSErviceTest

**Related issue(s)**:

Related to #10087 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
