### PR TITLE
Set prometheus pod priority class to high

### DIFF
--- a/charts/hedera-mirror-common/values.yaml
+++ b/charts/hedera-mirror-common/values.yaml
@@ -364,7 +364,7 @@ prometheus:
             app.kubernetes.io/name: traefik
     prometheusSpec:
       podMonitorSelectorNilUsesHelmValues: false
-      priorityClassName: low
+      priorityClassName: high
       resources:
         limits:
           cpu: 750m


### PR DESCRIPTION
**Description**:

This PR changes the default prometheus pod priority class to high

**Related issue(s)**:

Fixes #10256 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
