### PR TITLE
Fix additional tests in contract call service tests

### DIFF
--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/AbstractContractCallServiceTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.google.common.collect.Range;
 import com.hedera.mirror.common.domain.balance.AccountBalance;
 import com.hedera.mirror.common.domain.balance.TokenBalance;
 import com.hedera.mirror.common.domain.entity.Entity;
@@ -110,9 +111,19 @@ public abstract class AbstractContractCallServiceTest extends Web3IntegrationTes
                 domainBuilder.recordFile().customize(f -> f.index(0L)).persist();
         treasuryEntity = domainBuilder
                 .entity()
-                .customize(e -> e.id(2L).num(2L).balance(5000000000000000000L))
+                .customize(e -> e.id(2L)
+                        .num(2L)
+                        .balance(5000000000000000000L)
+                        .createdTimestamp(genesisRecordFile.getConsensusStart())
+                        .timestampRange(Range.atLeast(genesisRecordFile.getConsensusStart())))
                 .persist();
-        domainBuilder.entity().customize(e -> e.id(98L).num(98L)).persist();
+        domainBuilder
+                .entity()
+                .customize(e -> e.id(98L)
+                        .num(98L)
+                        .createdTimestamp(genesisRecordFile.getConsensusStart())
+                        .timestampRange(Range.atLeast(genesisRecordFile.getConsensusStart())))
+                .persist();
         domainBuilder
                 .accountBalance()
                 .customize(ab -> ab.id(new AccountBalance.Id(

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -708,7 +708,6 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         verifyEthCallAndEstimateGas(functionCall, contract);
     }
 
-    // IN PROGRESS
     @Test
     void estimateGasForDirectCreateContractDeploy() {
         // Given

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -247,13 +247,11 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         // When
         if (blockType.number() < EVM_V_34_BLOCK) { // Before the block the data did not exist yet
             contract.setDefaultBlockParameter(DefaultBlockParameter.valueOf(BigInteger.valueOf(blockType.number())));
-
             testWeb3jService.setBlockType(blockType);
             if (mirrorNodeEvmProperties.isModularizedServices()) {
                 assertThatThrownBy(functionCall::send)
                         .isInstanceOf(MirrorEvmTransactionException.class)
                         .hasMessage(INVALID_CONTRACT_ID.name());
-                ;
             } else {
                 assertThatThrownBy(functionCall::send)
                         .isInstanceOf(MirrorEvmTransactionException.class)

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -240,7 +240,6 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
                 .persist();
 
         final var gasUsedBeforeExecution = getGasUsedBeforeExecution(ETH_CALL);
-
         final var contract = testWeb3jService.deploy(EthCall::deploy);
         final var functionCall = contract.call_multiplySimpleNumbers();
         meterRegistry.clear(); // Clear it as the contract deploy increases the gas limit metric

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -565,7 +565,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
     }
 
     @Test
-    void ethCallWithValueAndNotExistingSenderAlias() throws Exception {
+    void ethCallWithValueAndNotExistingSenderAlias() {
         // Given
         final var receiverEntity = accountPersist();
         final var receiverAddress = getAliasAddressFromEntity(receiverEntity);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServiceTest.java
@@ -572,6 +572,7 @@ class ContractCallServiceTest extends AbstractContractCallServiceTest {
         final var notExistingSenderAlias = Address.fromHexString("0x6b175474e89094c44da98b954eedeac495271d0f");
         final var serviceParameters =
                 getContractExecutionParametersWithValue(Bytes.EMPTY, notExistingSenderAlias, receiverAddress, 10L);
+
         // When
         final var result = contractExecutionService.processCall(serviceParameters);
 


### PR DESCRIPTION
**Description**:
This PR Fixes 11 tests in ContractCallServicesTests
- added timestamp and timestamp range of genesis block in setup for accounts 0.0.2 and 0.0.98
- added payers for transactions
- adapted the correct response like `INVALID_CONTRACT_ID` in some negative scenarios 

This PR modifies ... in order to support ...


**Related issue(s)**:

Related to #10087 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
