### PR TITLE
Mirror node state scoped cache implementation

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
@@ -27,9 +27,12 @@ import com.hedera.mirror.web3.service.model.CallServiceParameters;
 import com.hedera.mirror.web3.viewmodel.BlockType;
 import java.util.ArrayList;
 import java.util.EmptyStackException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -72,6 +75,12 @@ public class ContractCallContext {
     /** Fixed "base" of stack: a R/O cache frame on top of the DB-backed cache frame */
     private CachingStateFrame<Object> stackBase;
 
+    @Getter(AccessLevel.NONE)
+    private Map<String, Map<Object, Object>> readCache = new HashMap<>();
+
+    @Getter(AccessLevel.NONE)
+    private Map<String, Map<Object, Object>> modifications = new HashMap<>();
+
     /**
      * The timestamp used to fetch the state from the stackedStateFrames.
      */
@@ -90,6 +99,7 @@ public class ContractCallContext {
 
     public void reset() {
         stack = stackBase;
+        modifications.clear();
     }
 
     public int getStackHeight() {
@@ -153,5 +163,13 @@ public class ContractCallContext {
 
     private Optional<Long> getTimestampOrDefaultFromRecordFile() {
         return timestamp.or(() -> Optional.ofNullable(recordFile).map(RecordFile::getConsensusEnd));
+    }
+
+    public Map<Object, Object> getReadCacheState(final String stateKey) {
+        return readCache.computeIfAbsent(stateKey, k -> new HashMap<>());
+    }
+
+    public Map<Object, Object> getModificationsState(final String stateKey) {
+        return modifications.computeIfAbsent(stateKey, k -> new HashMap<>());
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/common/ContractCallContext.java
@@ -79,7 +79,7 @@ public class ContractCallContext {
     private Map<String, Map<Object, Object>> readCache = new HashMap<>();
 
     @Getter(AccessLevel.NONE)
-    private Map<String, Map<Object, Object>> modifications = new HashMap<>();
+    private Map<String, Map<Object, Object>> writeCache = new HashMap<>();
 
     /**
      * The timestamp used to fetch the state from the stackedStateFrames.
@@ -99,7 +99,7 @@ public class ContractCallContext {
 
     public void reset() {
         stack = stackBase;
-        modifications.clear();
+        writeCache.clear();
     }
 
     public int getStackHeight() {
@@ -169,7 +169,7 @@ public class ContractCallContext {
         return readCache.computeIfAbsent(stateKey, k -> new HashMap<>());
     }
 
-    public Map<Object, Object> getModificationsState(final String stateKey) {
-        return modifications.computeIfAbsent(stateKey, k -> new HashMap<>());
+    public Map<Object, Object> getWriteCacheState(final String stateKey) {
+        return writeCache.computeIfAbsent(stateKey, k -> new HashMap<>());
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AbstractReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AbstractReadableKVState.java
@@ -18,7 +18,6 @@ package com.hedera.mirror.web3.state.keyvalue;
 
 import com.swirlds.state.spi.ReadableKVStateBase;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import jakarta.annotation.Nullable;
 import java.util.Collections;
 import java.util.Iterator;
 
@@ -26,12 +25,6 @@ public abstract class AbstractReadableKVState<K, V> extends ReadableKVStateBase<
 
     protected AbstractReadableKVState(@NonNull String stateKey) {
         super(stateKey);
-    }
-
-    @Nullable
-    @Override
-    public V get(@NonNull K key) {
-        return readFromDataSource(key);
     }
 
     @NonNull

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AbstractReadableKVState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/keyvalue/AbstractReadableKVState.java
@@ -17,17 +17,17 @@
 package com.hedera.mirror.web3.state.keyvalue;
 
 import com.swirlds.state.spi.ReadableKVStateBase;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import jakarta.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Iterator;
 
 public abstract class AbstractReadableKVState<K, V> extends ReadableKVStateBase<K, V> {
 
-    protected AbstractReadableKVState(@NonNull String stateKey) {
+    protected AbstractReadableKVState(@Nonnull String stateKey) {
         super(stateKey);
     }
 
-    @NonNull
+    @Nonnull
     @Override
     protected Iterator<K> iterateFromDataSource() {
         return Collections.emptyIterator();

--- a/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
+++ b/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
@@ -19,7 +19,6 @@ package com.swirlds.state.spi;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -35,8 +34,6 @@ import java.util.Set;
 public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V> {
     /** The state key, which cannot be null */
     private final String stateKey;
-
-    private final Set<K> unmodifiableReadKeys = new HashSet<>();
 
     private static final Object marker = new Object();
 
@@ -78,7 +75,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      */
     @Nonnull
     public final Set<K> readKeys() {
-        return (Set<K>) getReadCache().entrySet();
+        return (Set<K>) getReadCache().keySet();
     }
 
     /** {@inheritDoc} */

--- a/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
+++ b/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
@@ -117,7 +117,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * @param value The value
      */
     protected final void markRead(@Nonnull K key, @Nullable V value) {
-        getReadCache().put(key, Objects.requireNonNullElseGet(value, () -> (V) marker));
+        getReadCache().put(key, Objects.requireNonNullElse(value, (V) marker));
     }
 
     /**

--- a/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
+++ b/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
@@ -21,6 +21,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -66,8 +67,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
             final var value = readFromDataSource(key);
             markRead(key, value);
         }
-        final var value =
-                ContractCallContext.get().getReadCacheState(getStateKey()).get(key);
+        final var value = getReadCache().get(key);
         return (value == marker) ? null : (V) value;
     }
 
@@ -78,8 +78,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      */
     @Nonnull
     public final Set<K> readKeys() {
-        return (Set<K>)
-                ContractCallContext.get().getReadCacheState(getStateKey()).entrySet();
+        return (Set<K>) getReadCache().entrySet();
     }
 
     /** {@inheritDoc} */
@@ -92,7 +91,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
     /** Clears all cached data, including the set of all read keys. */
     /*@OverrideMustCallSuper*/
     public void reset() {
-        ContractCallContext.get().getReadCacheState(getStateKey()).clear();
+        getReadCache().clear();
     }
 
     /**
@@ -121,8 +120,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * @param value The value
      */
     protected final void markRead(@Nonnull K key, @Nullable V value) {
-        ContractCallContext.get().getReadCacheState(getStateKey()).put(key, Objects.requireNonNullElseGet(value, () ->
-                (V) marker));
+        getReadCache().put(key, Objects.requireNonNullElseGet(value, () -> (V) marker));
     }
 
     /**
@@ -132,6 +130,10 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * @return Whether it has been read
      */
     protected final boolean hasBeenRead(@Nonnull K key) {
-        return ContractCallContext.get().getReadCacheState(getStateKey()).containsKey(key);
+        return getReadCache().containsKey(key);
+    }
+
+    private Map<Object, Object> getReadCache() {
+        return ContractCallContext.get().getReadCacheState(getStateKey());
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
+++ b/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.state.spi;
+
+import com.hedera.mirror.web3.common.ContractCallContext;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A base class for implementations of {@link ReadableKVState} and {@link WritableKVState}.
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ */
+@SuppressWarnings("unchecked")
+public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V> {
+    /** The state key, which cannot be null */
+    private final String stateKey;
+
+    private final Set<K> unmodifiableReadKeys = new HashSet<>();
+
+    private static final Object marker = new Object();
+
+    /**
+     * Create a new StateBase.
+     *
+     * @param stateKey The state key. Cannot be null.
+     */
+    protected ReadableKVStateBase(@Nonnull String stateKey) {
+        this.stateKey = Objects.requireNonNull(stateKey);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Nonnull
+    public final String getStateKey() {
+        return stateKey;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Nullable
+    public V get(@Nonnull K key) {
+        // We need to cache the item because somebody may perform business logic basic on this
+        // contains call, even if they never need the value itself!
+        Objects.requireNonNull(key);
+        if (!hasBeenRead(key)) {
+            final var value = readFromDataSource(key);
+            markRead(key, value);
+        }
+        final var value =
+                ContractCallContext.get().getReadCacheState(getStateKey()).get(key);
+        return (value == marker) ? null : (V) value;
+    }
+
+    /**
+     * Gets the set of keys that a client read from the {@link ReadableKVState}.
+     *
+     * @return The possibly empty set of keys.
+     */
+    @Nonnull
+    public final Set<K> readKeys() {
+        return (Set<K>)
+                ContractCallContext.get().getReadCacheState(getStateKey()).entrySet();
+    }
+
+    /** {@inheritDoc} */
+    @Nonnull
+    @Override
+    public Iterator<K> keys() {
+        return iterateFromDataSource();
+    }
+
+    /** Clears all cached data, including the set of all read keys. */
+    /*@OverrideMustCallSuper*/
+    public void reset() {
+        ContractCallContext.get().getReadCacheState(getStateKey()).clear();
+    }
+
+    /**
+     * Reads the keys from the underlying data source (which may be a merkle data structure, a
+     * fast-copyable data structure, or something else).
+     *
+     * @param key key to read from state
+     * @return The value read from the underlying data source. May be null.
+     */
+    protected abstract V readFromDataSource(@Nonnull K key);
+
+    /**
+     * Gets an iterator from the data source that iterates over all keys.
+     *
+     * @return An iterator over all keys in the data source.
+     */
+    @Nonnull
+    protected abstract Iterator<K> iterateFromDataSource();
+
+    /**
+     * Records the given key and associated value were read. {@link WritableKVStateBase} will call
+     * this method in some cases when a key is read as part of a modification (for example, with
+     * {@link WritableKVStateBase#getForModify}).
+     *
+     * @param key The key
+     * @param value The value
+     */
+    protected final void markRead(@Nonnull K key, @Nullable V value) {
+        ContractCallContext.get().getReadCacheState(getStateKey()).put(key, Objects.requireNonNullElseGet(value, () ->
+                (V) marker));
+    }
+
+    /**
+     * Gets whether this key has been read at some point by this {@link ReadableKVStateBase}.
+     *
+     * @param key The key.
+     * @return Whether it has been read
+     */
+    protected final boolean hasBeenRead(@Nonnull K key) {
+        return ContractCallContext.get().getReadCacheState(getStateKey()).containsKey(key);
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/WritableKVStateBase.java
+++ b/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/WritableKVStateBase.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.state.spi;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.mirror.web3.common.ContractCallContext;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.*;
+
+/**
+ * A base class for implementations of {@link WritableKVState}.
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ */
+@SuppressWarnings("unchecked")
+public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V> implements WritableKVState<K, V> {
+    /** A map of all modified values buffered in this mutable state */
+    //    private final Map<K, V> modifications = new LinkedHashMap<>();
+    /**
+     * A list of listeners to be notified of changes to the state.
+     */
+    private final List<KVChangeListener<K, V>> listeners = new ArrayList<>();
+
+    /**
+     * Create a new StateBase.
+     *
+     * @param stateKey The state key. Cannot be null.
+     */
+    protected WritableKVStateBase(@NonNull final String stateKey) {
+        super(stateKey);
+    }
+
+    /**
+     * Register a listener to be notified of changes to the state on {@link #commit()}. We do not support unregistering
+     * a listener, as the lifecycle of a {@link WritableKVState} is scoped to the set of mutations made to a state in a
+     * round; and there is no use case where an application would only want to be notified of a subset of those changes.
+     * @param listener the listener to register
+     */
+    public void registerListener(@NonNull final KVChangeListener<K, V> listener) {
+        requireNonNull(listener);
+        listeners.add(listener);
+    }
+
+    /**
+     * Flushes all changes into the underlying data store. This method should <strong>ONLY</strong>
+     * be called by the code that created the {@link WritableKVStateBase} instance or owns it. Don't
+     * cast and commit unless you own the instance!
+     */
+    public void commit() {
+        // Do nothing since we do not want to propagate any changes to the underlying datasource.
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Clears the set of modified keys and removed keys. Equivalent semantically to a "rollback"
+     * operation.
+     */
+    @Override
+    public final void reset() {
+        super.reset();
+        ContractCallContext.get().getModificationsState(getStateKey()).clear();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Nullable
+    public final V get(@NonNull K key) {
+        // If there is a modification, then we've already done a "put" or "remove"
+        // and should return based on the modification
+        if (ContractCallContext.get().getModificationsState(getStateKey()).containsKey(key)) {
+            return (V) ContractCallContext.get()
+                    .getModificationsState(getStateKey())
+                    .get(key);
+        } else {
+            return super.get(key);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Nullable
+    @Override
+    public V getOriginalValue(@NonNull K key) {
+        return super.get(key);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    @Nullable
+    public final V getForModify(@NonNull final K key) {
+        Objects.requireNonNull(key);
+        // If there is a modification, then we've already done a "put" or "remove"
+        // and should return based on the modification
+        if (ContractCallContext.get().getModificationsState(getStateKey()).containsKey(key)) {
+            return (V) ContractCallContext.get()
+                    .getModificationsState(getStateKey())
+                    .get(key);
+        }
+
+        // If the modifications map does not contain an answer, but the read cache of the
+        // super class does, then it means we've looked this up before but never modified it.
+        // So we can just delegate to the super class.
+        if (hasBeenRead(key)) {
+            return super.get(key);
+        }
+
+        // We have not queried this key before, so let's look it up and store that we have
+        // read this key. And then return the value.
+        final var val = getForModifyFromDataSource(key);
+        markRead(key, val);
+        return val;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public final void put(@NonNull final K key, @NonNull final V value) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+        ContractCallContext.get().getModificationsState(getStateKey()).put(key, value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public final void remove(@NonNull final K key) {
+        Objects.requireNonNull(key);
+        ContractCallContext.get().getModificationsState(getStateKey()).put(key, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This is a bit of a pain, because we have to take into account modifications! If a key has
+     * been removed, then it must be omitted during iteration. If a key has been added, then it must
+     * be added into iteration.
+     *
+     * @return An iterator that iterates over all known keys.
+     */
+    @NonNull
+    @Override
+    public Iterator<K> keys() {
+        // Capture the set of keys that have been removed, and the set of keys that have been added.
+        final var removedKeys = new HashSet<K>();
+        final var maybeAddedKeys = new HashSet<K>();
+        for (final var mod :
+                ContractCallContext.get().getModificationsState(getStateKey()).entrySet()) {
+            final var key = mod.getKey();
+            final var val = mod.getValue();
+            if (val == null) {
+                removedKeys.add((K) key);
+            } else {
+                maybeAddedKeys.add((K) key);
+            }
+        }
+
+        // Get the iterator from the backing store
+        final var backendItr = super.keys();
+
+        // Create and return a special iterator which will only include those keys that
+        // have NOT been removed, ARE in the backendItr, and includes keys that HAVE
+        // been added (i.e. are not in the backendItr).
+        return new KVStateKeyIterator<>(backendItr, removedKeys, maybeAddedKeys);
+    }
+
+    /** {@inheritDoc} */
+    @NonNull
+    @Override
+    public final Set<K> modifiedKeys() {
+        return (Set<K>)
+                ContractCallContext.get().getModificationsState(getStateKey()).keySet();
+    }
+
+    /**
+     * {@inheritDoc}
+     * For the size of a {@link WritableKVState}, we need to take into account the size of the
+     * underlying data source, and the modifications that have been made to the state.
+     * <ol>
+     * <li>if the key is in backing store and is removed in modifications, then it is counted as removed</li>
+     * <li>if the key is not in backing store and is added in modifications, then it is counted as addition</li>
+     * <li>if the key is in backing store and is added in modifications, then it is not counted as the
+     * key already exists in state</li>
+     * <li>if the key is not in backing store and is being tried to be removed in modifications,
+     * then it is not counted as the key does not exist in state.</li>
+     * </ol>
+     * @return The size of the state.
+     */
+    public long size() {
+        final var sizeOfBackingMap = sizeOfDataSource();
+        int numAdditions = 0;
+        int numRemovals = 0;
+
+        for (final var mod :
+                ContractCallContext.get().getModificationsState(getStateKey()).entrySet()) {
+            boolean isPresentInBackingMap = readFromDataSource((K) mod.getKey()) != null;
+            boolean isRemovedInMod = mod.getValue() == null;
+
+            if (isPresentInBackingMap && isRemovedInMod) {
+                numRemovals++;
+            } else if (!isPresentInBackingMap && !isRemovedInMod) {
+                numAdditions++;
+            }
+        }
+        return sizeOfBackingMap + numAdditions - numRemovals;
+    }
+
+    /**
+     * Reads from the underlying data source in such a way as to cause any fast-copyable data
+     * structures underneath to make a fast copy.
+     *
+     * @param key key to read from state
+     * @return The value read from the underlying data source. May be null.
+     */
+    protected abstract V getForModifyFromDataSource(@NonNull K key);
+
+    /**
+     * Puts the given key/value pair into the underlying data source.
+     *
+     * @param key key to update
+     * @param value value to put
+     */
+    protected abstract void putIntoDataSource(@NonNull K key, @NonNull V value);
+
+    /**
+     * Removes the given key and implicit value from the underlying data source.
+     *
+     * @param key key to remove from the underlying data source
+     */
+    protected abstract void removeFromDataSource(@NonNull K key);
+
+    /**
+     * Returns the size of the underlying data source. This can be a merkle map or a virtual map.
+     * @return size of the underlying data source.
+     */
+    protected abstract long sizeOfDataSource();
+
+    /**
+     * A special iterator which includes all keys in the backend iterator, and all keys that have
+     * been added but are not part of the backend iterator, and excludes all keys that have been
+     * removed (even if they are in the backend iterator).
+     *
+     * <p>For each key it gets back from the backing store, it must inspect that key to see if it is
+     * in the removedKeys or maybeAddedKeys. If it is in the removedKeys, then we don't return it to
+     * the caller, and pump another key from the backing store iterator to check instead. If it is
+     * in maybeAddedKeys, then remove it from maybeAddedKeys (since it is clearly not added) and
+     * then return it to the caller. At the very end, when the backing store iterator tells us it is
+     * out of keys, we start going through everything in maybeAddedKeys.
+     *
+     * <p>This iterator is not fail-fast.
+     *
+     * @param <K> The type of key
+     */
+    private static final class KVStateKeyIterator<K> implements Iterator<K> {
+        private final Iterator<K> backendItr;
+        private final Set<K> removedKeys;
+        private final Set<K> maybeAddedKeys;
+        private Iterator<K> addedItr;
+        private K next;
+
+        private KVStateKeyIterator(
+                @NonNull final Iterator<K> backendItr,
+                @NonNull final Set<K> removedKeys,
+                @NonNull final Set<K> maybeAddedKeys) {
+            this.backendItr = backendItr;
+            this.removedKeys = removedKeys;
+            this.maybeAddedKeys = maybeAddedKeys;
+        }
+
+        @Override
+        public boolean hasNext() {
+            prepareNext();
+            return next != null;
+        }
+
+        @Override
+        public K next() {
+            prepareNext();
+
+            if (next == null) {
+                throw new NoSuchElementException();
+            }
+
+            final var ret = next;
+            next = null;
+            return ret;
+        }
+
+        private void prepareNext() {
+            while (next == null) {
+                if (backendItr.hasNext()) {
+                    final var candidate = backendItr.next();
+                    maybeAddedKeys.remove(candidate);
+                    if (removedKeys.contains(candidate)) {
+                        continue;
+                    }
+                    next = candidate;
+                    return;
+                }
+
+                if (addedItr == null) {
+                    addedItr = maybeAddedKeys.iterator();
+                }
+
+                if (addedItr.hasNext()) {
+                    next = addedItr.next();
+                }
+
+                // If we get here, then there is nothing.
+                return;
+            }
+        }
+    }
+}

--- a/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/WritableKVStateBase.java
+++ b/hedera-mirror-web3/src/main/java/com/swirlds/state/spi/WritableKVStateBase.java
@@ -19,9 +19,16 @@ package com.swirlds.state.spi;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.mirror.web3.common.ContractCallContext;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.*;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * A base class for implementations of {@link WritableKVState}.
@@ -43,7 +50,7 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
      *
      * @param stateKey The state key. Cannot be null.
      */
-    protected WritableKVStateBase(@NonNull final String stateKey) {
+    protected WritableKVStateBase(@Nonnull final String stateKey) {
         super(stateKey);
     }
 
@@ -53,7 +60,7 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
      * round; and there is no use case where an application would only want to be notified of a subset of those changes.
      * @param listener the listener to register
      */
-    public void registerListener(@NonNull final KVChangeListener<K, V> listener) {
+    public void registerListener(@Nonnull final KVChangeListener<K, V> listener) {
         requireNonNull(listener);
         listeners.add(listener);
     }
@@ -82,7 +89,7 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
     /** {@inheritDoc} */
     @Override
     @Nullable
-    public final V get(@NonNull K key) {
+    public final V get(@Nonnull K key) {
         // If there is a modification, then we've already done a "put" or "remove"
         // and should return based on the modification
         if (getModificationsCache().containsKey(key)) {
@@ -95,14 +102,14 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
     /** {@inheritDoc} */
     @Nullable
     @Override
-    public V getOriginalValue(@NonNull K key) {
+    public V getOriginalValue(@Nonnull K key) {
         return super.get(key);
     }
 
     /** {@inheritDoc} */
     @Override
     @Nullable
-    public final V getForModify(@NonNull final K key) {
+    public final V getForModify(@Nonnull final K key) {
         Objects.requireNonNull(key);
         // If there is a modification, then we've already done a "put" or "remove"
         // and should return based on the modification
@@ -126,7 +133,7 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
 
     /** {@inheritDoc} */
     @Override
-    public final void put(@NonNull final K key, @NonNull final V value) {
+    public final void put(@Nonnull final K key, @Nonnull final V value) {
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
         getModificationsCache().put(key, value);
@@ -134,7 +141,7 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
 
     /** {@inheritDoc} */
     @Override
-    public final void remove(@NonNull final K key) {
+    public final void remove(@Nonnull final K key) {
         Objects.requireNonNull(key);
         getModificationsCache().put(key, null);
     }
@@ -148,7 +155,7 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
      *
      * @return An iterator that iterates over all known keys.
      */
-    @NonNull
+    @Nonnull
     @Override
     public Iterator<K> keys() {
         // Capture the set of keys that have been removed, and the set of keys that have been added.
@@ -174,7 +181,7 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
     }
 
     /** {@inheritDoc} */
-    @NonNull
+    @Nonnull
     @Override
     public final Set<K> modifiedKeys() {
         return (Set<K>) getModificationsCache().keySet();
@@ -219,7 +226,7 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
      * @param key key to read from state
      * @return The value read from the underlying data source. May be null.
      */
-    protected abstract V getForModifyFromDataSource(@NonNull K key);
+    protected abstract V getForModifyFromDataSource(@Nonnull K key);
 
     /**
      * Puts the given key/value pair into the underlying data source.
@@ -227,14 +234,14 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
      * @param key key to update
      * @param value value to put
      */
-    protected abstract void putIntoDataSource(@NonNull K key, @NonNull V value);
+    protected abstract void putIntoDataSource(@Nonnull K key, @Nonnull V value);
 
     /**
      * Removes the given key and implicit value from the underlying data source.
      *
      * @param key key to remove from the underlying data source
      */
-    protected abstract void removeFromDataSource(@NonNull K key);
+    protected abstract void removeFromDataSource(@Nonnull K key);
 
     /**
      * Returns the size of the underlying data source. This can be a merkle map or a virtual map.
@@ -270,9 +277,9 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
         private K next;
 
         private KVStateKeyIterator(
-                @NonNull final Iterator<K> backendItr,
-                @NonNull final Set<K> removedKeys,
-                @NonNull final Set<K> maybeAddedKeys) {
+                @Nonnull final Iterator<K> backendItr,
+                @Nonnull final Set<K> removedKeys,
+                @Nonnull final Set<K> maybeAddedKeys) {
             this.backendItr = backendItr;
             this.removedKeys = removedKeys;
             this.maybeAddedKeys = maybeAddedKeys;

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/core/MapWritableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/core/MapWritableKVStateTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.token.Account;
-import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.state.keyvalue.AccountReadableKVState;
 import com.hedera.mirror.web3.state.keyvalue.AliasesReadableKVState;
 import com.swirlds.state.spi.ReadableKVState;
@@ -34,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
+@ExtendWith(ContextExtension.class)
 @ExtendWith(MockitoExtension.class)
 class MapWritableKVStateTest {
 
@@ -78,33 +79,24 @@ class MapWritableKVStateTest {
 
     @Test
     void testPutIntoDataSource() {
-        ContractCallContext.run(ctx -> {
-            assertThat(mapWritableKVState.contains(accountID)).isFalse();
-            mapWritableKVState.putIntoDataSource(accountID, account);
-            assertThat(mapWritableKVState.contains(accountID)).isTrue();
-            return ctx;
-        });
+        assertThat(mapWritableKVState.contains(accountID)).isFalse();
+        mapWritableKVState.putIntoDataSource(accountID, account);
+        assertThat(mapWritableKVState.contains(accountID)).isTrue();
     }
 
     @Test
     void testRemoveFromDataSource() {
-        ContractCallContext.run(ctx -> {
-            mapWritableKVState.putIntoDataSource(accountID, account);
-            assertThat(mapWritableKVState.contains(accountID)).isTrue();
-            mapWritableKVState.removeFromDataSource(accountID);
-            assertThat(mapWritableKVState.contains(accountID)).isFalse();
-            return ctx;
-        });
+        mapWritableKVState.putIntoDataSource(accountID, account);
+        assertThat(mapWritableKVState.contains(accountID)).isTrue();
+        mapWritableKVState.removeFromDataSource(accountID);
+        assertThat(mapWritableKVState.contains(accountID)).isFalse();
     }
 
     @Test
     void testCommit() {
-        ContractCallContext.run(ctx -> {
-            mapWritableKVState.putIntoDataSource(accountID, account);
-            assertThat(mapWritableKVState.contains(accountID)).isTrue();
-            mapWritableKVState.commit(); // Does nothing, just for test coverage.
-            return ctx;
-        });
+        mapWritableKVState.putIntoDataSource(accountID, account);
+        assertThat(mapWritableKVState.contains(accountID)).isTrue();
+        mapWritableKVState.commit(); // Does nothing, just for test coverage.
     }
 
     @Test
@@ -131,14 +123,11 @@ class MapWritableKVStateTest {
 
     @Test
     void testEqualsDifferentValues() {
-        ContractCallContext.run(ctx -> {
-            final var readableKVStateMock = mock(ReadableKVState.class);
-            MapWritableKVState<AccountID, Account> other =
-                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateMock);
-            other.put(accountID, account);
-            assertThat(mapWritableKVState).isNotEqualTo(other);
-            return ctx;
-        });
+        final var readableKVStateMock = mock(ReadableKVState.class);
+        MapWritableKVState<AccountID, Account> other =
+                new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateMock);
+        other.put(accountID, account);
+        assertThat(mapWritableKVState).isNotEqualTo(other);
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/core/MapWritableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/core/MapWritableKVStateTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.state.keyvalue.AccountReadableKVState;
 import com.hedera.mirror.web3.state.keyvalue.AliasesReadableKVState;
 import com.swirlds.state.spi.ReadableKVState;
@@ -77,25 +78,33 @@ class MapWritableKVStateTest {
 
     @Test
     void testPutIntoDataSource() {
-        assertThat(mapWritableKVState.contains(accountID)).isFalse();
-        mapWritableKVState.putIntoDataSource(accountID, account);
-        assertThat(mapWritableKVState.contains(accountID)).isTrue();
+        ContractCallContext.run(ctx -> {
+            assertThat(mapWritableKVState.contains(accountID)).isFalse();
+            mapWritableKVState.putIntoDataSource(accountID, account);
+            assertThat(mapWritableKVState.contains(accountID)).isTrue();
+            return ctx;
+        });
     }
 
     @Test
     void testRemoveFromDataSource() {
-        mapWritableKVState.putIntoDataSource(accountID, account);
-        assertThat(mapWritableKVState.contains(accountID)).isTrue();
-        mapWritableKVState.removeFromDataSource(accountID);
-        assertThat(mapWritableKVState.contains(accountID)).isFalse();
+        ContractCallContext.run(ctx -> {
+            mapWritableKVState.putIntoDataSource(accountID, account);
+            assertThat(mapWritableKVState.contains(accountID)).isTrue();
+            mapWritableKVState.removeFromDataSource(accountID);
+            assertThat(mapWritableKVState.contains(accountID)).isFalse();
+            return ctx;
+        });
     }
 
     @Test
     void testCommit() {
-        mapWritableKVState.putIntoDataSource(accountID, account);
-        assertThat(mapWritableKVState.contains(accountID)).isTrue();
-        mapWritableKVState.commit();
-        assertThat(mapWritableKVState.contains(accountID)).isFalse();
+        ContractCallContext.run(ctx -> {
+            mapWritableKVState.putIntoDataSource(accountID, account);
+            assertThat(mapWritableKVState.contains(accountID)).isTrue();
+            mapWritableKVState.commit(); // Does nothing, just for test coverage.
+            return ctx;
+        });
     }
 
     @Test
@@ -122,11 +131,14 @@ class MapWritableKVStateTest {
 
     @Test
     void testEqualsDifferentValues() {
-        final var readableKVStateMock = mock(ReadableKVState.class);
-        MapWritableKVState<AccountID, Account> other =
-                new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateMock);
-        other.put(accountID, account);
-        assertThat(mapWritableKVState).isNotEqualTo(other);
+        ContractCallContext.run(ctx -> {
+            final var readableKVStateMock = mock(ReadableKVState.class);
+            MapWritableKVState<AccountID, Account> other =
+                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateMock);
+            other.put(accountID, account);
+            assertThat(mapWritableKVState).isNotEqualTo(other);
+            return ctx;
+        });
     }
 
     @Test

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/ContractBytecodeReadableKVStateTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/keyvalue/ContractBytecodeReadableKVStateTest.java
@@ -18,6 +18,7 @@ package com.hedera.mirror.web3.state.keyvalue;
 
 import static com.hedera.mirror.web3.evm.utils.EvmTokenUtils.entityIdNumFromEvmAddress;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.ContractID;
@@ -25,6 +26,7 @@ import com.hedera.hapi.node.base.ContractID.ContractOneOfType;
 import com.hedera.hapi.node.state.contract.Bytecode;
 import com.hedera.mirror.common.domain.entity.Entity;
 import com.hedera.mirror.common.domain.entity.EntityId;
+import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.repository.ContractRepository;
 import com.hedera.mirror.web3.state.CommonEntityAccessor;
 import com.hedera.pbj.runtime.OneOf;
@@ -32,10 +34,15 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.util.Collections;
 import java.util.Optional;
 import org.hyperledger.besu.datatypes.Address;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,11 +74,31 @@ class ContractBytecodeReadableKVStateTest {
     @InjectMocks
     private ContractBytecodeReadableKVState contractBytecodeReadableKVState;
 
+    private static MockedStatic<ContractCallContext> contextMockedStatic;
+
     @Mock
     private ContractRepository contractRepository;
 
     @Mock
     private CommonEntityAccessor commonEntityAccessor;
+
+    @Spy
+    private ContractCallContext contractCallContext;
+
+    @BeforeAll
+    static void initStaticMocks() {
+        contextMockedStatic = mockStatic(ContractCallContext.class);
+    }
+
+    @AfterAll
+    static void closeStaticMocks() {
+        contextMockedStatic.close();
+    }
+
+    @BeforeEach
+    void setup() {
+        contextMockedStatic.when(ContractCallContext::get).thenReturn(contractCallContext);
+    }
 
     @Test
     void whenContractIdAndEvmAddressAreNotSetReturnNull() {

--- a/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/ReadableKVStateBaseTest.java
+++ b/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/ReadableKVStateBaseTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.state.core.MapReadableKVState;
 import com.hedera.mirror.web3.state.keyvalue.AccountReadableKVState;
@@ -30,34 +31,29 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(ContextExtension.class)
 @ExtendWith(MockitoExtension.class)
 class ReadableKVStateBaseTest {
 
     @Test
     void testReadKeys() {
-        ContractCallContext.run(ctx -> {
-            final var accountID = mock(AccountID.class);
-            final var account = mock(Account.class);
-            final ReadableKVStateBase<AccountID, Account> readableKVStateBase =
-                    new MapReadableKVState<>(AccountReadableKVState.KEY, Map.of());
-            ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
-            assertThat(readableKVStateBase.readKeys()).isEqualTo(Set.of(accountID));
-            return ctx;
-        });
+        final var accountID = mock(AccountID.class);
+        final var account = mock(Account.class);
+        final ReadableKVStateBase<AccountID, Account> readableKVStateBase =
+                new MapReadableKVState<>(AccountReadableKVState.KEY, Map.of());
+        ContractCallContext.get().getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
+        assertThat(readableKVStateBase.readKeys()).isEqualTo(Set.of(accountID));
     }
 
     @Test
     void testResetCache() {
-        ContractCallContext.run(ctx -> {
-            final var accountID = mock(AccountID.class);
-            final var account = mock(Account.class);
-            final ReadableKVStateBase<AccountID, Account> readableKVStateBase =
-                    new MapReadableKVState<>(AccountReadableKVState.KEY, Map.of());
-            readableKVStateBase.markRead(accountID, account);
-            assertThat(readableKVStateBase.hasBeenRead(accountID)).isTrue();
-            readableKVStateBase.reset();
-            assertThat(readableKVStateBase.hasBeenRead(accountID)).isFalse();
-            return ctx;
-        });
+        final var accountID = mock(AccountID.class);
+        final var account = mock(Account.class);
+        final ReadableKVStateBase<AccountID, Account> readableKVStateBase =
+                new MapReadableKVState<>(AccountReadableKVState.KEY, Map.of());
+        readableKVStateBase.markRead(accountID, account);
+        assertThat(readableKVStateBase.hasBeenRead(accountID)).isTrue();
+        readableKVStateBase.reset();
+        assertThat(readableKVStateBase.hasBeenRead(accountID)).isFalse();
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/ReadableKVStateBaseTest.java
+++ b/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/ReadableKVStateBaseTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.state.spi;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.state.core.MapReadableKVState;
+import com.hedera.mirror.web3.state.keyvalue.AccountReadableKVState;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ReadableKVStateBaseTest {
+
+    @Test
+    void testReadKeys() {
+        ContractCallContext.run(ctx -> {
+            final var accountID = mock(AccountID.class);
+            final var account = mock(Account.class);
+            final Map<Object, Object> map = Map.of(accountID, account);
+            final ReadableKVStateBase<AccountID, Account> readableKVStateBase =
+                    new MapReadableKVState<>(AccountReadableKVState.KEY, Map.of());
+            ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
+            assertThat(readableKVStateBase.readKeys()).isEqualTo(Set.of(accountID));
+            return ctx;
+        });
+    }
+
+    @Test
+    void testResetCache() {
+        ContractCallContext.run(ctx -> {
+            final var accountID = mock(AccountID.class);
+            final var account = mock(Account.class);
+            final Map<Object, Object> map = Map.of(accountID, account);
+            final ReadableKVStateBase<AccountID, Account> readableKVStateBase =
+                    new MapReadableKVState<>(AccountReadableKVState.KEY, Map.of());
+            readableKVStateBase.markRead(accountID, account);
+            assertThat(readableKVStateBase.hasBeenRead(accountID)).isTrue();
+            readableKVStateBase.reset();
+            assertThat(readableKVStateBase.hasBeenRead(accountID)).isFalse();
+            return ctx;
+        });
+    }
+}

--- a/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/ReadableKVStateBaseTest.java
+++ b/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/ReadableKVStateBaseTest.java
@@ -31,14 +31,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class ReadableKVStateBaseTest {
+class ReadableKVStateBaseTest {
 
     @Test
     void testReadKeys() {
         ContractCallContext.run(ctx -> {
             final var accountID = mock(AccountID.class);
             final var account = mock(Account.class);
-            final Map<Object, Object> map = Map.of(accountID, account);
             final ReadableKVStateBase<AccountID, Account> readableKVStateBase =
                     new MapReadableKVState<>(AccountReadableKVState.KEY, Map.of());
             ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
@@ -52,7 +51,6 @@ public class ReadableKVStateBaseTest {
         ContractCallContext.run(ctx -> {
             final var accountID = mock(AccountID.class);
             final var account = mock(Account.class);
-            final Map<Object, Object> map = Map.of(accountID, account);
             final ReadableKVStateBase<AccountID, Account> readableKVStateBase =
                     new MapReadableKVState<>(AccountReadableKVState.KEY, Map.of());
             readableKVStateBase.markRead(accountID, account);

--- a/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/WritableKVStateBaseTest.java
+++ b/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/WritableKVStateBaseTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.mirror.web3.ContextExtension;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.state.core.MapWritableKVState;
 import com.hedera.mirror.web3.state.keyvalue.AccountReadableKVState;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(ContextExtension.class)
 @ExtendWith(MockitoExtension.class)
 class WritableKVStateBaseTest {
 
@@ -42,121 +44,100 @@ class WritableKVStateBaseTest {
 
     @Test
     void testResetCache() {
-        ContractCallContext.run(ctx -> {
-            final var accountID = mock(AccountID.class);
-            final var account = mock(Account.class);
-            final Map<Object, Object> map = Map.of(accountID, account);
-            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
-                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
-            ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, account);
-            assertThat(ctx.getWriteCacheState(AccountReadableKVState.KEY)).isEqualTo(map);
-            writableKVStateBase.reset();
-            assertThat(ctx.getWriteCacheState(AccountReadableKVState.KEY)).isEqualTo(Map.of());
-            return ctx;
-        });
+        final var ctx = ContractCallContext.get();
+        final var accountID = mock(AccountID.class);
+        final var account = mock(Account.class);
+        final Map<Object, Object> map = Map.of(accountID, account);
+        final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+        ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, account);
+        assertThat(ctx.getWriteCacheState(AccountReadableKVState.KEY)).isEqualTo(map);
+        writableKVStateBase.reset();
+        assertThat(ctx.getWriteCacheState(AccountReadableKVState.KEY)).isEqualTo(Map.of());
     }
 
     @Test
     void testGetOriginalValue() {
-        ContractCallContext.run(ctx -> {
-            final var accountID = mock(AccountID.class);
-            final var account = mock(Account.class);
-            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
-                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
-            when(readableKVStateBase.get(accountID)).thenReturn(account);
-            assertThat(writableKVStateBase.getOriginalValue(accountID)).isEqualTo(account);
-            return ctx;
-        });
+        final var accountID = mock(AccountID.class);
+        final var account = mock(Account.class);
+        final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+        when(readableKVStateBase.get(accountID)).thenReturn(account);
+        assertThat(writableKVStateBase.getOriginalValue(accountID)).isEqualTo(account);
     }
 
     @Test
     void testGetForModifyFromModificationsCache() {
-        ContractCallContext.run(ctx -> {
-            final var accountID = mock(AccountID.class);
-            final var account = mock(Account.class);
-            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
-                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
-            ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, account);
-            assertThat(writableKVStateBase.getForModify(accountID)).isEqualTo(account);
-            return ctx;
-        });
+        final var accountID = mock(AccountID.class);
+        final var account = mock(Account.class);
+        final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+        ContractCallContext.get().getWriteCacheState(AccountReadableKVState.KEY).put(accountID, account);
+        assertThat(writableKVStateBase.getForModify(accountID)).isEqualTo(account);
     }
 
     @Test
     void testGetForModifyFromReadCache() {
-        ContractCallContext.run(ctx -> {
-            final var accountID = mock(AccountID.class);
-            final var account = mock(Account.class);
-            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
-                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
-            ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
-            assertThat(writableKVStateBase.getForModify(accountID)).isEqualTo(account);
-            return ctx;
-        });
+        final var accountID = mock(AccountID.class);
+        final var account = mock(Account.class);
+        final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+        ContractCallContext.get().getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
+        assertThat(writableKVStateBase.getForModify(accountID)).isEqualTo(account);
     }
 
     @Test
     void testGetForModifyFromDataSource() {
-        ContractCallContext.run(ctx -> {
-            final var accountID = mock(AccountID.class);
-            final var account = mock(Account.class);
-            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
-                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
-            when(readableKVStateBase.get(accountID)).thenReturn(account);
-            assertThat(writableKVStateBase.getForModify(accountID)).isEqualTo(account);
-            return ctx;
-        });
+        final var accountID = mock(AccountID.class);
+        final var account = mock(Account.class);
+        final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+        when(readableKVStateBase.get(accountID)).thenReturn(account);
+        assertThat(writableKVStateBase.getForModify(accountID)).isEqualTo(account);
     }
 
     @Test
     void testSizeWithRemovedEntry() {
-        ContractCallContext.run(ctx -> {
-            final var accountID = mock(AccountID.class);
-            final var accountID2 = mock(AccountID.class);
-            final var account = mock(Account.class);
-            final var account2 = mock(Account.class);
-            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
-                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
-            ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
-            ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID2, account2);
-            ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, null); // The entry was removed
-            when(readableKVStateBase.size()).thenReturn(2L);
-            when(readableKVStateBase.get(accountID)).thenReturn(account);
-            assertThat(writableKVStateBase.size()).isEqualTo(1L);
-            return ctx;
-        });
+        final var ctx = ContractCallContext.get();
+        final var accountID = mock(AccountID.class);
+        final var accountID2 = mock(AccountID.class);
+        final var account = mock(Account.class);
+        final var account2 = mock(Account.class);
+        final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+        ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
+        ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID2, account2);
+        ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, null); // The entry was removed
+        when(readableKVStateBase.size()).thenReturn(2L);
+        when(readableKVStateBase.get(accountID)).thenReturn(account);
+        assertThat(writableKVStateBase.size()).isEqualTo(1L);
     }
 
     @Test
     void testKeysEmpty() {
-        ContractCallContext.run(ctx -> {
-            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
-                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
-            when(readableKVStateBase.keys()).thenReturn(Collections.emptyIterator());
-            final var iterator = writableKVStateBase.keys();
-            assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class);
-            return ctx;
-        });
+        final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+        when(readableKVStateBase.keys()).thenReturn(Collections.emptyIterator());
+        final var iterator = writableKVStateBase.keys();
+        assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class);
     }
 
     @Test
     void testKeysWithRemovedEntry() {
-        ContractCallContext.run(ctx -> {
-            final var accountID = mock(AccountID.class);
-            final var accountID2 = mock(AccountID.class);
-            final var account = mock(Account.class);
-            final var account2 = mock(Account.class);
-            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
-                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
-            ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
-            ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID2, account2);
-            ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, null); // The entry was removed
-            when(readableKVStateBase.keys())
-                    .thenReturn(Map.of(accountID, account, accountID2, account2)
-                            .keySet()
-                            .iterator());
-            assertThat(writableKVStateBase.keys().next()).isEqualTo(accountID2);
-            return ctx;
-        });
+        final var ctx = ContractCallContext.get();
+        final var accountID = mock(AccountID.class);
+        final var accountID2 = mock(AccountID.class);
+        final var account = mock(Account.class);
+        final var account2 = mock(Account.class);
+        final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+        ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
+        ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID2, account2);
+        ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, null); // The entry was removed
+        when(readableKVStateBase.keys())
+                .thenReturn(Map.of(accountID, account, accountID2, account2)
+                        .keySet()
+                        .iterator());
+        assertThat(writableKVStateBase.keys().next()).isEqualTo(accountID2);
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/WritableKVStateBaseTest.java
+++ b/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/WritableKVStateBaseTest.java
@@ -48,10 +48,10 @@ class WritableKVStateBaseTest {
             final Map<Object, Object> map = Map.of(accountID, account);
             final WritableKVStateBase<AccountID, Account> writableKVStateBase =
                     new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
-            ctx.getModificationsState(AccountReadableKVState.KEY).put(accountID, account);
-            assertThat(ctx.getModificationsState(AccountReadableKVState.KEY)).isEqualTo(map);
+            ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, account);
+            assertThat(ctx.getWriteCacheState(AccountReadableKVState.KEY)).isEqualTo(map);
             writableKVStateBase.reset();
-            assertThat(ctx.getModificationsState(AccountReadableKVState.KEY)).isEqualTo(Map.of());
+            assertThat(ctx.getWriteCacheState(AccountReadableKVState.KEY)).isEqualTo(Map.of());
             return ctx;
         });
     }
@@ -76,7 +76,7 @@ class WritableKVStateBaseTest {
             final var account = mock(Account.class);
             final WritableKVStateBase<AccountID, Account> writableKVStateBase =
                     new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
-            ctx.getModificationsState(AccountReadableKVState.KEY).put(accountID, account);
+            ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, account);
             assertThat(writableKVStateBase.getForModify(accountID)).isEqualTo(account);
             return ctx;
         });
@@ -119,7 +119,7 @@ class WritableKVStateBaseTest {
                     new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
             ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
             ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID2, account2);
-            ctx.getModificationsState(AccountReadableKVState.KEY).put(accountID, null); // The entry was removed
+            ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, null); // The entry was removed
             when(readableKVStateBase.size()).thenReturn(2L);
             when(readableKVStateBase.get(accountID)).thenReturn(account);
             assertThat(writableKVStateBase.size()).isEqualTo(1L);
@@ -150,7 +150,7 @@ class WritableKVStateBaseTest {
                     new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
             ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
             ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID2, account2);
-            ctx.getModificationsState(AccountReadableKVState.KEY).put(accountID, null); // The entry was removed
+            ctx.getWriteCacheState(AccountReadableKVState.KEY).put(accountID, null); // The entry was removed
             when(readableKVStateBase.keys())
                     .thenReturn(Map.of(accountID, account, accountID2, account2)
                             .keySet()

--- a/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/WritableKVStateBaseTest.java
+++ b/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/WritableKVStateBaseTest.java
@@ -32,7 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class WritableKVStateBaseTest {
+class WritableKVStateBaseTest {
 
     @Mock
     private ReadableKVStateBase<AccountID, Account> readableKVStateBase;
@@ -58,7 +58,6 @@ public class WritableKVStateBaseTest {
         ContractCallContext.run(ctx -> {
             final var accountID = mock(AccountID.class);
             final var account = mock(Account.class);
-            final Map<Object, Object> map = Map.of(accountID, account);
             final WritableKVStateBase<AccountID, Account> writableKVStateBase =
                     new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
             when(readableKVStateBase.get(accountID)).thenReturn(account);
@@ -86,11 +85,24 @@ public class WritableKVStateBaseTest {
         ContractCallContext.run(ctx -> {
             final var accountID = mock(AccountID.class);
             final var account = mock(Account.class);
-            final Map<Object, Object> map = Map.of(accountID, account);
             final WritableKVStateBase<AccountID, Account> writableKVStateBase =
                     new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
             ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
             assertThat(writableKVStateBase.getForModify(accountID)).isEqualTo(account);
+            return ctx;
+        });
+    }
+
+    @Test
+    void testWithRemovedEntry() {
+        ContractCallContext.run(ctx -> {
+            final var accountID = mock(AccountID.class);
+            final var account = mock(Account.class);
+            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+            ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
+            ctx.getModificationsState(AccountReadableKVState.KEY).put(accountID, null); // The entry was removed
+            assertThat(writableKVStateBase.size()).isZero();
             return ctx;
         });
     }

--- a/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/WritableKVStateBaseTest.java
+++ b/hedera-mirror-web3/src/test/java/com/swirlds/state/spi/WritableKVStateBaseTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.state.spi;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.mirror.web3.common.ContractCallContext;
+import com.hedera.mirror.web3.state.core.MapWritableKVState;
+import com.hedera.mirror.web3.state.keyvalue.AccountReadableKVState;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class WritableKVStateBaseTest {
+
+    @Mock
+    private ReadableKVStateBase<AccountID, Account> readableKVStateBase;
+
+    @Test
+    void testResetCache() {
+        ContractCallContext.run(ctx -> {
+            final var accountID = mock(AccountID.class);
+            final var account = mock(Account.class);
+            final Map<Object, Object> map = Map.of(accountID, account);
+            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+            ctx.getModificationsState(AccountReadableKVState.KEY).put(accountID, account);
+            assertThat(ctx.getModificationsState(AccountReadableKVState.KEY)).isEqualTo(map);
+            writableKVStateBase.reset();
+            assertThat(ctx.getModificationsState(AccountReadableKVState.KEY)).isEqualTo(Map.of());
+            return ctx;
+        });
+    }
+
+    @Test
+    void testGetOriginalValue() {
+        ContractCallContext.run(ctx -> {
+            final var accountID = mock(AccountID.class);
+            final var account = mock(Account.class);
+            final Map<Object, Object> map = Map.of(accountID, account);
+            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+            when(readableKVStateBase.get(accountID)).thenReturn(account);
+            assertThat(writableKVStateBase.getOriginalValue(accountID)).isEqualTo(account);
+            return ctx;
+        });
+    }
+
+    @Test
+    void testGetForModifyFromModificationsCache() {
+        ContractCallContext.run(ctx -> {
+            final var accountID = mock(AccountID.class);
+            final var account = mock(Account.class);
+            final Map<Object, Object> map = Map.of(accountID, account);
+            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+            ctx.getModificationsState(AccountReadableKVState.KEY).put(accountID, account);
+            assertThat(writableKVStateBase.getForModify(accountID)).isEqualTo(account);
+            return ctx;
+        });
+    }
+
+    @Test
+    void testGetForModifyFromReadCache() {
+        ContractCallContext.run(ctx -> {
+            final var accountID = mock(AccountID.class);
+            final var account = mock(Account.class);
+            final Map<Object, Object> map = Map.of(accountID, account);
+            final WritableKVStateBase<AccountID, Account> writableKVStateBase =
+                    new MapWritableKVState<>(AccountReadableKVState.KEY, readableKVStateBase);
+            ctx.getReadCacheState(AccountReadableKVState.KEY).put(accountID, account);
+            assertThat(writableKVStateBase.getForModify(accountID)).isEqualTo(account);
+            return ctx;
+        });
+    }
+}


### PR DESCRIPTION
**Description**:
With this PR the `ReadableKVStateBase` and the `WritableKVStateBase` classes from the hedera app dependency have been replaced with custom implementations. The main difference is that the base classes have private maps that cache the read/modified entries and these classes are singletons that are shared between all transactions. This lead to inconsistencies such as:
1. Transaction T1 reads account A against the latest block and puts it in the cache.
2. Transaction T2 reads account A against a historical block where account A does not exist yet and since the cache is shared, A is returned instead of null.
3. Other similar cases where and entry needs to be returned, but the cache keeps its value as null.
The case for the writable cache is similar to the readable one.

This PR replaces the private cache maps with scoped value maps. They are now located in the `ContractCallContext` to ensure that each transaction has its own small cache that would not be affected by other transactions. Also, this cache will be valid only in the current context, so at the end of the scope the cache will be cleared automatically and no additional action is needed. A special case is the gas estimation - in there we reset the modifications cache to ensure a fresh start. The read cache is not currently cleared as it would contain only the test setup and this would not change between the different iterations. This way we skip some repository calls as well for some optimisation.

The read and the write cache in the `ContractCallContext` are kept as map of maps - the key for the parent map is the state key, e.g. "ACCOUNTS", "TOKENS", etc. The value of the parent map is a map itself that keeps the actual cache as key-value pairs the same way as it was before in the base classes.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/9264
