### PR TITLE
Fix failing acceptance tests on mainnet for scheduled transactions 

### DIFF
--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -71,7 +71,7 @@ public class ScheduleFeature extends AbstractFeature {
             "I successfully schedule a HBAR transfer from treasury to {account} with expiration time {string} and wait for expiry {string}")
     public void createNewHBarTransferSchedule(
             AccountNameEnum accountName, String expirationTimeInSeconds, String waitForExpiry) {
-       currentSignersCount = SIGNATORY_COUNT_OFFSET;
+        currentSignersCount = SIGNATORY_COUNT_OFFSET;
         var recipient = accountClient.getAccount(accountName);
         var scheduledTransaction = accountClient.getCryptoTransferTransaction(
                 accountClient.getTokenTreasuryAccount().getAccountId(),
@@ -103,11 +103,14 @@ public class ScheduleFeature extends AbstractFeature {
             log.info("Dummy transaction fails but triggers the schedule execution");
         }
 
-        //Wait until the transaction is executed and has a valid executed timestamp
+        // Wait until the transaction is executed and has a valid executed timestamp
         await().atMost(Duration.ofSeconds(30))
                 .pollDelay(Duration.ofMillis(100))
                 .pollInterval(Duration.ofMillis(100))
-                .untilAsserted(() -> assertThat(mirrorClient.getScheduleInfo(scheduleId.toString()).getExecutedTimestamp()).isNotNull());
+                .untilAsserted(() -> assertThat(mirrorClient
+                                .getScheduleInfo(scheduleId.toString())
+                                .getExecutedTimestamp())
+                        .isNotNull());
     }
 
     private void createNewSchedule(Transaction<?> transaction, Instant expirationTime, boolean waitForExpiry) {

--- a/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
+++ b/hedera-mirror-test/src/test/java/com/hedera/mirror/test/e2e/acceptance/steps/ScheduleFeature.java
@@ -71,19 +71,18 @@ public class ScheduleFeature extends AbstractFeature {
             "I successfully schedule a HBAR transfer from treasury to {account} with expiration time {string} and wait for expiry {string}")
     public void createNewHBarTransferSchedule(
             AccountNameEnum accountName, String expirationTimeInSeconds, String waitForExpiry) {
-        Instant expirationTime = null;
-
-        if (expirationTimeInSeconds != null && !expirationTimeInSeconds.equals("null")) {
-            Duration expirationOffset = DurationStyle.detectAndParse(expirationTimeInSeconds);
-            expirationTime = Instant.now().plus(expirationOffset);
-        }
-
-        currentSignersCount = SIGNATORY_COUNT_OFFSET;
+       currentSignersCount = SIGNATORY_COUNT_OFFSET;
         var recipient = accountClient.getAccount(accountName);
         var scheduledTransaction = accountClient.getCryptoTransferTransaction(
                 accountClient.getTokenTreasuryAccount().getAccountId(),
                 recipient.getAccountId(),
                 Hbar.fromTinybars(DEFAULT_TINY_HBAR));
+
+        Instant expirationTime = null;
+        if (expirationTimeInSeconds != null && !expirationTimeInSeconds.equals("null")) {
+            Duration expirationOffset = DurationStyle.detectAndParse(expirationTimeInSeconds);
+            expirationTime = Instant.now().plus(expirationOffset);
+        }
 
         createNewSchedule(scheduledTransaction, expirationTime, Boolean.parseBoolean(waitForExpiry));
     }
@@ -103,6 +102,12 @@ public class ScheduleFeature extends AbstractFeature {
         } catch (Exception e) {
             log.info("Dummy transaction fails but triggers the schedule execution");
         }
+
+        //Wait until the transaction is executed and has a valid executed timestamp
+        await().atMost(Duration.ofSeconds(30))
+                .pollDelay(Duration.ofMillis(100))
+                .pollInterval(Duration.ofMillis(100))
+                .untilAsserted(() -> assertThat(mirrorClient.getScheduleInfo(scheduleId.toString()).getExecutedTimestamp()).isNotNull());
     }
 
     private void createNewSchedule(Transaction<?> transaction, Instant expirationTime, boolean waitForExpiry) {

--- a/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
+++ b/hedera-mirror-test/src/test/resources/features/schedule/schedule.feature
@@ -19,13 +19,13 @@ Feature: Schedule Base Coverage Feature
     When the scheduled transaction is signed by treasuryAccount
     And the mirror node REST API should return status <httpStatusCode> for the schedule transaction
     And the mirror node REST API should verify the "EXECUTED" schedule entity with expiration time "60s" and wait for expiry "false"
-    Given I successfully schedule a HBAR transfer from treasury to ALICE with expiration time "8s" and wait for expiry "true"
+    Given I successfully schedule a HBAR transfer from treasury to ALICE with expiration time "16s" and wait for expiry "true"
     Then the mirror node REST API should return status <httpStatusCode> for the schedule transaction
-    And the mirror node REST API should verify the "NON_EXECUTED" schedule entity with expiration time "8s" and wait for expiry "true"
+    And the mirror node REST API should verify the "NON_EXECUTED" schedule entity with expiration time "16s" and wait for expiry "true"
     When the scheduled transaction is signed by treasuryAccount
     And the mirror node REST API should return status <httpStatusCode> for the schedule transaction
     Then I wait until the schedule's expiration time
-    And the mirror node REST API should verify the "EXECUTED" schedule entity with expiration time "8s" and wait for expiry "true"
+    And the mirror node REST API should verify the "EXECUTED" schedule entity with expiration time "16s" and wait for expiry "true"
 
     Examples:
       | httpStatusCode |


### PR DESCRIPTION
**Description**:
This PR fixes a failing test on mainnet for scheduled transactions
- Due to delay of transaction executions and responses handling increased the time for expiry from 8 to 16 seconds for the test that waits for expiration. Due to parallel test suites execution this increase will not cause a delay in the execution in general
- The accounts creation was after the set of expiration time which was causing additional delay in the schedule execution
- added additional check on "I wait until the schedule's expiration time" that waits until the transaction is executed and has a valid executedTimestamp

**Related issue(s)**:

Fixes #10290 

**Notes for reviewer**:
Those delays only occur on mainnet so it is hard to reproduce them on testnet or previewnet

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
