### PR TITLE
Use BlockHeader.firstTransactionConsensusTime

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/util/DomainUtils.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/util/DomainUtils.java
@@ -217,7 +217,7 @@ public class DomainUtils {
     }
 
     public static Long timestampInNanosMax(Timestamp timestamp) {
-        if (timestamp == null) {
+        if (timestamp == null || Timestamp.getDefaultInstance().equals(timestamp)) {
             return null;
         }
         return convertToNanosMax(timestamp.getSeconds(), timestamp.getNanos());

--- a/hedera-mirror-common/src/test/java/com/hedera/mirror/common/util/DomainUtilsTest.java
+++ b/hedera-mirror-common/src/test/java/com/hedera/mirror/common/util/DomainUtilsTest.java
@@ -258,6 +258,13 @@ class DomainUtilsTest {
                 .isEqualTo("abc�123�".getBytes(StandardCharsets.UTF_8));
     }
 
+    @Test
+    void timestampInNanosMaxEmpty() {
+        assertThat(DomainUtils.timestampInNanosMax(null)).isNull();
+        assertThat(DomainUtils.timestampInNanosMax(Timestamp.getDefaultInstance()))
+                .isNull();
+    }
+
     @ParameterizedTest(name = "with seconds {0} and nanos {1}")
     @CsvSource({"1569936354, 901", "0, 901", "1569936354, 0", "0,0"})
     void timeStampInNanosTimeStamp(long seconds, int nanos) {

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/block/ProtoBlockFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/block/ProtoBlockFileReader.java
@@ -49,9 +49,9 @@ import lombok.Value;
 import lombok.experimental.NonFinal;
 
 @Named
-public class ProtoBlockFileReader implements BlockFileReader {
+class ProtoBlockFileReader implements BlockFileReader {
 
-    private static final int VERSION = 7;
+    static final int VERSION = 7;
 
     @Override
     public BlockFile read(StreamFileData streamFileData) {
@@ -113,8 +113,11 @@ public class ProtoBlockFileReader implements BlockFileReader {
                     blockHeader.getHashAlgorithm(), context.getFilename()));
         }
 
+        Long consensusStart = DomainUtils.timestampInNanosMax(blockHeader.getFirstTransactionConsensusTime());
         var previousHash = DomainUtils.toBytes(blockHeader.getPreviousBlockHash());
         blockFileBuilder.blockHeader(blockHeader);
+        blockFileBuilder.consensusStart(consensusStart);
+        blockFileBuilder.consensusEnd(consensusStart);
         blockFileBuilder.index(blockHeader.getNumber());
         blockFileBuilder.previousHash(DomainUtils.bytesToHex(previousHash));
         context.getBlockRootHashDigest().setPreviousHash(previousHash);


### PR DESCRIPTION
**Description**:

Use `BlockHeader.firstTransactionConsensusTime` for consensus start and end

**Related issue(s)**:

Fixes #10073

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
