### PR TITLE
Adapt storage capturing in OpcodeTracer for modularized execution

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracer.java
@@ -23,20 +23,29 @@ import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_FAILED
 import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
 import static org.hyperledger.besu.evm.frame.MessageFrame.Type.MESSAGE_CALL;
 
+import com.hedera.hapi.node.state.contract.SlotKey;
+import com.hedera.hapi.node.state.contract.SlotValue;
 import com.hedera.mirror.common.domain.contract.ContractAction;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.convert.BytesDecoder;
 import com.hedera.mirror.web3.evm.config.PrecompiledContractProvider;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.state.core.MapWritableStates;
+import com.hedera.node.app.service.contract.ContractService;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExceptionalHaltReason;
 import com.hedera.node.app.service.mono.contracts.execution.traceability.HederaOperationTracer;
 import com.hedera.services.stream.proto.ContractActionType;
+import com.hedera.services.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.swirlds.state.State;
 import jakarta.inject.Named;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
@@ -57,11 +66,19 @@ import org.springframework.util.CollectionUtils;
 @Getter
 public class OpcodeTracer implements HederaOperationTracer {
 
+    private static final String STORAGE_KEY = "STORAGE";
     private final Map<Address, PrecompiledContract> hederaPrecompiles;
+    private final MirrorNodeEvmProperties evmProperties;
+    private final State mirrorNodeState;
 
-    public OpcodeTracer(final PrecompiledContractProvider precompiledContractProvider) {
+    public OpcodeTracer(
+            final PrecompiledContractProvider precompiledContractProvider,
+            MirrorNodeEvmProperties evmProperties,
+            State mirrorNodeState) {
         this.hederaPrecompiles = precompiledContractProvider.getHederaPrecompiles().entrySet().stream()
                 .collect(Collectors.toMap(e -> Address.fromHexString(e.getKey()), Map.Entry::getValue));
+        this.evmProperties = evmProperties;
+        this.mirrorNodeState = mirrorNodeState;
     }
 
     @Override
@@ -177,6 +194,10 @@ public class OpcodeTracer implements HederaOperationTracer {
                 return Collections.emptyMap();
             }
 
+            if (evmProperties.isModularizedServices()) {
+                return getModularizedUpdatedStorage(address);
+            }
+
             return new TreeMap<>(account.getUpdatedStorage());
         } catch (final ModificationNotAllowedException e) {
             log.warn("Failed to retrieve storage contents", e);
@@ -210,10 +231,10 @@ public class OpcodeTracer implements HederaOperationTracer {
     }
 
     /**
-     * When a contract tries to call a non-existing address
-     * (resulting in a {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} failure),
-     * a synthetic action is created to record this, otherwise the details of the intended call
-     * (e.g. the targeted invalid address) and sequence of events leading to the failure are lost
+     * When a contract tries to call a non-existing address (resulting in a
+     * {@link HederaExceptionalHaltReason#INVALID_SOLIDITY_ADDRESS} failure), a synthetic action is created to record
+     * this, otherwise the details of the intended call (e.g. the targeted invalid address) and sequence of events
+     * leading to the failure are lost
      */
     private boolean existsSyntheticActionForFrame(MessageFrame frame) {
         return (frame.getState() == EXCEPTIONAL_HALT || frame.getState() == COMPLETED_FAILED)
@@ -223,8 +244,9 @@ public class OpcodeTracer implements HederaOperationTracer {
     }
 
     /**
-     * Formats the revert reason to be consistent with the revert reason format in the EVM.
-     * <a href="https://besu.hyperledger.org/23.10.2/private-networks/how-to/send-transactions/revert-reason#revert-reason-format">...</a>
+     * Formats the revert reason to be consistent with the revert reason format in the EVM. <a
+     * href="https://besu.hyperledger.org/23.10.2/private-networks/how-to/send-transactions/revert-reason#revert-reason-format">...</a>
+     *
      * @param revertReason the revert reason
      * @return the formatted revert reason
      */
@@ -245,5 +267,51 @@ public class OpcodeTracer implements HederaOperationTracer {
         }
 
         return BytesDecoder.getAbiEncodedRevertReason(revertReason);
+    }
+
+    private Optional<Map<Bytes, Bytes>> getStorageUpdates(Address accountAddress) {
+        Map<Bytes, Bytes> storageUpdates = new HashMap<>();
+        MapWritableStates states = (MapWritableStates) mirrorNodeState.getWritableStates(ContractService.NAME);
+
+        try {
+            Set<SlotKey> modifiedKeys = states.get(STORAGE_KEY).modifiedKeys().stream()
+                    .filter(SlotKey.class::isInstance)
+                    .map(SlotKey.class::cast)
+                    .filter(SlotKey::hasContractID)
+                    .collect(Collectors.toSet());
+
+            if (modifiedKeys.isEmpty()) {
+                return Optional.empty();
+            }
+
+            for (SlotKey slotKey : modifiedKeys) {
+                Address contractAddress = EntityIdUtils.asHexedEvmAddress(slotKey.contractID());
+                if (!accountAddress.equals(contractAddress)) {
+                    continue;
+                }
+
+                SlotValue slotValue = (SlotValue) states.get(STORAGE_KEY).get(slotKey);
+                if (slotValue != null) {
+                    storageUpdates.put(
+                            Bytes.of(slotKey.key().toByteArray()),
+                            Bytes.of(slotValue.value().toByteArray()));
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            log.warn(
+                    "Failed to retrieve modified storage keys for service: {}, key: {}",
+                    ContractService.NAME,
+                    STORAGE_KEY,
+                    e);
+        }
+
+        return storageUpdates.isEmpty() ? Optional.empty() : Optional.of(storageUpdates);
+    }
+
+    private Map<Bytes, Bytes> getModularizedUpdatedStorage(Address accountAddress) {
+        return getStorageUpdates(accountAddress)
+                .map(storageUpdates -> storageUpdates.entrySet().stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> b, TreeMap::new)))
+                .orElseGet(TreeMap::new);
     }
 }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracer.java
@@ -277,7 +277,7 @@ public class OpcodeTracer implements HederaOperationTracer {
             storageState.modifiedKeys().stream()
                     .filter(SlotKey.class::isInstance)
                     .map(SlotKey.class::cast)
-                    .filter(slotKey -> slotKey.contractID().equals(accountContractID))
+                    .filter(slotKey -> accountContractID.equals(slotKey.contractID()))
                     .forEach(slotKey -> {
                         SlotValue slotValue = (SlotValue) storageState.get(slotKey);
                         if (slotValue != null) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracer.java
@@ -290,7 +290,8 @@ public class OpcodeTracer implements HederaOperationTracer {
                     continue;
                 }
 
-                SlotValue slotValue = (SlotValue) states.get(ContractStorageReadableKVState.KEY).get(slotKey);
+                SlotValue slotValue = (SlotValue)
+                        states.get(ContractStorageReadableKVState.KEY).get(slotKey);
                 if (slotValue != null) {
                     storageUpdates.put(
                             Bytes.of(slotKey.key().toByteArray()),

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracer.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracer.java
@@ -31,6 +31,7 @@ import com.hedera.mirror.web3.convert.BytesDecoder;
 import com.hedera.mirror.web3.evm.config.PrecompiledContractProvider;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.state.core.MapWritableStates;
+import com.hedera.mirror.web3.state.keyvalue.ContractStorageReadableKVState;
 import com.hedera.node.app.service.contract.ContractService;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExceptionalHaltReason;
 import com.hedera.node.app.service.mono.contracts.execution.traceability.HederaOperationTracer;
@@ -66,7 +67,6 @@ import org.springframework.util.CollectionUtils;
 @Getter
 public class OpcodeTracer implements HederaOperationTracer {
 
-    private static final String STORAGE_KEY = "STORAGE";
     private final Map<Address, PrecompiledContract> hederaPrecompiles;
     private final MirrorNodeEvmProperties evmProperties;
     private final State mirrorNodeState;
@@ -274,7 +274,7 @@ public class OpcodeTracer implements HederaOperationTracer {
         MapWritableStates states = (MapWritableStates) mirrorNodeState.getWritableStates(ContractService.NAME);
 
         try {
-            Set<SlotKey> modifiedKeys = states.get(STORAGE_KEY).modifiedKeys().stream()
+            Set<SlotKey> modifiedKeys = states.get(ContractStorageReadableKVState.KEY).modifiedKeys().stream()
                     .filter(SlotKey.class::isInstance)
                     .map(SlotKey.class::cast)
                     .filter(SlotKey::hasContractID)
@@ -290,7 +290,7 @@ public class OpcodeTracer implements HederaOperationTracer {
                     continue;
                 }
 
-                SlotValue slotValue = (SlotValue) states.get(STORAGE_KEY).get(slotKey);
+                SlotValue slotValue = (SlotValue) states.get(ContractStorageReadableKVState.KEY).get(slotKey);
                 if (slotValue != null) {
                     storageUpdates.put(
                             Bytes.of(slotKey.key().toByteArray()),
@@ -301,7 +301,7 @@ public class OpcodeTracer implements HederaOperationTracer {
             log.warn(
                     "Failed to retrieve modified storage keys for service: {}, key: {}",
                     ContractService.NAME,
-                    STORAGE_KEY,
+                    ContractStorageReadableKVState.KEY,
                     e);
         }
 

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -221,6 +221,12 @@ public final class EntityIdUtils {
                 .build();
     }
 
+    public static com.hedera.hapi.node.base.ContractID toContractID(final Address address) {
+        return com.hedera.hapi.node.base.ContractID.newBuilder()
+                .contractNum(numFromEvmAddress(address.toArrayUnsafe()))
+                .build();
+    }
+
     public static Address toAddress(final com.hedera.pbj.runtime.io.buffer.Bytes bytes) {
         final var evmAddressBytes = bytes.toByteArray();
         return Address.wrap(org.apache.tuweni.bytes.Bytes.wrap(evmAddressBytes));
@@ -265,10 +271,6 @@ public final class EntityIdUtils {
 
     public static String asHexedEvmAddress(final Id id) {
         return CommonUtils.hex(asEvmAddress(id.num()));
-    }
-
-    public static Address asHexedEvmAddress(final com.hedera.hapi.node.base.ContractID id) {
-        return Address.fromHexString(CommonUtils.hex(asEvmAddress(id.contractNum())));
     }
 
     public static boolean isAlias(final AccountID idOrAlias) {

--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -267,6 +267,10 @@ public final class EntityIdUtils {
         return CommonUtils.hex(asEvmAddress(id.num()));
     }
 
+    public static Address asHexedEvmAddress(final com.hedera.hapi.node.base.ContractID id) {
+        return Address.fromHexString(CommonUtils.hex(asEvmAddress(id.contractNum())));
+    }
+
     public static boolean isAlias(final AccountID idOrAlias) {
         return idOrAlias.getAccountNum() == 0 && !idOrAlias.getAlias().isEmpty();
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/MirrorEvmMessageCallProcessorTest.java
@@ -33,6 +33,8 @@ import static org.mockito.Mockito.when;
 import com.hedera.mirror.web3.evm.config.PrecompilesHolder;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.OpcodeTracer;
 import com.hedera.mirror.web3.evm.contracts.execution.traceability.OpcodeTracerOptions;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.state.MirrorNodeState;
 import com.hedera.node.app.service.evm.contracts.execution.HederaBlockValues;
 import com.hedera.node.app.service.evm.contracts.operations.HederaExceptionalHaltReason;
 import com.hedera.services.stream.proto.ContractActionType;
@@ -59,6 +61,12 @@ class MirrorEvmMessageCallProcessorTest extends MirrorEvmMessageCallProcessorBas
     @Mock
     private PrecompilesHolder precompilesHolder;
 
+    @Mock
+    private MirrorNodeEvmProperties evmProperties;
+
+    @Mock
+    private MirrorNodeState mirrorNodeState;
+
     private OpcodeTracer opcodeTracer;
     private MirrorEvmMessageCallProcessor subject;
 
@@ -66,7 +74,7 @@ class MirrorEvmMessageCallProcessorTest extends MirrorEvmMessageCallProcessorBas
     void setUp() {
         when(precompilesHolder.getHederaPrecompiles()).thenReturn(hederaPrecompileList);
         when(messageFrame.getWorldUpdater()).thenReturn(updater);
-        opcodeTracer = Mockito.spy(new OpcodeTracer(precompilesHolder));
+        opcodeTracer = Mockito.spy(new OpcodeTracer(precompilesHolder, evmProperties, mirrorNodeState));
         subject = new MirrorEvmMessageCallProcessor(
                 autoCreationLogic,
                 entityAddressSequencer,

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracerTest.java
@@ -36,6 +36,8 @@ import static org.hyperledger.besu.evm.frame.MessageFrame.Type.CONTRACT_CREATION
 import static org.hyperledger.besu.evm.frame.MessageFrame.Type.MESSAGE_CALL;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -45,18 +47,29 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSortedMap;
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.state.contract.SlotKey;
+import com.hedera.hapi.node.state.contract.SlotValue;
 import com.hedera.mirror.common.domain.contract.ContractAction;
 import com.hedera.mirror.common.domain.entity.EntityId;
 import com.hedera.mirror.common.domain.entity.EntityType;
 import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.evm.config.PrecompilesHolder;
+import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
+import com.hedera.mirror.web3.state.core.MapWritableStates;
+import com.hedera.node.app.service.contract.ContractService;
 import com.hedera.services.stream.proto.CallOperationType;
 import com.hedera.services.stream.proto.ContractActionType;
+import com.hedera.services.utils.EntityIdUtils;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.swirlds.state.State;
+import com.swirlds.state.spi.WritableKVState;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -101,6 +114,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class OpcodeTracerTest {
 
+    private static final String CONTRACT_SERVICE = ContractService.NAME;
+    private static final String STORAGE_KEY = "STORAGE";
     private static final Address CONTRACT_ADDRESS = Address.fromHexString("0x123");
     private static final Address ETH_PRECOMPILE_ADDRESS = Address.fromHexString("0x01");
     private static final Address HTS_PRECOMPILE_ADDRESS = Address.fromHexString(HTS_PRECOMPILED_CONTRACT_ADDRESS);
@@ -116,11 +131,10 @@ class OpcodeTracerTest {
             return new OperationResult(GAS_COST, null);
         }
     };
+    private static MockedStatic<ContractCallContext> contextMockedStatic;
 
     @Spy
     private ContractCallContext contractCallContext;
-
-    private static MockedStatic<ContractCallContext> contextMockedStatic;
 
     @Mock
     private WorldUpdater worldUpdater;
@@ -130,6 +144,12 @@ class OpcodeTracerTest {
 
     @Mock
     private PrecompilesHolder precompilesHolder;
+
+    @Mock
+    private MirrorNodeEvmProperties mirrorNodeEvmProperties;
+
+    @Mock
+    private State mirrorNodeState;
 
     // Transient test data
     private OpcodeTracer tracer;
@@ -167,7 +187,7 @@ class OpcodeTracerTest {
                         EXCHANGE_RATE_SYSTEM_CONTRACT_ADDRESS,
                         mock(PrecompiledContract.class)));
         REMAINING_GAS.set(INITIAL_GAS);
-        tracer = new OpcodeTracer(precompilesHolder);
+        tracer = new OpcodeTracer(precompilesHolder, mirrorNodeEvmProperties, mirrorNodeState);
         tracerOptions = new OpcodeTracerOptions(false, false, false);
         contextMockedStatic.when(ContractCallContext::get).thenReturn(contractCallContext);
     }
@@ -188,14 +208,20 @@ class OpcodeTracerTest {
                 MutableAccount account = worldUpdater.getAccount(frame.getRecipientAddress());
                 if (account != null) {
                     assertThat(account).isEqualTo(recipientAccount);
-                    verify(recipientAccount, times(1)).getUpdatedStorage();
+                    if (!mirrorNodeEvmProperties.isModularizedServices()) {
+                        verify(recipientAccount, times(1)).getUpdatedStorage();
+                    }
                 }
             } catch (final ModificationNotAllowedException e) {
-                verify(recipientAccount, never()).getUpdatedStorage();
+                if (!mirrorNodeEvmProperties.isModularizedServices()) {
+                    verify(recipientAccount, never()).getUpdatedStorage();
+                }
             }
         } else {
             verify(worldUpdater, never()).getAccount(any());
-            verify(recipientAccount, never()).getUpdatedStorage();
+            if (!mirrorNodeEvmProperties.isModularizedServices()) {
+                verify(recipientAccount, never()).getUpdatedStorage();
+            }
         }
     }
 
@@ -463,6 +489,161 @@ class OpcodeTracerTest {
         final Opcode opcode = executeOperation(frame);
         assertThat(opcode.storage()).isNotEmpty();
         assertThat(opcode.storage()).containsAllEntriesOf(updatedStorage);
+    }
+
+    @Test
+    @DisplayName("given storage is enabled in tracer options, should record storage for modularized services")
+    void shouldRecordStorageWhenEnabledModularized() {
+        // Given
+        tracerOptions = tracerOptions.toBuilder().storage(true).build();
+        when(mirrorNodeEvmProperties.isModularizedServices()).thenReturn(true);
+        frame = setupInitialFrame(tracerOptions);
+
+        // Mock writable states
+        MapWritableStates mockStates = mock(MapWritableStates.class);
+        when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
+        WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
+        doReturn(mockStorageState).when(mockStates).get(STORAGE_KEY);
+
+        // Mock SlotKey and SlotValue
+        SlotKey slotKey = createMockSlotKey();
+        SlotValue slotValue = createMockSlotValue(UInt256.valueOf(233));
+
+        // Mock modified keys retrieval
+        when(mockStorageState.modifiedKeys()).thenReturn(Set.of(slotKey));
+        when(mockStorageState.get(slotKey)).thenReturn(slotValue);
+
+        // Expected storage map
+        final Map<UInt256, UInt256> expectedStorage = ImmutableSortedMap.of(UInt256.ZERO, UInt256.valueOf(233));
+
+        // When
+        final Opcode opcode = executeOperation(frame);
+
+        // Then
+        assertThat(opcode.storage()).isNotEmpty().containsAllEntriesOf(expectedStorage);
+    }
+
+    @Test
+    @DisplayName(
+            "given storage is enabled in tracer options, should return empty storage when there are no updates for modularized services")
+    void shouldReturnEmptyStorageWhenThereAreNoUpdates() {
+        // Given
+        tracerOptions = tracerOptions.toBuilder().storage(true).build();
+        when(mirrorNodeEvmProperties.isModularizedServices()).thenReturn(true);
+        frame = setupInitialFrame(tracerOptions);
+
+        // Mock writable states
+        MapWritableStates mockStates = mock(MapWritableStates.class);
+        when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
+        WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
+        doReturn(mockStorageState).when(mockStates).get(STORAGE_KEY);
+
+        // Mock empty modified keys retrieval
+        when(mockStorageState.modifiedKeys()).thenReturn(Collections.emptySet());
+
+        // When
+        final Opcode opcode = executeOperation(frame);
+
+        // Then
+        assertThat(opcode.storage()).isEmpty();
+    }
+
+    @Test
+    @DisplayName(
+            "given storage is enabled in tracer options, should skip slotKey when hasContractID is false for modularized services")
+    void shouldSkipSlotKeyWhenHasContractIDIsFalse() {
+        // Given
+        tracerOptions = tracerOptions.toBuilder().storage(true).build();
+        when(mirrorNodeEvmProperties.isModularizedServices()).thenReturn(true);
+        frame = setupInitialFrame(tracerOptions);
+
+        MapWritableStates mockStates = mock(MapWritableStates.class);
+        when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
+        WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
+        doReturn(mockStorageState).when(mockStates).get(STORAGE_KEY);
+
+        SlotKey slotKeyWithoutContractID = mock(SlotKey.class);
+        when(slotKeyWithoutContractID.hasContractID()).thenReturn(false);
+
+        when(mockStorageState.modifiedKeys()).thenReturn(Set.of(slotKeyWithoutContractID));
+
+        // When
+        final Opcode opcode = executeOperation(frame);
+
+        // Then
+        assertThat(opcode.storage()).isEmpty();
+    }
+
+    @Test
+    @DisplayName(
+            "given storage is enabled in tracer options, should skip slotKey when contract address does not match for modularized services")
+    void shouldSkipSlotKeyWhenContractAddressDoesNotMatch() {
+        // Given
+        tracerOptions = tracerOptions.toBuilder().storage(true).build();
+        when(mirrorNodeEvmProperties.isModularizedServices()).thenReturn(true);
+        frame = setupInitialFrame(tracerOptions);
+
+        MapWritableStates mockStates = mock(MapWritableStates.class);
+        when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
+        WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
+        doReturn(mockStorageState).when(mockStates).get(STORAGE_KEY);
+
+        SlotKey mismatchedSlotKey = createMockSlotKey(Address.fromHexString("0xDEADBEEF"));
+        when(mockStorageState.modifiedKeys()).thenReturn(Set.of(mismatchedSlotKey));
+
+        // When
+        final Opcode opcode = executeOperation(frame);
+
+        // Then
+        assertThat(opcode.storage()).isEmpty();
+    }
+
+    @Test
+    @DisplayName(
+            "given storage is enabled in tracer options, should skip slotKey when slotValue is null for modularized services")
+    void shouldSkipSlotKeyWhenSlotValueIsNull() {
+        // Given
+        tracerOptions = tracerOptions.toBuilder().storage(true).build();
+        when(mirrorNodeEvmProperties.isModularizedServices()).thenReturn(true);
+        frame = setupInitialFrame(tracerOptions);
+
+        MapWritableStates mockStates = mock(MapWritableStates.class);
+        when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
+        WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
+        doReturn(mockStorageState).when(mockStates).get(STORAGE_KEY);
+
+        SlotKey slotKey = createMockSlotKey(CONTRACT_ADDRESS);
+
+        when(mockStorageState.modifiedKeys()).thenReturn(Set.of(slotKey));
+        when(mockStorageState.get(slotKey)).thenReturn(null); // SlotValue is null
+
+        // When
+        final Opcode opcode = executeOperation(frame);
+
+        // Then
+        assertThat(opcode.storage()).isEmpty();
+    }
+
+    @Test
+    @DisplayName(
+            "given storage is enabled in tracer options, should return empty storage when STORAGE_KEY retrieval fails for modularized services")
+    void shouldReturnEmptyStorageWhenStorageKeyRetrievalFails() {
+        // Given
+        tracerOptions = tracerOptions.toBuilder().storage(true).build();
+        when(mirrorNodeEvmProperties.isModularizedServices()).thenReturn(true);
+        frame = setupInitialFrame(tracerOptions);
+
+        MapWritableStates mockStates = mock(MapWritableStates.class);
+        when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
+
+        // Mock storage retrieval to throw IllegalArgumentException
+        when(mockStates.get(STORAGE_KEY)).thenThrow(new IllegalArgumentException("Storage retrieval failed"));
+
+        // When
+        final Opcode opcode = executeOperation(frame);
+
+        // Then
+        assertThat(opcode.storage()).isEmpty(); // Ensures empty storage response instead of exception
     }
 
     @Test
@@ -756,7 +937,9 @@ class OpcodeTracerTest {
                 UInt256.ZERO, UInt256.valueOf(233),
                 UInt256.ONE, UInt256.valueOf(2424));
 
-        when(recipientAccount.getUpdatedStorage()).thenReturn(storage);
+        if (!mirrorNodeEvmProperties.isModularizedServices()) {
+            when(recipientAccount.getUpdatedStorage()).thenReturn(storage);
+        }
         when(worldUpdater.getAccount(frame.getRecipientAddress())).thenReturn(recipientAccount);
 
         return storage;
@@ -862,5 +1045,43 @@ class OpcodeTracerTest {
                 .resultDataType(resultDataType)
                 .value(1L)
                 .build();
+    }
+
+    /**
+     * Helper method to create a mocked SlotKey with a specified contract address. Uses lenient stubbing to prevent
+     * UnnecessaryStubbingException in certain tests.
+     */
+    private SlotKey createMockSlotKey(Address contractAddress) {
+        SlotKey slotKey = mock(SlotKey.class);
+
+        when(slotKey.hasContractID()).thenReturn(true);
+
+        ContractID testContractId = com.hedera.hapi.node.base.ContractID.newBuilder()
+                .contractNum(EntityIdUtils.numFromEvmAddress(contractAddress.toArray()))
+                .build();
+
+        lenient().when(slotKey.contractID()).thenReturn(testContractId);
+        lenient().when(slotKey.key()).thenReturn(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(UInt256.ZERO.toArray()));
+
+        return slotKey;
+    }
+
+    /**
+     * Overloaded method to create a SlotKey with the default contract address.
+     */
+    /**
+     * Overloaded method to create a SlotKey with the default contract address.
+     */
+    private SlotKey createMockSlotKey() {
+        return createMockSlotKey(OpcodeTracerTest.CONTRACT_ADDRESS);
+    }
+
+    /**
+     * Helper method to create a mocked SlotValue.
+     */
+    private SlotValue createMockSlotValue(UInt256 value) {
+        SlotValue slotValue = mock(SlotValue.class);
+        when(slotValue.value()).thenReturn(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(value.toArray()));
+        return slotValue;
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracerTest.java
@@ -637,8 +637,8 @@ class OpcodeTracerTest {
         when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
 
         // Mock storage retrieval to throw IllegalArgumentException
-        when(mockStates.get(ContractStorageReadableKVState.KEY)).thenThrow(
-                new IllegalArgumentException("Storage retrieval failed"));
+        when(mockStates.get(ContractStorageReadableKVState.KEY))
+                .thenThrow(new IllegalArgumentException("Storage retrieval failed"));
 
         // When
         final Opcode opcode = executeOperation(frame);
@@ -792,7 +792,7 @@ class OpcodeTracerTest {
         assertThat(opcodeForPrecompileCall.reason())
                 .isNotEmpty()
                 .isEqualTo(getAbiEncodedRevertReason(Bytes.of(
-                        ResponseCodeEnum.INVALID_ACCOUNT_ID.name().getBytes()))
+                                ResponseCodeEnum.INVALID_ACCOUNT_ID.name().getBytes()))
                         .toHexString());
     }
 
@@ -947,8 +947,8 @@ class OpcodeTracerTest {
     }
 
     private UInt256[] setupStackForCapture(final MessageFrame frame) {
-        final UInt256[] stack = new UInt256[]{
-                UInt256.fromHexString("0x01"), UInt256.fromHexString("0x02"), UInt256.fromHexString("0x03")
+        final UInt256[] stack = new UInt256[] {
+            UInt256.fromHexString("0x01"), UInt256.fromHexString("0x02"), UInt256.fromHexString("0x03")
         };
 
         for (final UInt256 stackItem : stack) {
@@ -959,8 +959,8 @@ class OpcodeTracerTest {
     }
 
     private Bytes[] setupMemoryForCapture(final MessageFrame frame) {
-        final Bytes[] words = new Bytes[]{
-                Bytes.fromHexString("0x01", 32), Bytes.fromHexString("0x02", 32), Bytes.fromHexString("0x03", 32)
+        final Bytes[] words = new Bytes[] {
+            Bytes.fromHexString("0x01", 32), Bytes.fromHexString("0x02", 32), Bytes.fromHexString("0x03", 32)
         };
 
         for (int i = 0; i < words.length; i++) {
@@ -1006,8 +1006,7 @@ class OpcodeTracerTest {
                 .code(CodeV0.EMPTY_CODE)
                 .sender(Address.ZERO)
                 .originator(Address.ZERO)
-                .completer(ignored -> {
-                })
+                .completer(ignored -> {})
                 .miningBeneficiary(Address.ZERO)
                 .address(recipientAddress)
                 .contract(recipientAddress)

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracerTest.java
@@ -57,6 +57,7 @@ import com.hedera.mirror.web3.common.ContractCallContext;
 import com.hedera.mirror.web3.evm.config.PrecompilesHolder;
 import com.hedera.mirror.web3.evm.properties.MirrorNodeEvmProperties;
 import com.hedera.mirror.web3.state.core.MapWritableStates;
+import com.hedera.mirror.web3.state.keyvalue.ContractStorageReadableKVState;
 import com.hedera.node.app.service.contract.ContractService;
 import com.hedera.services.stream.proto.CallOperationType;
 import com.hedera.services.stream.proto.ContractActionType;
@@ -115,7 +116,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class OpcodeTracerTest {
 
     private static final String CONTRACT_SERVICE = ContractService.NAME;
-    private static final String STORAGE_KEY = "STORAGE";
     private static final Address CONTRACT_ADDRESS = Address.fromHexString("0x123");
     private static final Address ETH_PRECOMPILE_ADDRESS = Address.fromHexString("0x01");
     private static final Address HTS_PRECOMPILE_ADDRESS = Address.fromHexString(HTS_PRECOMPILED_CONTRACT_ADDRESS);
@@ -503,7 +503,7 @@ class OpcodeTracerTest {
         MapWritableStates mockStates = mock(MapWritableStates.class);
         when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
         WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
-        doReturn(mockStorageState).when(mockStates).get(STORAGE_KEY);
+        doReturn(mockStorageState).when(mockStates).get(ContractStorageReadableKVState.KEY);
 
         // Mock SlotKey and SlotValue
         SlotKey slotKey = createMockSlotKey();
@@ -536,7 +536,7 @@ class OpcodeTracerTest {
         MapWritableStates mockStates = mock(MapWritableStates.class);
         when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
         WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
-        doReturn(mockStorageState).when(mockStates).get(STORAGE_KEY);
+        doReturn(mockStorageState).when(mockStates).get(ContractStorageReadableKVState.KEY);
 
         // Mock empty modified keys retrieval
         when(mockStorageState.modifiedKeys()).thenReturn(Collections.emptySet());
@@ -560,7 +560,7 @@ class OpcodeTracerTest {
         MapWritableStates mockStates = mock(MapWritableStates.class);
         when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
         WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
-        doReturn(mockStorageState).when(mockStates).get(STORAGE_KEY);
+        doReturn(mockStorageState).when(mockStates).get(ContractStorageReadableKVState.KEY);
 
         SlotKey slotKeyWithoutContractID = mock(SlotKey.class);
         when(slotKeyWithoutContractID.hasContractID()).thenReturn(false);
@@ -586,7 +586,7 @@ class OpcodeTracerTest {
         MapWritableStates mockStates = mock(MapWritableStates.class);
         when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
         WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
-        doReturn(mockStorageState).when(mockStates).get(STORAGE_KEY);
+        doReturn(mockStorageState).when(mockStates).get(ContractStorageReadableKVState.KEY);
 
         SlotKey mismatchedSlotKey = createMockSlotKey(Address.fromHexString("0xDEADBEEF"));
         when(mockStorageState.modifiedKeys()).thenReturn(Set.of(mismatchedSlotKey));
@@ -610,7 +610,7 @@ class OpcodeTracerTest {
         MapWritableStates mockStates = mock(MapWritableStates.class);
         when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
         WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
-        doReturn(mockStorageState).when(mockStates).get(STORAGE_KEY);
+        doReturn(mockStorageState).when(mockStates).get(ContractStorageReadableKVState.KEY);
 
         SlotKey slotKey = createMockSlotKey(CONTRACT_ADDRESS);
 
@@ -637,7 +637,8 @@ class OpcodeTracerTest {
         when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
 
         // Mock storage retrieval to throw IllegalArgumentException
-        when(mockStates.get(STORAGE_KEY)).thenThrow(new IllegalArgumentException("Storage retrieval failed"));
+        when(mockStates.get(ContractStorageReadableKVState.KEY)).thenThrow(
+                new IllegalArgumentException("Storage retrieval failed"));
 
         // When
         final Opcode opcode = executeOperation(frame);
@@ -791,7 +792,7 @@ class OpcodeTracerTest {
         assertThat(opcodeForPrecompileCall.reason())
                 .isNotEmpty()
                 .isEqualTo(getAbiEncodedRevertReason(Bytes.of(
-                                ResponseCodeEnum.INVALID_ACCOUNT_ID.name().getBytes()))
+                        ResponseCodeEnum.INVALID_ACCOUNT_ID.name().getBytes()))
                         .toHexString());
     }
 
@@ -946,8 +947,8 @@ class OpcodeTracerTest {
     }
 
     private UInt256[] setupStackForCapture(final MessageFrame frame) {
-        final UInt256[] stack = new UInt256[] {
-            UInt256.fromHexString("0x01"), UInt256.fromHexString("0x02"), UInt256.fromHexString("0x03")
+        final UInt256[] stack = new UInt256[]{
+                UInt256.fromHexString("0x01"), UInt256.fromHexString("0x02"), UInt256.fromHexString("0x03")
         };
 
         for (final UInt256 stackItem : stack) {
@@ -958,8 +959,8 @@ class OpcodeTracerTest {
     }
 
     private Bytes[] setupMemoryForCapture(final MessageFrame frame) {
-        final Bytes[] words = new Bytes[] {
-            Bytes.fromHexString("0x01", 32), Bytes.fromHexString("0x02", 32), Bytes.fromHexString("0x03", 32)
+        final Bytes[] words = new Bytes[]{
+                Bytes.fromHexString("0x01", 32), Bytes.fromHexString("0x02", 32), Bytes.fromHexString("0x03", 32)
         };
 
         for (int i = 0; i < words.length; i++) {
@@ -1005,7 +1006,8 @@ class OpcodeTracerTest {
                 .code(CodeV0.EMPTY_CODE)
                 .sender(Address.ZERO)
                 .originator(Address.ZERO)
-                .completer(ignored -> {})
+                .completer(ignored -> {
+                })
                 .miningBeneficiary(Address.ZERO)
                 .address(recipientAddress)
                 .contract(recipientAddress)
@@ -1066,9 +1068,6 @@ class OpcodeTracerTest {
         return slotKey;
     }
 
-    /**
-     * Overloaded method to create a SlotKey with the default contract address.
-     */
     /**
      * Overloaded method to create a SlotKey with the default contract address.
      */

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracerTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/evm/contracts/execution/traceability/OpcodeTracerTest.java
@@ -550,32 +550,6 @@ class OpcodeTracerTest {
 
     @Test
     @DisplayName(
-            "given storage is enabled in tracer options, should skip slotKey when hasContractID is false for modularized services")
-    void shouldSkipSlotKeyWhenHasContractIDIsFalse() {
-        // Given
-        tracerOptions = tracerOptions.toBuilder().storage(true).build();
-        when(mirrorNodeEvmProperties.isModularizedServices()).thenReturn(true);
-        frame = setupInitialFrame(tracerOptions);
-
-        MapWritableStates mockStates = mock(MapWritableStates.class);
-        when(mirrorNodeState.getWritableStates(CONTRACT_SERVICE)).thenReturn(mockStates);
-        WritableKVState<SlotKey, SlotValue> mockStorageState = mock(WritableKVState.class);
-        doReturn(mockStorageState).when(mockStates).get(ContractStorageReadableKVState.KEY);
-
-        SlotKey slotKeyWithoutContractID = mock(SlotKey.class);
-        when(slotKeyWithoutContractID.hasContractID()).thenReturn(false);
-
-        when(mockStorageState.modifiedKeys()).thenReturn(Set.of(slotKeyWithoutContractID));
-
-        // When
-        final Opcode opcode = executeOperation(frame);
-
-        // Then
-        assertThat(opcode.storage()).isEmpty();
-    }
-
-    @Test
-    @DisplayName(
             "given storage is enabled in tracer options, should skip slotKey when contract address does not match for modularized services")
     void shouldSkipSlotKeyWhenContractAddressDoesNotMatch() {
         // Given
@@ -1054,8 +1028,6 @@ class OpcodeTracerTest {
      */
     private SlotKey createMockSlotKey(Address contractAddress) {
         SlotKey slotKey = mock(SlotKey.class);
-
-        when(slotKey.hasContractID()).thenReturn(true);
 
         ContractID testContractId = com.hedera.hapi.node.base.ContractID.newBuilder()
                 .contractNum(EntityIdUtils.numFromEvmAddress(contractAddress.toArray()))

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/OpcodeServiceTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/OpcodeServiceTest.java
@@ -549,7 +549,7 @@ class OpcodeServiceTest extends AbstractContractCallServiceOpcodeTracerTest {
         final var contract = testWeb3jService.deploy(ExchangeRatePrecompile::deploy);
         final var functionCall = contract.call_tinybarsToTinycents(BigInteger.TEN);
         final var callData = functionCall.encodeFunctionCall().getBytes();
-        final var senderEntity = accountPersist();
+        final var senderEntity = accountEntityPersist();
         final var consensusTimestamp = domainBuilder.timestamp();
         final var transactionIdOrHash = setUp(
                 TransactionType.CONTRACTCALL,
@@ -574,7 +574,7 @@ class OpcodeServiceTest extends AbstractContractCallServiceOpcodeTracerTest {
         final var contract = testWeb3jService.deploy(ExchangeRatePrecompile::deploy);
         final var functionCall = contract.call_tinybarsToTinycents(BigInteger.TEN);
         final var callData = functionCall.encodeFunctionCall().getBytes();
-        final var senderEntity = accountPersist();
+        final var senderEntity = accountEntityPersist();
 
         final var transactionIdOrHash = setUp(
                 TransactionType.CONTRACTCALL,
@@ -897,10 +897,6 @@ class OpcodeServiceTest extends AbstractContractCallServiceOpcodeTracerTest {
                         .serialNumber(1))
                 .persist();
         return token;
-    }
-
-    private Entity accountPersist() {
-        return domainBuilder.entity().customize(a -> a.evmAddress(null)).persist();
     }
 
     private Entity accountPersistWithAccountBalances() {

--- a/hedera-mirror-web3/src/test/solidity/StorageContract.sol
+++ b/hedera-mirror-web3/src/test/solidity/StorageContract.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract StorageContract {
+    mapping(uint256 => uint256) public storageMap;
+    uint256 public storedValue;
+
+    function updateStorage(uint256 key, uint256 value) public {
+        storageMap[key] = value; // SSTORE operation
+    }
+
+    function updateSingleValue(uint256 value) public {
+        storedValue = value; // SSTORE operation
+    }
+}


### PR DESCRIPTION
**Description**:

This PR is a copy of https://github.com/hashgraph/hedera-mirror-node/pull/10307. (It was checkout from the pr fixing the states caching but it will be delayed due to needed upstream changes). So opening with main as base branch.

This PR fixes storage capturing in modularized execution.
Storage values are now read from mirror node writable states during execution.
Added a test who actually modifies storage of a contract and can verify execution.
This pr also fixes 4 failing test in `OpcodeServiceTests`. Now `OpcodeServiceTest` fixes are completed.

Changes:
`OpcodeTracer` - reads storage changes from writablestates - STORAGE_KEY for modularized
`OpcodeTracerTest` - adds codecov for new methods
`OpcodeServiceTest` - adds new test contract which modifies contract storage and verifies storage changes

**Related issue(s)**:

Fixes #10259 

**Notes for reviewer**:
This PR only captures properly storage changes from state after fixes from https://github.com/hashgraph/hedera-mirror-node/pull/10306 but since the mentioned PR might require changes upstream. In order not to slow down this PR it's opened from main. Tests will be passing but storage changes will be empty for now until resolution of the above PR where state will be properly populated.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
