### PR TITLE
HIP-1056 Read previous hash from block proof

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/BlockFile.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/BlockFile.java
@@ -44,10 +44,8 @@ public class BlockFile implements StreamFile<BlockItem> {
     private static final char BASENAME_PADDING = '0';
     private static final String COMPRESSED_FILE_SUFFIX = ".blk.gz";
 
-    // Contains the block number and the previous block hash
     private BlockHeader blockHeader;
 
-    // Used to generate block hash
     private BlockProof blockProof;
 
     @ToString.Exclude

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/block/ProtoBlockFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/block/ProtoBlockFileReader.java
@@ -131,7 +131,7 @@ public class ProtoBlockFileReader implements BlockFileReader {
         var blockFile = context.getBlockFile();
         var blockProof = blockItem.getBlockProof();
         var blockRootHashDigest = context.getBlockRootHashDigest();
-        var previousHash = DomainUtils.toBytes(blockProof.getPreviousBlockRootHash());
+        byte[] previousHash = DomainUtils.toBytes(blockProof.getPreviousBlockRootHash());
         blockFile.blockProof(blockProof).previousHash(DomainUtils.bytesToHex(previousHash));
         blockRootHashDigest.setPreviousHash(previousHash);
         blockRootHashDigest.setStartOfBlockStateHash(DomainUtils.toBytes(blockProof.getStartOfBlockStateRootHash()));

--- a/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/block/ProtoBlockFileReader.java
+++ b/hedera-mirror-importer/src/main/java/com/hedera/mirror/importer/reader/block/ProtoBlockFileReader.java
@@ -116,13 +116,10 @@ public class ProtoBlockFileReader implements BlockFileReader {
         Long consensusStart = blockHeader.hasFirstTransactionConsensusTime()
                 ? DomainUtils.timestampInNanosMax(blockHeader.getFirstTransactionConsensusTime())
                 : null;
-        var previousHash = DomainUtils.toBytes(blockHeader.getPreviousBlockHash());
         blockFileBuilder.blockHeader(blockHeader);
         blockFileBuilder.consensusStart(consensusStart);
         blockFileBuilder.consensusEnd(consensusStart);
         blockFileBuilder.index(blockHeader.getNumber());
-        blockFileBuilder.previousHash(DomainUtils.bytesToHex(previousHash));
-        context.getBlockRootHashDigest().setPreviousHash(previousHash);
     }
 
     private void readBlockProof(ReaderContext context) {
@@ -131,10 +128,13 @@ public class ProtoBlockFileReader implements BlockFileReader {
             throw new InvalidStreamFileException("Missing block proof in file " + context.getFilename());
         }
 
+        var blockFile = context.getBlockFile();
         var blockProof = blockItem.getBlockProof();
-        context.getBlockFile().blockProof(blockProof);
-        context.getBlockRootHashDigest()
-                .setStartOfBlockStateHash(DomainUtils.toBytes(blockProof.getStartOfBlockStateRootHash()));
+        var blockRootHashDigest = context.getBlockRootHashDigest();
+        var previousHash = DomainUtils.toBytes(blockProof.getPreviousBlockRootHash());
+        blockFile.blockProof(blockProof).previousHash(DomainUtils.bytesToHex(previousHash));
+        blockRootHashDigest.setPreviousHash(previousHash);
+        blockRootHashDigest.setStartOfBlockStateHash(DomainUtils.toBytes(blockProof.getStartOfBlockStateRootHash()));
     }
 
     private void readEvents(ReaderContext context) {

--- a/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/block/ProtoBlockFileReaderTest.java
+++ b/hedera-mirror-importer/src/test/java/com/hedera/mirror/importer/reader/block/ProtoBlockFileReaderTest.java
@@ -20,7 +20,6 @@ import static com.hedera.mirror.common.util.DomainUtils.NANOS_PER_SECOND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.google.protobuf.ByteString;
 import com.hedera.hapi.block.stream.input.protoc.EventHeader;
 import com.hedera.hapi.block.stream.input.protoc.RoundHeader;
 import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
@@ -32,6 +31,7 @@ import com.hedera.hapi.block.stream.protoc.RecordFileItem;
 import com.hedera.hapi.platform.event.legacy.EventTransaction;
 import com.hedera.mirror.common.domain.DigestAlgorithm;
 import com.hedera.mirror.common.domain.transaction.BlockFile;
+import com.hedera.mirror.common.util.DomainUtils;
 import com.hedera.mirror.importer.TestUtils;
 import com.hedera.mirror.importer.domain.StreamFileData;
 import com.hedera.mirror.importer.exception.InvalidStreamFileException;
@@ -183,7 +183,7 @@ public class ProtoBlockFileReaderTest {
         var eventHeader = BlockItem.newBuilder().setEventHeader(EventHeader.getDefaultInstance());
         var eventTransaction = BlockItem.newBuilder()
                 .setEventTransaction(EventTransaction.newBuilder()
-                        .setApplicationTransaction(ByteString.copyFrom(TestUtils.generateRandomByteArray(32))));
+                        .setApplicationTransaction(DomainUtils.fromBytes(TestUtils.generateRandomByteArray(32))));
         var transactionResult = BlockItem.newBuilder().setTransactionResult(TransactionResult.getDefaultInstance());
         var block = Block.newBuilder()
                 .addItems(blockHeader())
@@ -204,14 +204,15 @@ public class ProtoBlockFileReaderTest {
         return BlockItem.newBuilder()
                 .setBlockHeader(BlockHeader.newBuilder()
                         .setFirstTransactionConsensusTime(Timestamp.newBuilder().setSeconds(TIMESTAMP))
-                        .setPreviousBlockHash(ByteString.copyFrom(TestUtils.generateRandomByteArray(48))))
+                        .setPreviousBlockHash(DomainUtils.fromBytes(TestUtils.generateRandomByteArray(48))))
                 .build();
     }
 
     private BlockItem blockProof() {
         return BlockItem.newBuilder()
                 .setBlockProof(BlockProof.newBuilder()
-                        .setStartOfBlockStateRootHash(ByteString.copyFrom(TestUtils.generateRandomByteArray(48))))
+                        .setPreviousBlockRootHash(DomainUtils.fromBytes(TestUtils.generateRandomByteArray(48)))
+                        .setStartOfBlockStateRootHash(DomainUtils.fromBytes(TestUtils.generateRandomByteArray(48))))
                 .build();
     }
 


### PR DESCRIPTION
**Description**:

This PR changes block file reader to read previous hash from block proof.

**Related issue(s)**:

Fixes #10364 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
