### PR TITLE
Fix unboxing issue causing errors in acceptance tests

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/services/utils/EntityIdUtils.java
@@ -162,6 +162,9 @@ public final class EntityIdUtils {
     }
 
     public static com.hedera.hapi.node.base.AccountID toAccountId(final Long id) {
+        if (id == null) {
+            return null;
+        }
         final var decodedEntityId = EntityId.of(id);
 
         return toAccountId(decodedEntityId);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
@@ -201,21 +201,17 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         // Given
         final var notAssociatedAccount = accountEntityPersist();
 
-        final var tokenEntity = tokenEntityPersist();
-
-        domainBuilder
-                .token()
-                .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))
-                .persist();
-
+        final var tokenEntity = fungibleTokenPersist();
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
         // When
         final var functionCall = single
                 ? contract.call_associateTokenExternal(
-                        getAddressFromEntity(notAssociatedAccount), getAddressFromEntity(tokenEntity))
+                        getAddressFromEntity(notAssociatedAccount),
+                        toAddress(tokenEntity.getTokenId()).toHexString())
                 : contract.call_associateTokensExternal(
-                        getAddressFromEntity(notAssociatedAccount), List.of(getAddressFromEntity(tokenEntity)));
+                        getAddressFromEntity(notAssociatedAccount),
+                        List.of(toAddress(tokenEntity.getTokenId()).toHexString()));
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
@@ -232,21 +228,17 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                 .alias(null)
                 .evmAddress(null));
 
-        final var tokenEntity = tokenEntityPersist();
-
-        domainBuilder
-                .token()
-                .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))
-                .persist();
-
+        final var tokenEntity = fungibleTokenPersist();
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
         // When
         final var functionCall = single
                 ? contract.call_associateTokenExternal(
-                        getAddressFromEntity(notAssociatedAccount), getAddressFromEntity(tokenEntity))
+                        getAddressFromEntity(notAssociatedAccount),
+                        toAddress(tokenEntity.getTokenId()).toHexString())
                 : contract.call_associateTokensExternal(
-                        getAddressFromEntity(notAssociatedAccount), List.of(getAddressFromEntity(tokenEntity)));
+                        getAddressFromEntity(notAssociatedAccount),
+                        List.of(toAddress(tokenEntity.getTokenId()).toHexString()));
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
@@ -222,6 +222,37 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void associateTokenWithNullAutoRenew(final Boolean single) throws Exception {
+        // Given
+        final var notAssociatedAccount = accountEntityPersistCustomizable(e -> e.type(EntityType.ACCOUNT)
+                .balance(DEFAULT_ACCOUNT_BALANCE)
+                .autoRenewAccountId(null)
+                .alias(null)
+                .evmAddress(null));
+
+        final var tokenEntity = tokenEntityPersist();
+
+        domainBuilder
+                .token()
+                .customize(t -> t.tokenId(tokenEntity.getId()).type(TokenTypeEnum.FUNGIBLE_COMMON))
+                .persist();
+
+        final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
+
+        // When
+        final var functionCall = single
+                ? contract.call_associateTokenExternal(
+                        getAddressFromEntity(notAssociatedAccount), getAddressFromEntity(tokenEntity))
+                : contract.call_associateTokensExternal(
+                        getAddressFromEntity(notAssociatedAccount), List.of(getAddressFromEntity(tokenEntity)));
+
+        // Then
+        verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
+        verifyOpcodeTracerCall(functionCall.encodeFunctionCall(), contract);
+    }
+
     @Test
     void associateTokenHRC() throws Exception {
         // Given

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallServicePrecompileModificationTest.java
@@ -201,17 +201,17 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
         // Given
         final var notAssociatedAccount = accountEntityPersist();
 
-        final var tokenEntity = fungibleTokenPersist();
+        final var token = fungibleTokenPersist();
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
         // When
         final var functionCall = single
                 ? contract.call_associateTokenExternal(
                         getAddressFromEntity(notAssociatedAccount),
-                        toAddress(tokenEntity.getTokenId()).toHexString())
+                        toAddress(token.getTokenId()).toHexString())
                 : contract.call_associateTokensExternal(
                         getAddressFromEntity(notAssociatedAccount),
-                        List.of(toAddress(tokenEntity.getTokenId()).toHexString()));
+                        List.of(toAddress(token.getTokenId()).toHexString()));
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);
@@ -228,17 +228,17 @@ class ContractCallServicePrecompileModificationTest extends AbstractContractCall
                 .alias(null)
                 .evmAddress(null));
 
-        final var tokenEntity = fungibleTokenPersist();
+        final var token = fungibleTokenPersist();
         final var contract = testWeb3jService.deploy(ModificationPrecompileTestContract::deploy);
 
         // When
         final var functionCall = single
                 ? contract.call_associateTokenExternal(
                         getAddressFromEntity(notAssociatedAccount),
-                        toAddress(tokenEntity.getTokenId()).toHexString())
+                        toAddress(token.getTokenId()).toHexString())
                 : contract.call_associateTokensExternal(
                         getAddressFromEntity(notAssociatedAccount),
-                        List.of(toAddress(tokenEntity.getTokenId()).toHexString()));
+                        List.of(toAddress(token.getTokenId()).toHexString()));
 
         // Then
         verifyEthCallAndEstimateGas(functionCall, contract, ZERO_VALUE);

--- a/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/services/utils/EntityIdUtilsTest.java
@@ -278,6 +278,11 @@ class EntityIdUtilsTest {
     }
 
     @Test
+    void toAccountIdFromNullId() {
+        assertThat(EntityIdUtils.toAccountId((Long) null)).isNull();
+    }
+
+    @Test
     void toAccountIdFromShardRealmNum() {
         final var expectedAccountId = com.hedera.hapi.node.base.AccountID.newBuilder()
                 .shardNum(1)


### PR DESCRIPTION
**Description**:
After running acceptance tests against modularized web3 most of the web3 calls were failing. 
This was caused by a subtle bug caused by unboxing of null Long in `toAccountId` method called by `AccountReadableKVState`. `EntityId.of(id)` fails with nullPointer when id is null. 
Now just returning null if the id is null.
Reproduced with` Then I call estimateGas with associate function for fungible token` acceptance test.

* `ContractCallServicePrecompileModificationTest` - adds test to verify calls are passing null auto renew account now.
* `EntityIdUtils` - `toAccountId(final Long)` adds null check


**Related issue(s)**:

Partially completes #10374

**Notes for reviewer**:
Acceptance tests are now more stable but still need additional adjustments to make all pass.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
