### PR TITLE
Fix null previous block item

### DIFF
--- a/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/BlockItem.java
+++ b/hedera-mirror-common/src/main/java/com/hedera/mirror/common/domain/transaction/BlockItem.java
@@ -37,11 +37,11 @@ public record BlockItem(
         implements StreamItem {
 
     public BlockItem {
-        parent = parseParent(transactionResult, previous, parent);
+        parent = parseParent(transactionResult, previous);
         successful = parseSuccess(transactionResult, parent);
     }
 
-    private BlockItem parseParent(TransactionResult transactionResult, BlockItem previous, BlockItem parent) {
+    private BlockItem parseParent(TransactionResult transactionResult, BlockItem previous) {
         // set parent, parent-child items are assured to exist in sequential order of [Parent, Child1,..., ChildN]
         if (transactionResult.hasParentConsensusTimestamp() && previous != null) {
             var parentTimestamp = transactionResult.getParentConsensusTimestamp();


### PR DESCRIPTION
**Description**:

This PR fixes the null previous block item issue.

**Related issue(s)**:

Fixes #10376

**Notes for reviewer**:

Problem is `readEventTransactions` process all event transactions in a single event, so it'll lose context of previous event transactions in a preceding event 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
