### PR TITLE
Configure GraphQL parsing limits

### DIFF
--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/CustomExceptionResolver.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/CustomExceptionResolver.java
@@ -16,6 +16,7 @@
 
 package com.hedera.mirror.graphql.config;
 
+import com.hedera.mirror.common.exception.MirrorNodeException;
 import graphql.ErrorType;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorBuilder;
@@ -27,7 +28,9 @@ import org.springframework.graphql.execution.DataFetcherExceptionResolverAdapter
 public class CustomExceptionResolver extends DataFetcherExceptionResolverAdapter {
     @Override
     protected GraphQLError resolveToSingleError(Throwable ex, DataFetchingEnvironment env) {
-        if (ex instanceof IllegalStateException || ex instanceof IllegalArgumentException) {
+        if (ex instanceof IllegalStateException
+                || ex instanceof IllegalArgumentException
+                || ex instanceof MirrorNodeException) {
             return GraphqlErrorBuilder.newError()
                     .errorType(ErrorType.ValidationError)
                     .message(ex.getMessage())

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/GraphQlConfiguration.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/GraphQlConfiguration.java
@@ -16,24 +16,50 @@
 
 package com.hedera.mirror.graphql.config;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.StreamWriteConstraints;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.hedera.mirror.graphql.scalar.GraphQlDuration;
 import com.hedera.mirror.graphql.scalar.GraphQlTimestamp;
+import graphql.analysis.MaxQueryComplexityInstrumentation;
+import graphql.analysis.MaxQueryDepthInstrumentation;
+import graphql.execution.instrumentation.ChainedInstrumentation;
 import graphql.execution.preparsed.PreparsedDocumentProvider;
+import graphql.parser.ParserOptions;
+import graphql.parser.ParserOptions.Builder;
 import graphql.scalars.ExtendedScalars;
 import graphql.schema.idl.SchemaDirectiveWiring;
 import graphql.validation.rules.OnValidationErrorStrategy;
 import graphql.validation.rules.ValidationRules;
 import graphql.validation.schemawiring.ValidationSchemaWiring;
+import java.util.function.Consumer;
 import org.springframework.boot.autoconfigure.graphql.GraphQlSourceBuilderCustomizer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.graphql.execution.RuntimeWiringConfigurer;
 
 @Configuration
 class GraphQlConfiguration {
+
+    static {
+        // Configure GraphQL parsing limits to reject malicious input
+        Consumer<Builder> consumer =
+                b -> b.maxCharacters(10000).maxRuleDepth(10).maxTokens(1000).maxWhitespaceTokens(1000);
+        ParserOptions.setDefaultParserOptions(
+                ParserOptions.getDefaultParserOptions().transform(consumer));
+        ParserOptions.setDefaultOperationParserOptions(
+                ParserOptions.getDefaultOperationParserOptions().transform(consumer));
+    }
+
     @Bean
     GraphQlSourceBuilderCustomizer graphQlCustomizer(PreparsedDocumentProvider provider) {
-        return b -> b.configureGraphQl(graphQL -> graphQL.preparsedDocumentProvider(provider));
+        var maxQueryComplexity = new MaxQueryComplexityInstrumentation(20);
+        var maxQueryDepth = new MaxQueryDepthInstrumentation(10);
+        var instrumentation = new ChainedInstrumentation(maxQueryComplexity, maxQueryDepth);
+
+        return b -> b.configureGraphQl(
+                graphQL -> graphQL.instrumentation(instrumentation).preparsedDocumentProvider(provider));
     }
 
     @Bean
@@ -52,5 +78,26 @@ class GraphQlConfiguration {
                 .onValidationErrorStrategy(OnValidationErrorStrategy.RETURN_NULL)
                 .build();
         return new ValidationSchemaWiring(validationRules);
+    }
+
+    // Configure JSON parsing limits to reject malicious input
+    @Bean
+    Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
+        return builder -> {
+            var streamReadConstraints = StreamReadConstraints.builder()
+                    .maxDocumentLength(11000)
+                    .maxNameLength(100)
+                    .maxNestingDepth(10)
+                    .maxNumberLength(8)
+                    .maxStringLength(11000)
+                    .maxTokenCount(100)
+                    .build();
+            var streamWriteConstraints =
+                    StreamWriteConstraints.builder().maxNestingDepth(100).build();
+            var factory = new MappingJsonFactory();
+            factory.setStreamReadConstraints(streamReadConstraints);
+            factory.setStreamWriteConstraints(streamWriteConstraints);
+            builder.factory(factory);
+        };
     }
 }

--- a/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/GraphQlConfiguration.java
+++ b/hedera-mirror-graphql/src/main/java/com/hedera/mirror/graphql/config/GraphQlConfiguration.java
@@ -45,7 +45,7 @@ class GraphQlConfiguration {
     static {
         // Configure GraphQL parsing limits to reject malicious input
         Consumer<Builder> consumer =
-                b -> b.maxCharacters(10000).maxRuleDepth(10).maxTokens(1000).maxWhitespaceTokens(1000);
+                b -> b.maxCharacters(10000).maxRuleDepth(100).maxTokens(1000).maxWhitespaceTokens(1000);
         ParserOptions.setDefaultParserOptions(
                 ParserOptions.getDefaultParserOptions().transform(consumer));
         ParserOptions.setDefaultOperationParserOptions(
@@ -54,7 +54,7 @@ class GraphQlConfiguration {
 
     @Bean
     GraphQlSourceBuilderCustomizer graphQlCustomizer(PreparsedDocumentProvider provider) {
-        var maxQueryComplexity = new MaxQueryComplexityInstrumentation(20);
+        var maxQueryComplexity = new MaxQueryComplexityInstrumentation(200);
         var maxQueryDepth = new MaxQueryDepthInstrumentation(10);
         var instrumentation = new ChainedInstrumentation(maxQueryComplexity, maxQueryDepth);
 
@@ -88,7 +88,7 @@ class GraphQlConfiguration {
                     .maxDocumentLength(11000)
                     .maxNameLength(100)
                     .maxNestingDepth(10)
-                    .maxNumberLength(8)
+                    .maxNumberLength(19)
                     .maxStringLength(11000)
                     .maxTokenCount(100)
                     .build();

--- a/hedera-mirror-graphql/src/main/resources/application.yml
+++ b/hedera-mirror-graphql/src/main/resources/application.yml
@@ -47,6 +47,10 @@ server:
     connection-timeout: 3s
   port: 8083
   shutdown: graceful
+  tomcat:
+    connection-timeout: 3s
+    max-http-form-post-size: 20KB
+    max-swallow-size: 20KB
 spring:
   application:
     name: hedera-mirror-graphql
@@ -73,7 +77,7 @@ spring:
       validation-timeout: 3000
   graphql:
     graphiql:
-      enabled: true
+      enabled: false
     path: /graphql/alpha
   jpa:
     database: PostgreSQL

--- a/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/controller/AccountControllerTest.java
+++ b/hedera-mirror-graphql/src/test/java/com/hedera/mirror/graphql/controller/AccountControllerTest.java
@@ -46,6 +46,7 @@ class AccountControllerTest extends GraphqlIntegrationTest {
               query { account(input: {}) { id }}                                                         | Must provide exactly one input value
               query { account(input: {alias: ""}) { id }}                                                | alias must match
               query { account(input: {alias: "abcZ"}) { id }}                                            | alias must match
+              query { account(input: {entityId: {num: 123456789012}}) { id }}                            | Invalid entity ID
               query { account(input: {entityId: {num: -1}}) { id }}                                      | num must be greater than or equal to 0
               query { account(input: {entityId: {realm: -1, num: 1}}) { id }}                            | realm must be greater than or equal to 0
               query { account(input: {entityId: {shard: -1, num: 1}}) { id }}                            | shard must be greater than or equal to 0


### PR DESCRIPTION
**Description**:

* Add GraphQL query complexity and depth instrumentation
* Configure GraphQL parsing limits
* Configure Jackson parsing limits
* Configure Tomcat request body limits
* Disable GraphiQL by default for improved security

**Related issue(s)**:

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
