### PR TITLE
Fix the rest `ContractCallDynamicCallsTest` tests

### DIFF
--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutionService.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/service/TransactionExecutionService.java
@@ -92,7 +92,7 @@ public class TransactionExecutionService {
         if (transactionRecord.receiptOrThrow().status() == com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS) {
             result = buildSuccessResult(isContractCreate, transactionRecord, params);
         } else {
-            handleFailedResult(transactionRecord, isContractCreate, gasUsedCounter);
+            result = handleFailedResult(transactionRecord, isContractCreate, gasUsedCounter);
         }
         return result;
     }
@@ -128,7 +128,7 @@ public class TransactionExecutionService {
                 params.getReceiver());
     }
 
-    private void handleFailedResult(
+    private HederaEvmTransactionProcessingResult handleFailedResult(
             final TransactionRecord transactionRecord,
             final boolean isContractCreate,
             final MeterProvider<Counter> gasUsedCounter)
@@ -144,7 +144,15 @@ public class TransactionExecutionService {
             var errorMessage = getErrorMessage(result).orElse(Bytes.EMPTY);
             var detail = maybeDecodeSolidityErrorStringToReadableMessage(errorMessage);
             updateErrorGasUsedMetric(gasUsedCounter, result.gasUsed(), 1);
-            throw new MirrorEvmTransactionException(status.protoName(), detail, errorMessage.toHexString());
+            if (ContractCallContext.get().getOpcodeTracerOptions() == null) {
+                throw new MirrorEvmTransactionException(status.protoName(), detail, errorMessage.toHexString());
+            } else {
+                // If we are in an opcode trace scenario, we need to return a failed result in order to get the
+                // opcode list from the ContractCallContext. If we throw an exception instead of returning a result,
+                // as in the regular case, we won't be able to get the opcode list.
+                return HederaEvmTransactionProcessingResult.failed(
+                        result.gasUsed(), 0L, 0L, Optional.of(errorMessage), Optional.empty());
+            }
         }
     }
 

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -45,7 +45,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.hyperledger.besu.datatypes.Address;
 import org.junit.jupiter.api.Test;
@@ -248,6 +250,8 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
 
         try {
             mirrorNodeEvmProperties.setModularizedServices(true);
+            // Re-init the captors, because the flag was changed.
+            super.setUpArgumentCaptors();
             Method postConstructMethod = Arrays.stream(MirrorNodeState.class.getDeclaredMethods())
                     .filter(method -> method.isAnnotationPresent(PostConstruct.class))
                     .findFirst()
@@ -255,6 +259,11 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
 
             postConstructMethod.setAccessible(true); // Make the method accessible
             postConstructMethod.invoke(state);
+
+            final Map<String, String> propertiesMap = new HashMap<>();
+            propertiesMap.put("contracts.maxRefundPercentOfGasLimit", "100");
+            propertiesMap.put("contracts.maxGasPerSec", "15000000");
+            mirrorNodeEvmProperties.setProperties(propertiesMap);
 
             final var treasuryAccount = accountEntityPersist();
             final var sender = accountEntityPersist();

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -340,7 +340,6 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
                 : nftPersist(treasuryEntityId, ownerEntityId, spenderEntityId);
         final var tokenId = token.getTokenId();
         final var tokenAddress = toAddress(tokenId);
-        final var tokenEntityId = entityIdFromEvmAddress(toAddress(tokenId));
 
         final var contract = testWeb3jService.deploy(DynamicEthCalls::deploy);
         final var contractAddress = Address.fromHexString(contract.getContractAddress());
@@ -390,7 +389,6 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
                 : nftPersist(treasuryEntityId, contractEntityId, spenderEntityId);
         final var tokenId = token.getTokenId();
         final var tokenAddress = toAddress(tokenId);
-        final var tokenEntityId = entityIdFromEvmAddress(tokenAddress);
 
         tokenAccountPersist(tokenId, contractEntityId.getId());
         tokenAccountPersist(tokenId, spenderEntityId.getId());

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/service/ContractCallDynamicCallsTest.java
@@ -350,7 +350,7 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
         tokenAccountPersist(tokenId, ownerEntityId.getId());
 
         if (tokenType == TokenTypeEnum.NON_FUNGIBLE_UNIQUE) {
-            nftAllowancePersist(tokenEntityId, contractEntityId, ownerEntityId);
+            nftAllowancePersist(tokenId, contractEntityId, ownerEntityId);
         }
 
         // When
@@ -397,7 +397,7 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
         tokenAccountPersist(tokenId, ownerEntityId.getId());
 
         if (tokenType == TokenTypeEnum.NON_FUNGIBLE_UNIQUE) {
-            nftAllowancePersist(tokenEntityId, contractEntityId, ownerEntityId);
+            nftAllowancePersist(tokenId, contractEntityId, ownerEntityId);
         }
 
         // When
@@ -546,6 +546,7 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
 
         tokenAccountPersist(tokenId, spenderEntityId.getId());
         tokenAccountPersist(tokenId, contractEntityId.getId());
+        nftAllowancePersist(tokenId, contractEntityId, contractEntityId);
 
         var tokenTransferList = new TokenTransferList(
                 tokenAddress.toHexString(),
@@ -587,6 +588,8 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
 
         tokenAccountPersist(tokenId, spenderEntityId.getId());
         tokenAccountPersist(tokenId, contractEntityId.getId());
+        nftAllowancePersist(tokenId, spenderEntityId, contractEntityId);
+        nftAllowancePersist(tokenId, contractEntityId, contractEntityId);
 
         TokenTransferList tokenTransferList;
         if (tokenType == TokenTypeEnum.FUNGIBLE_COMMON) {
@@ -633,6 +636,7 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
 
         tokenAccountPersist(tokenId, spenderEntityId.getId());
         tokenAccountPersist(tokenId, contractEntityId.getId());
+        nftAllowancePersist(tokenId, contractEntityId, spenderEntityId);
 
         // When
         final var functionCall = contract.send_transferFromNFTGetAllowance(tokenAddress.toHexString(), BigInteger.ONE);
@@ -809,10 +813,10 @@ class ContractCallDynamicCallsTest extends AbstractContractCallServiceOpcodeTrac
     }
 
     private void nftAllowancePersist(
-            final EntityId tokenEntityId, final EntityId spenderEntityId, final EntityId ownerEntityId) {
+            final long tokenEntityId, final EntityId spenderEntityId, final EntityId ownerEntityId) {
         domainBuilder
                 .nftAllowance()
-                .customize(a -> a.tokenId(tokenEntityId.getId())
+                .customize(a -> a.tokenId(tokenEntityId)
                         .spender(spenderEntityId.getId())
                         .owner(ownerEntityId.getId())
                         .payerAccountId(ownerEntityId)


### PR DESCRIPTION
**Description**:
This PR fixes the setup for the `ContractCallDynamicCallsTest` tests when the `modularizedServices` flag is set to `true`. Also, the `TransactionExecutionService` is modified in case of a failure in an opcode trace scenario to return a failed result instead of throwing an exception directly. The reason for this is that we need to be able to return the opcode list from the context before throwing an exception.

Fixes https://github.com/hashgraph/hedera-mirror-node/issues/10077