### PR TITLE
Bump com.hedera.hashgraph:app version from 0.58.4 to 0.59.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
         api("com.graphql-java-generator:graphql-java-client-runtime:2.8")
         api("com.graphql-java:graphql-java-extended-scalars:22.0")
         api("com.graphql-java:graphql-java-extended-validation:22.0")
-        api("com.hedera.hashgraph:app:0.58.4")
+        api("com.hedera.hashgraph:app:0.59.0")
         api("com.hedera.evm:hedera-evm:0.54.2")
         api("com.hedera.hashgraph:hedera-protobuf-java-api:0.59.1")
         api("com.hedera.hashgraph:sdk:2.46.0")

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/MirrorNodeState.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/MirrorNodeState.java
@@ -56,12 +56,6 @@ import com.hedera.node.app.throttle.ThrottleAccumulator;
 import com.hedera.node.app.version.ServicesSoftwareVersion;
 import com.hedera.node.app.workflows.handle.metric.UnavailableMetrics;
 import com.hedera.node.config.data.VersionConfig;
-import com.swirlds.common.metrics.config.MetricsConfig;
-import com.swirlds.common.metrics.platform.DefaultPlatformMetrics;
-import com.swirlds.common.metrics.platform.MetricKeyRegistry;
-import com.swirlds.common.metrics.platform.PlatformMetricsFactoryImpl;
-import com.swirlds.config.api.Configuration;
-import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.state.State;
 import com.swirlds.state.StateChangeListener;
 import com.swirlds.state.lifecycle.StartupNetworks;
@@ -90,7 +84,6 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 
@@ -366,15 +359,6 @@ public class MirrorNodeState implements State {
     private void registerServices(ServicesRegistry servicesRegistry) {
         // Register all service schema RuntimeConstructable factories before platform init
 
-        final Configuration configuration = ConfigurationBuilder.create()
-                .withConfigDataType(MetricsConfig.class)
-                .build();
-
-        MetricsConfig metricsConfig = configuration.getConfigData(MetricsConfig.class);
-        PlatformMetricsFactoryImpl factory = new PlatformMetricsFactoryImpl(metricsConfig);
-        DefaultPlatformMetrics metrics = new DefaultPlatformMetrics(
-                null, new MetricKeyRegistry(), Executors.newSingleThreadScheduledExecutor(), factory, metricsConfig);
-
         final var appContext = new AppContextImpl(
                 InstantSource.system(),
                 signatureVerifier(),
@@ -391,7 +375,7 @@ public class MirrorNodeState implements State {
                         new EntityIdService(),
                         new TokenServiceImpl(),
                         new FileServiceImpl(),
-                        new ContractServiceImpl(appContext, metrics),
+                        new ContractServiceImpl(appContext, UNAVAILABLE_METRICS),
                         new BlockRecordService(),
                         new FeeService(),
                         new CongestionThrottleService(),

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/SchemaRegistryImpl.java
@@ -181,6 +181,11 @@ public class SchemaRegistryImpl implements SchemaRegistry {
             }
 
             @Override
+            public long newEntityNumForAccount() {
+                return nextEntityNum.getAndIncrement();
+            }
+
+            @Override
             public SemanticVersion previousVersion() {
                 return previousVersion;
             }
@@ -215,13 +220,20 @@ public class SchemaRegistryImpl implements SchemaRegistry {
             }
 
             @Override
-            public long newEntityNum() {
-                return nextEntityNum.getAndIncrement();
+            public Map<String, Object> sharedValues() {
+                return sharedValues;
             }
 
             @Override
-            public Map<String, Object> sharedValues() {
-                return sharedValues;
+            public boolean isGenesis() {
+                return MigrationContext.super.isGenesis();
+            }
+
+            @Override
+            public <T extends Comparable<? super T>> boolean isUpgrade(
+                    @Nonnull Function<Configuration, T> currentVersionFn,
+                    @Nonnull Function<SemanticVersion, T> previousVersionFn) {
+                return MigrationContext.super.isUpgrade(currentVersionFn, previousVersionFn);
             }
         };
     }

--- a/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/StartupNetworksImpl.java
+++ b/hedera-mirror-web3/src/main/java/com/hedera/mirror/web3/state/components/StartupNetworksImpl.java
@@ -32,7 +32,7 @@ public class StartupNetworksImpl implements StartupNetworks {
     }
 
     @Override
-    public Optional<Network> overrideNetworkFor(long roundNumber) {
+    public Optional<Network> overrideNetworkFor(long roundNumber, Configuration platformConfig) {
         return Optional.empty();
     }
 
@@ -46,9 +46,13 @@ public class StartupNetworksImpl implements StartupNetworks {
         // This is a no-op in the current context, and other implementations may provide behavior.
     }
 
-    @SuppressWarnings("deprecation")
+    /**
+     * @deprecated in the StartupNetworks interface
+     */
+    @SuppressWarnings({"java:S1133", "java:S6355"})
+    @Deprecated
     @Override
-    public Network migrationNetworkOrThrow() {
+    public Network migrationNetworkOrThrow(Configuration platformConfig) {
         return Network.DEFAULT;
     }
 }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/SchemaRegistryImplTest.java
@@ -227,7 +227,7 @@ class SchemaRegistryImplTest {
             assertThat(c.appConfig()).isEqualTo(config);
             assertThat(c.platformConfig()).isEqualTo(config);
             assertThat(c.genesisNetworkInfo()).isEqualTo(networkInfo);
-            assertThat(c.newEntityNum()).isEqualTo(1);
+            assertThat(c.newEntityNumForAccount()).isEqualTo(1);
             assertThat(c.sharedValues()).isEqualTo(EMPTY_MAP);
         });
     }

--- a/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/StartupNetworksImplTest.java
+++ b/hedera-mirror-web3/src/test/java/com/hedera/mirror/web3/state/components/StartupNetworksImplTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 
+import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.internal.network.Network;
 import com.swirlds.config.api.Configuration;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +43,8 @@ class StartupNetworksImplTest {
 
     @Test
     void testOverrideNetworkFor() {
-        assertThat(startupNetworks.overrideNetworkFor(0)).isEmpty();
+        final Configuration configuration = new ConfigProviderImpl().getConfiguration();
+        assertThat(startupNetworks.overrideNetworkFor(0, configuration)).isEmpty();
     }
 
     @Test
@@ -53,10 +55,5 @@ class StartupNetworksImplTest {
     @Test
     void testArchiveStartupNetworks() {
         assertDoesNotThrow(() -> startupNetworks.archiveStartupNetworks());
-    }
-
-    @Test
-    void testMigrationNetworkOrThrow() {
-        assertThat(startupNetworks.migrationNetworkOrThrow()).isEqualTo(Network.DEFAULT);
     }
 }


### PR DESCRIPTION
**Description**:
Bump com.hedera.hashgraph:app version from 0.58.4 to 0.59.0
This PR should fix the compilation issues that the dependabot PR bumping the same version is having. (https://github.com/hashgraph/hedera-mirror-node/pull/10390)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
